### PR TITLE
Fix stats display alignment for preprocessing

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -60,7 +60,7 @@ static struct {
 	{ STATS_CACHEHIT_CPP, "cache hit (preprocessed)       ", NULL, FLAG_ALWAYS },
 	{ STATS_TOCACHE,      "cache miss                     ", NULL, FLAG_ALWAYS },
 	{ STATS_LINK,         "called for link                ", NULL, 0 },
-	{ STATS_PREPROCESSING, "called for preprocessing      ", NULL, 0 },
+	{ STATS_PREPROCESSING, "called for preprocessing       ", NULL, 0 },
 	{ STATS_MULTIPLE,     "multiple source files          ", NULL, 0 },
 	{ STATS_STDOUT,       "compiler produced stdout       ", NULL, 0 },
 	{ STATS_NOOUTPUT,     "compiler produced no output    ", NULL, 0 },


### PR DESCRIPTION
This fixes the alignment when printing stats for the "called for preprocessing line".
