### PR TITLE
Support adjusting the compression level through CCACHE_COMPRESS_LEVEL

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -244,6 +244,13 @@ WRAPPERS>>.
     cache; compressed and uncompressed results will still be usable regardless
     of this setting.
 
+*CCACHE_COMPRESS_LEVEL*::
+
+    This environment variable determines the level at which ccache will
+    compress object files. It only has effect if *CCACHE_COMPRESS* is also
+    set. The value defaults to 6, and must be no lower than 1 (fastest, worst
+    compression) and no higher than 9 (slowest, best compression).
+
 *CCACHE_CPP2*::
 
     If you set the environment variable *CCACHE_CPP2* then ccache will not use

--- a/ccache.c
+++ b/ccache.c
@@ -163,10 +163,10 @@ static bool enable_unify;
 static bool enable_direct = true;
 
 /*
- * Whether to enable compression of files stored in the cache. (Manifest files
- * are always compressed.)
+ * If non-zero, enables compression of files stored in the cache, compressed
+ * at the given level. (Manifest files are always compressed.)
  */
-static bool enable_compression = false;
+static int enable_compression = 0;
 
 /* number of levels (1 <= nlevels <= 8) */
 static int nlevels = 2;
@@ -2084,7 +2084,11 @@ ccache(int argc, char *argv[])
 
 	if (getenv("CCACHE_COMPRESS")) {
 		cc_log("Compression enabled");
-		enable_compression = true;
+		if (getenv("CCACHE_COMPRESS_LEVEL")) {
+			enable_compression = atoi(getenv("CCACHE_COMPRESS_LEVEL"));
+		} else {
+			enable_compression = 6;
+		}
 	}
 
 	if ((env = getenv("CCACHE_NLEVELS"))) {

--- a/ccache.h
+++ b/ccache.h
@@ -102,10 +102,10 @@ void cc_log(const char *format, ...) ATTR_FORMAT(printf, 1, 2);
 void cc_log_argv(const char *prefix, char **argv);
 void fatal(const char *format, ...) ATTR_FORMAT(printf, 1, 2);
 void copy_fd(int fd_in, int fd_out);
-int copy_file(const char *src, const char *dest, int compress_dest);
-int move_file(const char *src, const char *dest, int compress_dest);
+int copy_file(const char *src, const char *dest, int compress_level);
+int move_file(const char *src, const char *dest, int compress_level);
 int move_uncompressed_file(const char *src, const char *dest,
-                           int compress_dest);
+                           int compress_level);
 bool file_is_compressed(const char *filename);
 int create_dir(const char *dir);
 int create_parent_dirs(const char *path);


### PR DESCRIPTION
My development laptop's CPU is slow by today's standards and gzipping object files at the default compression level is a significant bottleneck. This patch makes it possible to customize the compression level. I set it to 3 which is (for me) a reasonable speed/disk space tradeoff.
