### PR TITLE
Fix type of `f`

### DIFF
--- a/manifest.c
+++ b/manifest.c
@@ -690,7 +690,7 @@ manifest_dump(const char *manifest_path, FILE *stream)
 {
 	struct manifest *mf = NULL;
 	int fd;
-	gzFile *f = NULL;
+	gzFile f = NULL;
 	bool ret = false;
 	unsigned i, j;
 


### PR DESCRIPTION
I was getting this error when building:
gcc -g -O2 -Wall -W -Werror -DHAVE_CONFIG_H  -DSYSCONFDIR=/usr/local/etc -I. -I. -MD -MP -MF .deps/manifest.c.d -c -o manifest.o manifest.c
manifest.c: In function ‘manifest_dump’:
manifest.c:702:4: error: assignment from incompatible pointer type [-Werror]
manifest.c:708:2: error: passing argument 1 of ‘read_manifest’ from incompatible pointer type [-Werror]
manifest.c:222:1: note: expected ‘gzFile’ but argument is of type ‘struct gzFile_s *_’
manifest.c:758:3: error: passing argument 1 of ‘gzclose’ from incompatible pointer type [-Werror]
/usr/include/zlib.h:1488:24: note: expected ‘gzFile’ but argument is of type ‘struct gzFile_s *_’
