### PR TITLE
Fix broken Makefile when zlib is already installed on the system

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -68,6 +68,8 @@ clean:
 
 conf.c: confitems_lookup.c envtoconfitems_lookup.c
 
+.PHONY: -lz
+
 zlib/libz.a: $(zlib_objs)
 	$(AR) cr $@ $(zlib_objs)
 	$(RANLIB) $@


### PR DESCRIPTION
The Makefile had no rule to make -lz which is used when autotools can find a system version of zlib.
