### PR TITLE
fix issue to handle the -arch compiler option with arg

### DIFF
--- a/compopt.c
+++ b/compopt.c
@@ -52,7 +52,7 @@ static const struct compopt compopts[] = {
 	{"-Xclang",         TAKES_ARG},
 	{"-Xlinker",        TAKES_ARG},
 	{"-Xpreprocessor",  TOO_HARD_DIRECT | TAKES_ARG},
-	{"-arch",           AFFECTS_CPP | TAKES_ARG }, /* Darwin compiler option to specify architecture which sets a define */
+	{"-arch",           TAKES_ARG }, /* Darwin compiler option to specify architecture which sets a define */
 	{"-aux-info",       TAKES_ARG},
 	{"-b",              TAKES_ARG},
 	{"-frepo",          TOO_HARD},


### PR DESCRIPTION
ccache was logging a warning on Mac since the -arch option always
has a argument. The option also affects compilation because
the compiler will set a corresponding architecture define
