### PR TITLE
Improve dev.mk to be more platform independent

### DIFF
--- a/dev.mk.in
+++ b/dev.mk.in
@@ -18,8 +18,10 @@ version := \
 dist_dir = ccache-$(version)
 dist_archives = \
     ccache-$(version).tar.bz2 \
-    ccache-$(version).tar.gz \
-    ccache-$(version).tar.xz
+    ccache-$(version).tar.gz
+ifneq ($(shell uname), Darwin)
+    dist_archives += ccache-$(version).tar.xz
+endif
 
 generated_docs = \
     ccache.1 AUTHORS.html INSTALL.html LICENSE.html MANUAL.html NEWS.html \
@@ -104,7 +106,13 @@ $(dist_archives): $(dist_files)
 	 rsync -r --relative $(source_dist_files) $$dir) && \
 	cp $(built_dist_files) $$dir && \
 	(cd $$tmpdir && \
-	 tar cf $(CURDIR)/$@ $(dist_dir)) && \
+    tarcompression= && \
+    case $@ in \
+        *.bz2) tarcompression=-j ;; \
+        *.gz) tarcompression=-z ;; \
+        *.xz) tarcompression=-J ;; \
+     esac && \
+	 tar -c $$tarcompression -f $(CURDIR)/$@ $(dist_dir)) && \
 	rm -rf $$tmpdir
 
 .PHONY: distcheck


### PR DESCRIPTION
The dev.mk was improved to allow for the make dist to work on mac os x
1) asciidoc may not always be install to /etc, so also check /usr/local/etc
2) --parents parameter for cp does not work on mac so use rsync --relative
3) the a parameter for tar does not exist on mac and it seems the default
   already auto detects the compression algorithm to use
