### PR TITLE
Only clean dist generate targets when using distclean

### DIFF
--- a/dev.mk.in
+++ b/dev.mk.in
@@ -44,7 +44,7 @@ headers = \
     test/util.h
 
 files_to_clean += *.tar.bz2 *.tar.gz *.tar.xz *.xml .deps/*
-files_to_clean += $(built_dist_files) version.c test/suites.h
+files_to_distclean += $(built_dist_files) version.c test/suites.h
 files_to_distclean += .deps version.c dev.mk
 
 source_dist_files = \


### PR DESCRIPTION
Some file are only generated when making a distribute, such as docs, and should
only be cleaned when using the distclean target. If we clean the docs with the
normal clean target then when using the Makefile with the distributed source
code will lead to an error if you configure, make, make clean, and then make
again.
