### PR TITLE
Added object file comparison check for numerous test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -81,7 +81,7 @@ checkstat() {
 }
 
 compare_file() {
-    diff "$1" "$2" 2>&1 >/dev/null
+    cmp -s "$1" "$2"
     if [ $? -eq 0 ]; then
         :
     else
@@ -2104,7 +2104,7 @@ export CCACHE_CONFIGPATH
 touch $CCACHE_CONFIGPATH
 
 # comand used to bypass ccache
-DIRECT_COMPILE=$(which $COMPILER)
+DIRECT_COMPILE=`which $COMPILER`
 
 # ---------------------------------------
 


### PR DESCRIPTION
Comparing the output of ccache and direct compilation is a useful check to make
sure we are creating the same object file. It is especially useful when performing
2 stage compilation like ccache does when CCACHE_CPP2 is not set.
