### PR TITLE
changed -x language option to use new objective c standard for gcc and clang

### DIFF
--- a/language.c
+++ b/language.c
@@ -45,7 +45,7 @@ static const struct {
 	{".i",   "cpp-output"},
 	{".ii",  "c++-cpp-output"},
 	{".mi",  "objective-c-cpp-output"},
-	{".mii", "objective-c++-cpp-output"},	
+	{".mii", "objective-c++-cpp-output"},
 	/* Header file (for precompilation): */
 	{".h",   "c-header"},
 	{".H",   "c++-header"},
@@ -70,19 +70,20 @@ static const struct {
 	const char *language;
 	const char *p_language;
 } languages[] = {
-	{"c",                      "cpp-output"},
-	{"cpp-output",             "cpp-output"},
-	{"c-header",               "cpp-output"},
-	{"c++",                    "c++-cpp-output"},
-	{"c++-cpp-output",         "c++-cpp-output"},
-	{"c++-header",             "c++-cpp-output"},
-	{"objective-c",            "objective-c-cpp-output"},	
-	{"objective-c-header",     "objective-c-cpp-output"},
-	{"objc-cpp-output",        "objective-c-cpp-output"},
-	{"objective-c-cpp-output", "objective-c-cpp-output"},
-	{"objective-c++",          "objective-c++-cpp-output"},
-	{"objc++-cpp-output",      "objective-c++-cpp-output"},
-	{"objective-c++-header",   "objective-c++-cpp-output"},
+	{"c",                        "cpp-output"},
+	{"cpp-output",               "cpp-output"},
+	{"c-header",                 "cpp-output"},
+	{"c++",                      "c++-cpp-output"},
+	{"c++-cpp-output",           "c++-cpp-output"},
+	{"c++-header",               "c++-cpp-output"},
+	{"objective-c",              "objective-c-cpp-output"},
+	{"objective-c-header",       "objective-c-cpp-output"},
+	{"objc-cpp-output",          "objective-c-cpp-output"},
+	{"objective-c-cpp-output",   "objective-c-cpp-output"},
+	{"objective-c++",            "objective-c++-cpp-output"},
+	{"objc++-cpp-output",        "objective-c++-cpp-output"},
+	{"objective-c++-header",     "objective-c++-cpp-output"},
+	{"objective-c++-cpp-output", "objective-c++-cpp-output"}
 	{NULL,  NULL}};
 
 /*


### PR DESCRIPTION
When preprocessing objective-c[++] files use -x objective-c-cpp-output
or -x objective-c++-cpp-output which is supported by gcc 4.0+ and clang.
Previously -x objc-cpp-output or -x objc++-cpp-output was used, but not
supported by clang.
