### PR TITLE
Fix compile error with Xcode 4.6

### DIFF
--- a/confitems_lookup.c
+++ b/confitems_lookup.c
@@ -75,6 +75,7 @@ confitems_hash (register const char *str, register unsigned int len)
   return len + asso_values[(unsigned char)str[1]] + asso_values[(unsigned char)str[0]];
 }
 
+static
 #ifdef __GNUC__
 __inline
 #ifdef __GNUC_STDC_INLINE__

--- a/envtoconfitems_lookup.c
+++ b/envtoconfitems_lookup.c
@@ -89,6 +89,7 @@ envtoconfitems_hash (register const char *str, register unsigned int len)
   return hval;
 }
 
+static
 #ifdef __GNUC__
 __inline
 #ifdef __GNUC_STDC_INLINE__


### PR DESCRIPTION
static function ... is used in an inline function with external linkage
[-Werror,-Wstatic-in-inline] use 'static' to give inline function ... internal
linkage
