### PR TITLE
Bugfix for working with Xcode/clang: Copy clang diagnostic files if compilation failed

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -715,6 +715,33 @@ to_cache(struct args *args)
 				copy_fd(fd, 2);
 				close(fd);
 				tmp_unlink(tmp_stderr);
+              
+				if (output_dia) {
+ 					int ret;
+					x_unlink(output_dia);
+					/* only make a hardlink if the cache file is uncompressed */
+					ret = move_file(tmp_dia, output_dia, 0);
+                
+					if (ret == -1) {
+						if (errno == ENOENT) {
+							/*
+							 * Someone removed the file just before we
+							 * began copying?
+							 */
+							cc_log("Diagnostic file %s just disappeared", output_dia);
+							stats_update(STATS_MISSING);
+						} else {
+							cc_log("Failed to move %s to %s: %s",
+							       tmp_dia, output_dia, strerror(errno));
+							stats_update(STATS_ERROR);
+							failed();
+						}
+						x_unlink(tmp_dia);
+					} else {
+						cc_log("Created %s from %s", output_dia, tmp_dia);
+					}
+				}
+
 				exit(status);
 			}
 		}


### PR DESCRIPTION
clang's .dia files were not copied back if compiling failed. However, they are used by Xcode to display the errors found during compiling, which did not work with ccache so far. Now it does.
