### PR TITLE
Fixed build with mingw

### DIFF
--- a/util.c
+++ b/util.c
@@ -74,7 +74,7 @@ log_prefix(bool log_updated_time)
 	if (log_updated_time) {
 		gettimeofday(&tv, NULL);
 #ifdef __MINGW64_VERSION_MAJOR
-		tm = _localtime32(&tv.tv_sec);
+		tm = localtime((time_t*)&tv.tv_sec);
 #else
 		tm = localtime(&tv.tv_sec);
 #endif


### PR DESCRIPTION
_localtime32 was removed from the runtime because it was only avalible at
some Windows versions.
Maybe the time_t\* cast could be used on all systems?
