### PR TITLE
Introduce copy_uncompressed_file, for direct copy

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -988,7 +988,7 @@ put_file_in_cache(const char *source, const char *dest)
 		}
 	}
 	if (!do_link) {
-		ret = copy_file(
+		ret = copy_uncompressed_file(
 		  source, dest, conf->compression ? conf->compression_level : 0);
 		if (ret != 0) {
 			cc_log("Failed to copy %s to %s: %s", source, dest, strerror(errno));
@@ -1009,11 +1009,14 @@ static void
 get_file_from_cache(const char *source, const char *dest)
 {
 	int ret;
-	bool do_link = conf->hard_link && !file_is_compressed(source);
+	bool is_compressed = file_is_compressed(source);
+	bool do_link = conf->hard_link && !is_compressed;
 
 	if (do_link) {
 		x_unlink(dest);
 		ret = link(source, dest);
+	} else if (!is_compressed) {
+		ret = copy_uncompressed_file(source, dest, 0);
 	} else {
 		ret = copy_file(source, dest, 0);
 	}

--- a/ccache.h
+++ b/ccache.h
@@ -123,6 +123,8 @@ void fatal(const char *format, ...) ATTR_FORMAT(printf, 1, 2) ATTR_NORETURN;
 
 void copy_fd(int fd_in, int fd_out);
 int copy_file(const char *src, const char *dest, int compress_level);
+int copy_uncompressed_file(const char *src, const char *dest,
+                           int compress_level);
 int move_file(const char *src, const char *dest, int compress_level);
 int move_uncompressed_file(const char *src, const char *dest,
                            int compress_level);


### PR DESCRIPTION
For copying compressed files etc, fall back to the original copy version.
(this is mostly a refactoring, for future features and also optimizations)
