### PR TITLE
Count the number of cleanups performed, in stats

### DIFF
--- a/ccache.h
+++ b/ccache.h
@@ -51,6 +51,7 @@ enum stats {
 	STATS_COMPCHECK = 26,
 	STATS_CANTUSEPCH = 27,
 	STATS_PREPROCESSING = 28,
+	STATS_NUMCLEANUPS = 29,
 
 	STATS_END
 };
@@ -186,6 +187,7 @@ void stats_update_size(uint64_t size, unsigned files);
 void stats_get_obsolete_limits(const char *dir, unsigned *maxfiles,
                                uint64_t *maxsize);
 void stats_set_sizes(const char *dir, unsigned num_files, uint64_t total_size);
+void stats_add_cleanup(const char *dir, unsigned count);
 void stats_read(const char *path, struct counters *counters);
 void stats_write(const char *path, struct counters *counters);
 

--- a/test.sh
+++ b/test.sh
@@ -1854,6 +1854,7 @@ cleanup_suite() {
     checkfilecount 0 '*.d' $CCACHE_DIR
     checkfilecount 0 '*.stderr' $CCACHE_DIR
     checkstat 'files in cache' 0
+    checkstat 'cleanups performed' 1
 
     testname="forced cleanup, no limits"
     $CCACHE -C >/dev/null
@@ -1864,6 +1865,7 @@ cleanup_suite() {
     checkfilecount 10 '*.d' $CCACHE_DIR
     checkfilecount 10 '*.stderr' $CCACHE_DIR
     checkstat 'files in cache' 30
+    checkstat 'cleanups performed' 0
 
     testname="forced cleanup, file limit"
     $CCACHE -C >/dev/null
@@ -1876,6 +1878,7 @@ cleanup_suite() {
     checkfilecount 7 '*.d' $CCACHE_DIR
     checkfilecount 7 '*.stderr' $CCACHE_DIR
     checkstat 'files in cache' 21
+    checkstat 'cleanups performed' 1
     for i in 0 1 2 3 4 5 9; do
         file=$CCACHE_DIR/a/result$i-4017.o
         if [ ! -f $file ]; then
@@ -1905,6 +1908,7 @@ cleanup_suite() {
     checkfilecount 3 '*.d' $CCACHE_DIR
     checkfilecount 3 '*.stderr' $CCACHE_DIR
     checkstat 'files in cache' 9
+    checkstat 'cleanups performed' 1
     for i in 3 4 5; do
         file=$CCACHE_DIR/a/result$i-4017.o
         if [ ! -f $file ]; then
@@ -1936,6 +1940,7 @@ cleanup_suite() {
     checkfilecount 156 '*.d' $CCACHE_DIR
     checkfilecount 156 '*.stderr' $CCACHE_DIR
     checkstat 'files in cache' 469
+    checkstat 'cleanups performed' 1
 
     testname="sibling cleanup"
     $CCACHE -C >/dev/null


### PR DESCRIPTION
When running a busy ccache, it is useful to keep track of the number
of cleanups performed to know when you need to increase the cache size.

The number shown is actually the number of subdirectories, so when
you do a full cleanup the counter usually increases by 16 (not just 1).