### PR TITLE
preprocessor mode: enable using identical header in different paths

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -863,7 +863,6 @@ process_preprocessed_file(struct mdfour *hash, const char *path)
 				has_absolute_include_headers = is_absolute_path(path);
 			}
 			path = make_relative_path(path);
-			hash_string(hash, path);
 			remember_include_file(path, hash, system);
 			p = r;
 		} else {

--- a/test.sh
+++ b/test.sh
@@ -1247,8 +1247,8 @@ EOF
     checkstat 'cache miss' 1
     $CCACHE $COMPILER -c `pwd`/file.c
     checkstat 'cache hit (direct)' 1
-    checkstat 'cache hit (preprocessed)' 0
-    checkstat 'cache miss' 2
+    checkstat 'cache hit (preprocessed)' 1
+    checkstat 'cache miss' 1
 
     testname="__FILE__ in include file"
     $CCACHE -Cz >/dev/null
@@ -1271,8 +1271,8 @@ EOF
     mv file_h.c file2_h.c
     $CCACHE $COMPILER -c `pwd`/file2_h.c
     checkstat 'cache hit (direct)' 1
-    checkstat 'cache hit (preprocessed)' 0
-    checkstat 'cache miss' 2
+    checkstat 'cache hit (preprocessed)' 1
+    checkstat 'cache miss' 1
 
     ##################################################################
     # Check that direct mode ignores __FILE__ if sloppiness is specified.
@@ -1458,12 +1458,12 @@ EOF
     checkstat 'cache miss' 1
     CPATH=subdir2 $CCACHE $COMPILER -c foo.c
     checkstat 'cache hit (direct)' 1
-    checkstat 'cache hit (preprocessed)' 0
-    checkstat 'cache miss' 2 # subdir2 is part of the preprocessor output
+    checkstat 'cache hit (preprocessed)' 1
+    checkstat 'cache miss' 1 # subdir2 is part of the preprocessor output
     CPATH=subdir2 $CCACHE $COMPILER -c foo.c
     checkstat 'cache hit (direct)' 2
-    checkstat 'cache hit (preprocessed)' 0
-    checkstat 'cache miss' 2
+    checkstat 'cache hit (preprocessed)' 1
+    checkstat 'cache miss' 1
 
     testname="comment in strings"
     $CCACHE -Cz >/dev/null
@@ -1561,8 +1561,8 @@ EOF
     cd dir2
     CCACHE_BASEDIR="" $CCACHE $COMPILER -I`pwd`/include -c src/test.c
     checkstat 'cache hit (direct)' 0
-    checkstat 'cache hit (preprocessed)' 0
-    checkstat 'cache miss' 2
+    checkstat 'cache hit (preprocessed)' 1
+    checkstat 'cache miss' 1
     cd ..
 
     ##################################################################
@@ -1617,8 +1617,8 @@ EOF
     $CCACHE -z >/dev/null
     $CCACHE $COMPILER -I`pwd`/include -c src/test.c
     checkstat 'cache hit (direct)' 0
-    checkstat 'cache hit (preprocessed)' 0
-    checkstat 'cache miss' 1
+    checkstat 'cache hit (preprocessed)' 1
+    checkstat 'cache miss' 0
     cd ..
 
     ##################################################################

--- a/test.sh
+++ b/test.sh
@@ -1459,7 +1459,7 @@ EOF
     CPATH=subdir2 $CCACHE $COMPILER -c foo.c
     checkstat 'cache hit (direct)' 1
     checkstat 'cache hit (preprocessed)' 1
-    checkstat 'cache miss' 1 # subdir2 is part of the preprocessor output
+    checkstat 'cache miss' 1
     CPATH=subdir2 $CCACHE $COMPILER -c foo.c
     checkstat 'cache hit (direct)' 2
     checkstat 'cache hit (preprocessed)' 1


### PR DESCRIPTION
Please see the following thread: http://www.mail-archive.com/ccache@lists.samba.org/msg01329.html

This fix will improve the ccache hit as it makes the preprocessor mode to be come insensitive to identical head files path changes.