### PR TITLE
Fortran support

### DIFF
--- a/compopt.c
+++ b/compopt.c
@@ -41,6 +41,7 @@ static const struct compopt compopts[] = {
 	{"-F",              AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
 	{"-G",              TAKES_ARG},
 	{"-I",              AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
+	{"-J",              TAKES_ARG | TAKES_PATH},
 	{"-L",              TAKES_ARG},
 	{"-M",              TOO_HARD},
 	{"-MF",             TAKES_ARG},

--- a/language.c
+++ b/language.c
@@ -74,19 +74,15 @@ static const struct {
 	{".FPP", "f77-cpp-input"},
 	{".FTN", "f77-cpp-input"},
 	/* Free form Fortran without preprocessing */
-	/* could generate modules, ignore for now!
 	{".f90", "f95"},
 	{".f95", "f95"},
 	{".f03", "f95"},
 	{".f08", "f95"},
-	*/
 	/* Free form Fortran with traditional preprocessing */
-  /* could generate modules, ignore for now!
 	{".F90", "f95-cpp-input"},
 	{".F95", "f95-cpp-input"},
 	{".F03", "f95-cpp-input"},
 	{".F08", "f95-cpp-input"},
-	*/
 	{NULL,  NULL}
 };
 
@@ -114,10 +110,9 @@ static const struct {
 	{"cuda",                     "cuda-output"},
 	{"f77-cpp-input",            "f77"},
 	{"f77",                      "f77"},
-	/* could generate module files, ignore for now!
-	{"f95-cpp-input",            "f95"},
 	{"f95",                      "f95"},
-	*/
+	{"f77-cpp-input",            "f77"},
+	{"f95-cpp-input",            "f95"},
 	{NULL,  NULL}
 };
 

--- a/language.c
+++ b/language.c
@@ -63,6 +63,30 @@ static const struct {
 	{".TCC", "c++-header"},
 	{".cu",  "cuda"},
 	{".ic",  "cuda-output"},
+	/* Fixed form Fortran without preprocessing */
+	{".f",   "f77"},
+	{".for", "f77"},
+	{".ftn", "f77"},
+	/* Fixed form Fortran with traditional preprocessing */
+	{".F",   "f77-cpp-input"},
+	{".FOR", "f77-cpp-input"},
+	{".fpp", "f77-cpp-input"},
+	{".FPP", "f77-cpp-input"},
+	{".FTN", "f77-cpp-input"},
+	/* Free form Fortran without preprocessing */
+	/* could generate modules, ignore for now!
+	{".f90", "f95"},
+	{".f95", "f95"},
+	{".f03", "f95"},
+	{".f08", "f95"},
+	*/
+	/* Free form Fortran with traditional preprocessing */
+  /* could generate modules, ignore for now!
+	{".F90", "f95-cpp-input"},
+	{".F95", "f95-cpp-input"},
+	{".F03", "f95-cpp-input"},
+	{".F08", "f95-cpp-input"},
+	*/
 	{NULL,  NULL}
 };
 
@@ -88,6 +112,12 @@ static const struct {
 	{"objective-c++-header",     "objective-c++-cpp-output"},
 	{"objective-c++-cpp-output", "objective-c++-cpp-output"},
 	{"cuda",                     "cuda-output"},
+	{"f77-cpp-input",            "f77"},
+	{"f77",                      "f77"},
+	/* could generate module files, ignore for now!
+	{"f95-cpp-input",            "f95"},
+	{"f95",                      "f95"},
+	*/
 	{NULL,  NULL}
 };
 


### PR DESCRIPTION
first commit works for old Fortran 77.
second commit tries direct mode for Fortran 90/95 and newer...

Special things in (modern) Fortran:
* preprocessing doesn't resolve module dependencies; module files are required at compile time;
  so I disabled usage of indirect mode there (assuming ccache doesn't care about file dependencies after preprocessing...)
* the compiler may output an arbitrary number of module files per source file; these are currently not cached, but recreated using the -fsyntax-only flag on a cache hit.

Needs some more testing...