### PR TITLE
Multiple -arch options support

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -790,9 +790,9 @@ process_preprocessed_file(struct mdfour *hash, const char *path)
 		free(p);
 	}
 
-    if (!included_files) {
-        included_files = create_hashtable(1000, hash_from_string, strings_equal);
-    }
+	if (!included_files) {
+		included_files = create_hashtable(1000, hash_from_string, strings_equal);
+	}
 
 	/* Bytes between p and q are pending to be hashed. */
 	end = data + size;
@@ -1412,11 +1412,11 @@ get_object_name_from_cpp(struct args *args, struct mdfour *hash)
 		path_stdout_fd = create_tmp_fd(&path_stdout);
 		add_pending_tmp_file(path_stdout);
 
-        int args_added = 2;
+		int args_added = 2;
 		args_add(args, "-E");
 		if (conf->keep_comments_cpp) {
 			args_add(args, "-C");
-            args_added = 3;
+			args_added = 3;
 		}
 		args_add(args, input_file);
 		add_prefix(args, conf->prefix_command_cpp);
@@ -1925,9 +1925,9 @@ calculate_object_hash(struct args *args, struct mdfour *hash, int direct_mode)
 			}
 			args_pop(args, 1);
 		}
-        if (generating_dependencies) {
+		if (generating_dependencies) {
 			cc_log("Preprocessor created %s", output_dep);
-        }
+		}
 	}
 
 	return object_hash;
@@ -2132,7 +2132,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 	int i;
 	bool found_c_opt = false;
 	bool found_S_opt = false;
-    bool found_pch = false;
+	bool found_pch = false;
 	bool found_fpch_preprocess = false;
 	const char *explicit_language = NULL; /* As specified with -x. */
 	const char *file_language;            /* As deduced from file extension. */
@@ -2260,13 +2260,13 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			}
 		}
 
-        /* -Xarch_* options are too hard */
-        if (str_startswith(argv[i], "-Xarch_")) {
-            cc_log("Unsupported compiler option :%s", argv[i]);
-            stats_update(STATS_UNSUPPORTED);
-            result = false;
-            goto out;
-        }
+		/* -Xarch_* options are too hard */
+		if (str_startswith(argv[i], "-Xarch_")) {
+			cc_log("Unsupported compiler option :%s", argv[i]);
+			stats_update(STATS_UNSUPPORTED);
+			result = false;
+			goto out;
+		}
 
 		/* Handle -arch options. */
 		if (str_eq(argv[i], "-arch")) {

--- a/ccache.c
+++ b/ccache.c
@@ -2276,7 +2276,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
                 result = false;
                 goto out;
             } else {
-                arch_args[arch_args_size++] = argv[i+1];
+                arch_args[arch_args_size++] = argv[++i];
 			}
             continue;
 		}

--- a/ccache.c
+++ b/ccache.c
@@ -180,7 +180,7 @@ time_t time_of_compilation;
  * Files included by the preprocessor and their hashes/sizes. Key: file path.
  * Value: struct file_hash.
  */
-static struct hashtable *included_files;
+static struct hashtable *included_files = NULL;
 
 /* uses absolute path for some include files */
 static bool has_absolute_include_headers = false;
@@ -790,7 +790,9 @@ process_preprocessed_file(struct mdfour *hash, const char *path)
 		free(p);
 	}
 
-	included_files = create_hashtable(1000, hash_from_string, strings_equal);
+    if (!included_files) {
+        included_files = create_hashtable(1000, hash_from_string, strings_equal);
+    }
 
 	/* Bytes between p and q are pending to be hashed. */
 	end = data + size;
@@ -2259,7 +2261,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		}
 
         /* -Xarch_* options are too hard */
-        if (str_startswith(argv[i]), "-Xarch_") {
+        if (str_startswith(argv[i], "-Xarch_")) {
             cc_log("Unsupported compiler option :%s", argv[i]);
             stats_update(STATS_UNSUPPORTED);
             result = false;

--- a/ccache.c
+++ b/ccache.c
@@ -1908,25 +1908,25 @@ calculate_object_hash(struct args *args, struct mdfour *hash, int direct_mode)
 			cc_log("Did not find object file hash in manifest");
 		}
 	} else {
-        if (arch_args_size == 0) {
-            object_hash = get_object_name_from_cpp(args, hash);
-            cc_log("Got object file hash from preprocessor");
-        } else {
-            size_t i = 0;
-            args_add(args, "-arch");
-            for(i = 0; i < arch_args_size; ++i) {
-                args_add(args, arch_args[i]);
-                object_hash = get_object_name_from_cpp(args, hash);
-                cc_log("Got object file hash from preprocessor with -arch %s", arch_args[i]);
-                if (i != arch_args_size - 1) {
-                    free(object_hash);
-                }
-                args_pop(args, 1);
-            }
-            args_pop(args, 1);
-        }
+		if (arch_args_size == 0) {
+			object_hash = get_object_name_from_cpp(args, hash);
+			cc_log("Got object file hash from preprocessor");
+		} else {
+			size_t i = 0;
+			args_add(args, "-arch");
+			for(i = 0; i < arch_args_size; ++i) {
+				args_add(args, arch_args[i]);
+				object_hash = get_object_name_from_cpp(args, hash);
+				cc_log("Got object file hash from preprocessor with -arch %s", arch_args[i]);
+				if (i != arch_args_size - 1) {
+					free(object_hash);
+				}
+				args_pop(args, 1);
+			}
+			args_pop(args, 1);
+		}
         if (generating_dependencies) {
-            cc_log("Preprocessor created %s", output_dep);
+			cc_log("Preprocessor created %s", output_dep);
         }
 	}
 
@@ -2270,18 +2270,18 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 
 		/* Handle -arch options. */
 		if (str_eq(argv[i], "-arch")) {
-            if (arch_args_size == MAX_ARCH_ARGS - 1) {
-                cc_log("Too many -arch compiler options are unsupported");
-                stats_update(STATS_UNSUPPORTED);
-                result = false;
-                goto out;
-            } else {
-                arch_args[arch_args_size++] = x_strdup(argv[++i]); /* it will leak */
-                if (arch_args_size == 2) {
-                    conf->run_second_cpp = true;
-                }
+			if (arch_args_size == MAX_ARCH_ARGS - 1) {
+				cc_log("Too many -arch compiler options are unsupported");
+				stats_update(STATS_UNSUPPORTED);
+				result = false;
+				goto out;
+			} else {
+				arch_args[arch_args_size++] = x_strdup(argv[++i]); /* it will leak */
+				if (arch_args_size == 2) {
+					conf->run_second_cpp = true;
+				}
 			}
-            continue;
+			continue;
 		}
 
 		if (str_eq(argv[i], "-fpch-preprocess")
@@ -3035,11 +3035,11 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		args_add(*compiler_args, "-c");
 	}
 
-    size_t j = 0;
-    for(j = 0; j < arch_args_size; ++j) {
-        args_add(*compiler_args, "-arch");
-        args_add(*compiler_args, arch_args[j]);
-    }
+	size_t j = 0;
+	for(j = 0; j < arch_args_size; ++j) {
+		args_add(*compiler_args, "-arch");
+		args_add(*compiler_args, arch_args[j]);
+	}
 
 	/*
 	 * Only pass dependency arguments to the preprocesor since Intel's C++

--- a/ccache.c
+++ b/ccache.c
@@ -2277,12 +2277,6 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
                 goto out;
             } else {
                 arch_args[arch_args_size++] = argv[i+1];
-
-                /* Remove me when direct mode is supported */
-                if (arch_args_size > 1u) {
-                    cc_log("Direct mode is disabled because multiple \"-arch\" options are found");
-                    conf->direct_mode = false;
-                }
 			}
             continue;
 		}

--- a/ccache.c
+++ b/ccache.c
@@ -2276,7 +2276,10 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
                 result = false;
                 goto out;
             } else {
-                arch_args[arch_args_size++] = argv[++i];
+                arch_args[arch_args_size++] = x_strdup(argv[++i]); /* it will leak */
+                if (arch_args_size == 2) {
+                    conf->run_second_cpp = true;
+                }
 			}
             continue;
 		}

--- a/ccache.c
+++ b/ccache.c
@@ -2258,6 +2258,14 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			}
 		}
 
+        /* -Xarch_* options are too hard */
+        if (str_startswith(argv[i]), "-Xarch_") {
+            cc_log("Unsupported compiler option :%s", argv[i]);
+            stats_update(STATS_UNSUPPORTED);
+            result = false;
+            goto out;
+        }
+
 		/* Handle -arch options. */
 		if (str_eq(argv[i], "-arch")) {
             if (arch_args_size == MAX_ARCH_ARGS - 1) {

--- a/test.sh
+++ b/test.sh
@@ -661,12 +661,14 @@ EOF
     if [ $HOST_OS_APPLE -eq 1 ]; then
         $CCACHE -Cz > /dev/null
         testname="multiple-arch-options"
-		$CCACHE_COMPILE -c --arch i386 --arch x86_64 -fprofile-use test1.c 2>/dev/null
+		$CCACHE_COMPILE --arch i386 --arch x86_64 -c test1.c 2>/dev/null
         checkstat 'cache hit (preprocessed)' 0
         checkstat 'cache miss' 1
-		$CCACHE_COMPILE -c --arch i386 --arch x86_64 -fprofile-use test1.c 2>/dev/null
+		checkstat 'preprocessor error' 0
+		$CCACHE_COMPILE --arch i386 --arch x86_64 -c test1.c 2>/dev/null
 		checkstat 'cache hit (preprocessed)' 1
 		checkstat 'cache miss' 1
+		checkstat 'preprocessor error' 0
     fi
 	
     ##################################################################

--- a/test.sh
+++ b/test.sh
@@ -664,11 +664,9 @@ EOF
 		$CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c 2>/dev/null
         checkstat 'cache hit (preprocessed)' 0
         checkstat 'cache miss' 1
-		checkstat 'preprocessor error' 0
 		$CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c 2>/dev/null
 		checkstat 'cache hit (preprocessed)' 1
 		checkstat 'cache miss' 1
-		checkstat 'preprocessor error' 0
     fi
 	
     ##################################################################

--- a/test.sh
+++ b/test.sh
@@ -656,6 +656,14 @@ EOF
         $CCACHE_COMPILE -c -fprofile-use test1.c 2>/dev/null
         checkstat 'cache hit (preprocessed)' 3
         checkstat 'cache miss' 3
+
+		testname="multiple-arch-options"
+		$CCACHE_COMPILE -c --arch i386 --arch x86_64 -fprofile-use test1.c 2>/dev/null
+        checkstat 'cache hit (preprocessed)' 3
+        checkstat 'cache miss' 3
+		$CCACHE_COMPILE -c --arch i386 --arch x86_64 -fprofile-use test1.c 2>/dev/null
+		checkstat 'cache hit (preprocessed)' 4
+		checkstat 'cache miss' 3
     fi
 
     ##################################################################

--- a/test.sh
+++ b/test.sh
@@ -665,7 +665,7 @@ EOF
         checkstat 'cache hit (preprocessed)' 0
         checkstat 'cache miss' 1
 		checkstat 'preprocessor error' 0
-		$CCACHE_COMPILE --arch i386 --arch x86_64 -c test1.c 2>/dev/null
+		$CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c 2>/dev/null
 		checkstat 'cache hit (preprocessed)' 1
 		checkstat 'cache miss' 1
 		checkstat 'preprocessor error' 0

--- a/test.sh
+++ b/test.sh
@@ -661,7 +661,7 @@ EOF
     if [ $HOST_OS_APPLE -eq 1 ]; then
         $CCACHE -Cz > /dev/null
         testname="multiple-arch-options"
-		$CCACHE_COMPILE --arch i386 --arch x86_64 -c test1.c 2>/dev/null
+		$CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c 2>/dev/null
         checkstat 'cache hit (preprocessed)' 0
         checkstat 'cache miss' 1
 		checkstat 'preprocessor error' 0

--- a/test.sh
+++ b/test.sh
@@ -656,16 +656,19 @@ EOF
         $CCACHE_COMPILE -c -fprofile-use test1.c 2>/dev/null
         checkstat 'cache hit (preprocessed)' 3
         checkstat 'cache miss' 3
-
-		testname="multiple-arch-options"
-		$CCACHE_COMPILE -c --arch i386 --arch x86_64 -fprofile-use test1.c 2>/dev/null
-        checkstat 'cache hit (preprocessed)' 3
-        checkstat 'cache miss' 3
-		$CCACHE_COMPILE -c --arch i386 --arch x86_64 -fprofile-use test1.c 2>/dev/null
-		checkstat 'cache hit (preprocessed)' 4
-		checkstat 'cache miss' 3
     fi
 
+    if [ $HOST_OS_APPLE -eq 1 ]; then
+        $CCACHE -Cz > /dev/null
+        testname="multiple-arch-options"
+		$CCACHE_COMPILE -c --arch i386 --arch x86_64 -fprofile-use test1.c 2>/dev/null
+        checkstat 'cache hit (preprocessed)' 0
+        checkstat 'cache miss' 1
+		$CCACHE_COMPILE -c --arch i386 --arch x86_64 -fprofile-use test1.c 2>/dev/null
+		checkstat 'cache hit (preprocessed)' 1
+		checkstat 'cache miss' 1
+    fi
+	
     ##################################################################
     # Check that -Wp,-P disables ccache. (-P removes preprocessor information
     # in such a way that the object file from compiling the preprocessed file

--- a/test.sh
+++ b/test.sh
@@ -661,12 +661,12 @@ EOF
     if [ $HOST_OS_APPLE -eq 1 ]; then
         $CCACHE -Cz > /dev/null
         testname="multiple-arch-options"
-		$CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c 2>/dev/null
+        $CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c 2>/dev/null
         checkstat 'cache hit (preprocessed)' 0
         checkstat 'cache miss' 1
-		$CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c 2>/dev/null
-		checkstat 'cache hit (preprocessed)' 1
-		checkstat 'cache miss' 1
+        $CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c 2>/dev/null
+        checkstat 'cache hit (preprocessed)' 1
+        checkstat 'cache miss' 1
     fi
 	
     ##################################################################


### PR DESCRIPTION
This pull request adds multiple "-arch" options support.

According to http://www.unix.com/man-page/osx/1/gcc/, -arch is APPLE only option for specifying target architecture. In case of specifying "-arch" multiple times a "fat" (all in one) binary will be created.

The idea of changes is as follows: 

1. For the preprocessor mode: run preprocessor multiple times (once per architecture) and then add each output to resulting hash
2. Direct mode remains the same, except minor changes with included_files variable initialization