### PR TITLE
Fix for "ccache no longer supports building of single -archs #127"

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -1740,6 +1740,12 @@ calculate_object_hash(struct args *args, struct mdfour *hash, int direct_mode)
 		free(gcda_name);
 	}
 
+	// Adding -arch to hash since cpp output is affected
+	for(size_t i = 0; i < arch_args_size; ++i) {
+		hash_delimiter(hash, "-arch");
+		hash_string(hash, arch_args[i]);
+	}
+
 	struct file_hash *object_hash = NULL;
 	if (direct_mode) {
 		// Hash environment variables that affect the preprocessor output.

--- a/test.sh
+++ b/test.sh
@@ -1119,19 +1119,62 @@ SUITE_multi_arch_PROBE() {
     fi
 }
 
+SUITE_multi_arch_SETUP() {
+    generate_code 1 test1.c
+    unset CCACHE_NODIRECT
+}
+
 SUITE_multi_arch() {
-    # -------------------------------------------------------------------------
+# -------------------------------------------------------------------------
     TEST "cache hit"
 
-    generate_code 1 test1.c
+    # Different arches shouldn't affect each other
+    $CCACHE_COMPILE -arch i386 -c test1.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache miss' 1
+    
+    $CCACHE_COMPILE -arch x86_64 -c test1.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache miss' 2
+    
+    $CCACHE_COMPILE -arch i386 -c test1.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache miss' 2
 
+    # Multiple arches should be cached too
     $CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache miss' 3
+    
+    $CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c
+    expect_stat 'cache hit (direct)' 2
+    expect_stat 'cache miss' 3
+
+    #The same for preprocessor mode
+    clear_cache
+    export CCACHE_NODIRECT=1
+    
+    $CCACHE_COMPILE -arch i386 -c test1.c
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
+    
+    $CCACHE_COMPILE -arch x86_64 -c test1.c
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+    
+    $CCACHE_COMPILE -arch i386 -c test1.c
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 2
 
+    # Multiple arches should be cached too
     $CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c
     expect_stat 'cache hit (preprocessed)' 1
-    expect_stat 'cache miss' 1
+    expect_stat 'cache miss' 3
+    
+    $CCACHE_COMPILE -arch i386 -arch x86_64 -c test1.c
+    expect_stat 'cache hit (preprocessed)' 2
+    expect_stat 'cache miss' 3
+
 }
 
 # =============================================================================
@@ -2402,7 +2445,7 @@ SUITE_readonly() {
         test_failed "Read-only mode + direct mode stored files in the cache"
     fi
 }
-
+ 
 # =============================================================================
 
 SUITE_readonly_direct_SETUP() {


### PR DESCRIPTION
Hashing of -arch options was missed. Now it's there. Tests are updated.