### PR TITLE
Clang modules support

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -2329,7 +2329,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		// '@import <module name>;', this causes preprocessor output to be useless
 		// for determining included headers. To workaround this problem, don't pass
 		// '-fmodules' when generating preprocessor output.
-		if (str_eq(argv[i], "-fmodules")) {
+		if (str_eq(argv[i], "-fmodules") || str_eq(argv[i], "-fcxx-modules")) {
 			if (!conf->run_second_cpp) {
 				cc_log("Clang modules are not supported when run_second_cpp = false");
 				stats_update(STATS_UNSUPPORTED);

--- a/ccache.c
+++ b/ccache.c
@@ -2332,7 +2332,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		if (str_eq(argv[i], "-fmodules") || str_eq(argv[i], "-fcxx-modules")) {
 			if (!conf->run_second_cpp) {
 				cc_log("Clang modules are not supported when run_second_cpp = false");
-				stats_update(STATS_UNSUPPORTED);
+				stats_update(STATS_UNSUPPORTED_OPTION);
 				result = false;
 				goto out;
 			} else {

--- a/compopt.c
+++ b/compopt.c
@@ -56,7 +56,6 @@ static const struct compopt compopts[] = {
 	{"-arch",           TAKES_ARG},
 	{"-aux-info",       TAKES_ARG},
 	{"-b",              TAKES_ARG},
-	{"-fmodules",       TOO_HARD},
 	{"-fno-working-directory", AFFECTS_CPP},
 	{"-fplugin=libcc1plugin", TOO_HARD}, // interaction with GDB
 	{"-frepo",          TOO_HARD},
@@ -72,6 +71,7 @@ static const struct compopt compopts[] = {
 	{"-iquote",         AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
 	{"-isysroot",       AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
 	{"-isystem",        AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
+	{"-ivfsoverlay",    AFFECTS_CPP | TAKES_ARG | TAKES_PATH},
 	{"-iwithprefix",    AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
 	{"-iwithprefixbefore",
 	 AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},

--- a/test.sh
+++ b/test.sh
@@ -1200,7 +1200,6 @@ SUITE_clang_modules() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    # preprocessor should be disabled when dealing with modules!
     cat <<EOF >test1.h
 #import <Foundation/Foundation.h>
 // modification
@@ -1218,7 +1217,6 @@ EOF
     $CCACHE_COMPILE -MD -fmodules -c test1.m
     expect_stat 'cache miss' 1
 
-    # preprocessor should be disabled when dealing with modules!
     cat <<EOF >test1.h
 #import <Foundation/Foundation.h>
 void f();

--- a/test.sh
+++ b/test.sh
@@ -1178,6 +1178,9 @@ SUITE_clang_modules() {
     $CCACHE_COMPILE -fmodules -c test1.m
     expect_stat 'unsupported compiler option' 1
 
+    $CCACHE_COMPILE -fmodules -fcxx-modules -c test1.m
+    expect_stat 'unsupported compiler option' 2
+
     # -------------------------------------------------------------------------
     TEST "cache hit, direct mode"
 

--- a/test.sh
+++ b/test.sh
@@ -1136,6 +1136,13 @@ SUITE_nocpp2() {
 
 # =============================================================================
 
+SUITE_clang_modules_PROBE() {
+    if ! $COMPILER_TYPE_CLANG; then
+        echo "-fmodules/-fcxx-modules not supported by compiler"
+        return
+    fi
+ }
+
 SUITE_clang_modules_SETUP() {
     unset CCACHE_NODIRECT
     export CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS include_file_mtime"


### PR DESCRIPTION
This has been achieved by not passing '-fmodules' flag when generating preprocessor output, so that ccache can parse it to get list of included headers. Also, to get Clang modules working correctly, you have to set `run_second_cpp` to `true`, or define environment variable `CCACHE_CPP2`.

This is continuation of previous PR: #126
