### PR TITLE
Removed time_of_compilation check wrt SLOPPY_FILE_STAT_MATCHES

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -1869,12 +1869,6 @@ from_cache(enum fromcache_call_mode mode, bool put_object_in_manifest)
 		return;
 	}
 
-	// Check if the diagnostic file is there.
-	if (output_dia && stat(cached_dia, &st) != 0) {
-		cc_log("Diagnostic file %s not in cache", cached_dia);
-		return;
-	}
-
 	// Occasionally, e.g. on hard reset, our cache ends up as just filesystem
 	// meta-data with no content. Catch an easy case of this.
 	if (st.st_size == 0) {
@@ -1907,6 +1901,12 @@ from_cache(enum fromcache_call_mode mode, bool put_object_in_manifest)
 	// If the dependency file should be in the cache, check that it is.
 	if (produce_dep_file && stat(cached_dep, &st) != 0) {
 		cc_log("Dependency file %s missing in cache", cached_dep);
+		return;
+	}
+
+	// Check if the diagnostic file is there.
+	if (output_dia && stat(cached_dia, &st) != 0) {
+		cc_log("Diagnostic file %s not in cache", cached_dia);
 		return;
 	}
 

--- a/manifest.c
+++ b/manifest.c
@@ -377,14 +377,12 @@ verify_object(struct conf *conf, struct manifest *mf, struct object *obj,
 			hashtable_insert(stated_files, x_strdup(path), st);
 		}
 
+		if (fi->size != st->size) {
+			return 0;
+		}
+
 		if (conf->sloppiness & SLOPPY_FILE_STAT_MATCHES) {
-			// st->ctime is sometimes 0, so we can't check that both st->ctime and
-			// st->mtime are greater than time_of_compilation. But it's sufficient to
-			// check that either is.
-			if (fi->size == st->size
-			    && fi->mtime == st->mtime
-			    && fi->ctime == st->ctime
-			    && MAX(st->mtime, st->ctime) >= time_of_compilation) {
+			if (fi->mtime == st->mtime && fi->ctime == st->ctime) {
 				cc_log("size/mtime/ctime hit for %s", path);
 				continue;
 			} else {


### PR DESCRIPTION
The whole code seems to be a thinko.  For a hit, neither ctime
nor mtime should be greater than or equal to time_of_compilation.
The code only seems to work because time_of_compilation is 0
at this stage (i.e. has not been initialized).

While at it, I also introduce an optimization: when sizes do
not match, it's a good chance to bail out early; there is no
point in further hashing the file.