### PR TITLE
POC add ignore_implicit_pch sloppiness flag

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -2103,7 +2103,7 @@ detect_pch(const char *option, const char *arg, bool *found_pch)
 			cc_log("Detected use of precompiled header: %s", arg);
 			pch_file = x_strdup(arg);
 		}
-	} else {
+	} else if (!(conf->sloppiness & SLOPPY_IGNORE_IMPLICIT_PCH)) {
 		char *gchpath = format("%s.gch", arg);
 		if (stat(gchpath, &st) == 0) {
 			cc_log("Detected use of precompiled header: %s", gchpath);

--- a/ccache.h
+++ b/ccache.h
@@ -69,6 +69,7 @@ enum stats {
 // Allow us to not include any system headers in the manifest include files,
 // similar to -MM versus -M for dependencies.
 #define SLOPPY_NO_SYSTEM_HEADERS 64
+#define SLOPPY_IGNORE_IMPLICIT_PCH 128
 
 #define str_eq(s1, s2) (strcmp((s1), (s2)) == 0)
 #define str_startswith(s, prefix) \

--- a/conf.c
+++ b/conf.c
@@ -116,6 +116,8 @@ parse_sloppiness(const char *str, void *result, char **errmsg)
 			*value |= SLOPPY_PCH_DEFINES;
 		} else if (str_eq(word, "time_macros")) {
 			*value |= SLOPPY_TIME_MACROS;
+		} else if (str_eq(word, "ignore_implicit_pch")) {
+			*value |= SLOPPY_IGNORE_IMPLICIT_PCH;
 		} else {
 			*errmsg = format("unknown sloppiness: \"%s\"", word);
 			free(p);

--- a/conf.c
+++ b/conf.c
@@ -641,6 +641,9 @@ conf_print_items(struct conf *conf,
 	if (conf->sloppiness & SLOPPY_NO_SYSTEM_HEADERS) {
 		reformat(&s, "%sno_system_headers, ", s);
 	}
+	if (conf->sloppiness & SLOPPY_IGNORE_IMPLICIT_PCH) {
+		reformat(&s, "%signore_implicit_pch, ", s);
+	}
 	if (conf->sloppiness) {
 		// Strip last ", ".
 		s[strlen(s) - 2] = '\0';


### PR DESCRIPTION
I'm filing this to start a conversation rather than to get it merged in, so there are no docs or test yet.

I've been trying out ccache with pch-enabled compilations and there seem to be two posibilities, both with strong enough downsides that they don't seem viable:

* Use sloppiness=pch_defines when compiling the pch. This causes compiles that use the pch file to use the cache even if #defines in the headers have changed. This is a non-starter for any project using config headers.
* Don't cache the pch file but cache the compilations that use it. This is problematic because both clang and gcc embed timestamps in the pch file so the hashes are never the same, so the cache becomes dead every time you recompile the pch file.

This patch proposes a third option very similar to the second. The difference is that when the ignore_implicit_pch flag is used, ccache will not go looking for pch files, and will pretend that the compiler is just using the normal headers. This relies on the build system to ensure that the pch files accurately reflect the headers before calling into ccache (which is why it is sloppiness-guarded), but the build system wouldn't really work if it didn't do that.

I've tested locally with gcc 6.3.1 and clang 3.9.1. Both will output the full preprocessed file when using -E as long as you *don't* include -fpch-preprocess. This means that ccache will be able to use the non-direct mode. However I haven't tested older compilers. I have tried builds where I change #defines in the config header (which is included in the pch) and with this flag, ccache seems to be caching correctly and rebuilding only when it is getting an actual new value.

Does anyone know what downsides this approach has, other than relying on the build system to keep the pch file up to date? I would assume that ccache is seeking out implicit pch files and including them in the hash for a good reason, but I don't know why. Did some older compilers not include the real output with -E when using a pch file?

Thanks for considering this. If you like this approach either feel free to take it and run with it, or I can put in the work to document, test, etc.