### PR TITLE
Support using multiple -fdebug-prefix-map

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -182,7 +182,10 @@ static bool generating_coverage;
 static bool generating_stackusage;
 
 // Relocating debuginfo in the format old=new.
-static char *debug_prefix_map = NULL;
+static char **debug_prefix_maps = NULL;
+
+// Size of debug_prefix_maps list.
+static size_t debug_prefix_maps_len = 0;
 
 // Is the compiler being asked to output coverage data (.gcda) at runtime?
 static bool profile_arcs;
@@ -1607,8 +1610,8 @@ calculate_common_hash(struct args *args, struct mdfour *hash)
 	// Possibly hash the current working directory.
 	if (generating_debuginfo && conf->hash_dir) {
 		char *cwd = gnu_getcwd();
-		if (debug_prefix_map) {
-			char *map = debug_prefix_map;
+		for (size_t i = 0; i < debug_prefix_maps_len; i++) {
+			char *map = debug_prefix_maps[i];
 			char *sep = strchr(map, '=');
 			if (sep) {
 				char *old = x_strndup(map, sep - map);
@@ -2376,7 +2379,9 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			continue;
 		}
 		if (str_startswith(argv[i], "-fdebug-prefix-map=")) {
-			debug_prefix_map = x_strdup(argv[i] + 19);
+			debug_prefix_maps = x_realloc(debug_prefix_maps,
+				(debug_prefix_maps_len + 1) * sizeof(char *));
+			debug_prefix_maps[debug_prefix_maps_len++] = x_strdup(argv[i] + 19);
 			args_add(stripped_args, argv[i]);
 			continue;
 		}
@@ -3185,7 +3190,12 @@ cc_reset(void)
 	free(primary_config_path); primary_config_path = NULL;
 	free(secondary_config_path); secondary_config_path = NULL;
 	free(current_working_dir); current_working_dir = NULL;
-	free(debug_prefix_map); debug_prefix_map = NULL;
+	for (size_t i = 0; i < debug_prefix_maps_len; i++) {
+		free(debug_prefix_maps[i]);
+		debug_prefix_maps[i] = NULL;
+	}
+	free(debug_prefix_maps); debug_prefix_maps = NULL;
+	debug_prefix_maps_len = 0;
 	free(profile_dir); profile_dir = NULL;
 	free(included_pch_file); included_pch_file = NULL;
 	args_free(orig_args); orig_args = NULL;

--- a/test.sh
+++ b/test.sh
@@ -1323,6 +1323,32 @@ SUITE_debug_prefix_map() {
     if grep -E "[^=]`pwd`[^=]" test.o >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
+
+    # -------------------------------------------------------------------------
+    TEST "Multiple -fdebug-prefix-map"
+
+    cd dir1
+    CCACHE_BASEDIR=`pwd` $CCACHE_COMPILE -I`pwd`/include -g -fdebug-prefix-map=`pwd`=foobar -fdebug-prefix-map=foo=bar -c `pwd`/src/test.c -o `pwd`/test.o
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 2
+    if grep -E "[^=]`pwd`[^=]" test.o >/dev/null 2>&1; then
+        test_failed "Source dir (`pwd`) found in test.o"
+    fi
+    if ! grep "foobar" test.o >/dev/null 2>&1; then
+        test_failed "Relocation (foobar) not found in test.o"
+    fi
+
+    cd ../dir2
+    CCACHE_BASEDIR=`pwd` $CCACHE_COMPILE -I`pwd`/include -g -fdebug-prefix-map=`pwd`=foobar -fdebug-prefix-map=foo=bar -c `pwd`/src/test.c -o `pwd`/test.o
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 2
+    if grep -E "[^=]`pwd`[^=]" test.o >/dev/null 2>&1; then
+        test_failed "Source dir (`pwd`) found in test.o"
+    fi
 }
 
 # =============================================================================


### PR DESCRIPTION
Previously only the last one was actually being applied to the hash.
Note that the compiler will actually only *use* one of all the paths.

Closes #163.