### PR TITLE
Add docker target for running test with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+**/.vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+                gcc \
+                make \
+                autoconf \
+                gperf \
+                zlib1g-dev \
+        && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/build
+
+COPY . .
+
+RUN ./autogen.sh \
+        && ./configure \
+        && make \
+        && make test

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -7,6 +7,7 @@ ASCIIDOC = asciidoc
 CPPCHECK = cppcheck
 CPPCHECK_SUPPRESSIONS = cppcheck-suppressions.txt
 SCAN_BUILD = scan-build
+DOCKER = docker
 GPERF = gperf
 XSLTPROC = xsltproc
 MANPAGE_XSL = $(shell if [ -e /usr/local/etc/asciidoc/docbook-xsl/manpage.xsl ]; \
@@ -166,5 +167,9 @@ uncrustify:
 analyze:
 	$(SCAN_BUILD) --use-cc=$(CC) ./configure
 	$(SCAN_BUILD) --use-cc=$(CC) --status-bugs $(MAKE) -B
+
+.PHONY: docker
+docker: Dockerfile
+	$(DOCKER) build $(srcdir)
 
 -include .deps/*.d


### PR DESCRIPTION
Add standard container definition for running the tests,
to make things easier for developers on other platforms.

@jrosdahl : You can change the standard distro used,
if you prefer Debian (or something) ? Doesn't matter.

Eventually we could use multiple Dockerfiles for this,
for instance to run tests with clang - or something ?