### PR TITLE
Add comment about why SLOPPY_INCLUDE_FILE_[CM]TIME compares using >=t

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -600,12 +600,16 @@ remember_include_file(char *path, struct mdfour *cpp_hash, bool system)
 		}
 	}
 
+	// The comparison using >= is intentional, due to a possible race
+	// between starting compilation and writing the include file.
+	// See https://github.com/ccache/ccache/blob/master/MANUAL.txt
 	if (!(conf->sloppiness & SLOPPY_INCLUDE_FILE_MTIME)
 	    && st.st_mtime >= time_of_compilation) {
 		cc_log("Include file %s too new", path);
 		goto failure;
 	}
 
+	// The same >= logic as above applies to the change time of the file.
 	if (!(conf->sloppiness & SLOPPY_INCLUDE_FILE_CTIME)
 	    && st.st_ctime >= time_of_compilation) {
 		cc_log("Include file %s ctime too new", path);


### PR DESCRIPTION
If a file has the same modification or change time as the current
compile, all should be good.

Removes the need for setting the sloppiness to `include_file_ctime` in
the tests, which was done to work around the fact that backdating
files (modification time) would bump their change time, and likely
be the same as the one of the following compilation job.