### PR TITLE
Update log message and docs when using SLOPPY_FILE_STAT_MATCHES

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -491,7 +491,7 @@ when compiling preprocessed source code.
 *file_stat_matches*::
     ccache normally examines a file's contents to determine whether it matches
     the cached version. With this option set, ccache will consider a file as
-    matching its cached version if the sizes, mtimes and ctimes match.
+    matching its cached version if the mtimes and ctimes match.
 *include_file_ctime*::
     By default, ccache also will not cache a file if it includes a header whose
     ctime is too new. This option disables that check.

--- a/manifest.c
+++ b/manifest.c
@@ -383,10 +383,10 @@ verify_object(struct conf *conf, struct manifest *mf, struct object *obj,
 
 		if (conf->sloppiness & SLOPPY_FILE_STAT_MATCHES) {
 			if (fi->mtime == st->mtime && fi->ctime == st->ctime) {
-				cc_log("size/mtime/ctime hit for %s", path);
+				cc_log("mtime/ctime hit for %s", path);
 				continue;
 			} else {
-				cc_log("size/mtime/ctime miss for %s", path);
+				cc_log("mtime/ctime miss for %s", path);
 			}
 		}
 


### PR DESCRIPTION
The size is no longer part of this check.