### PR TITLE
Fail if boolean env vars are set with common negative strings

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -222,11 +222,12 @@ Boolean values
 Some settings are boolean values (i.e. truth values). In a configuration file,
 such values must be set to the string *true* or *false*. For the corresponding
 environment variables, the semantics are a bit different: a set environment
-variable means ``true'' regardless of the value (even if set to the empty
-string), and an unset environment variable means ``false''. Each boolean
-environment variable also has a negated form starting with *CCACHE_NO*. For
-example, *CCACHE_COMPRESS* can be set to force compression and
-*CCACHE_NOCOMPRESS* can be set to force no compression.
+variable means ``true'' (even if set to the empty string), the following
+case-insensitive negative values are considered an error (rather than surprise
+the user): "0", "false", "disable" and "no", and an unset environment variable
+means ``false''. Each boolean environment variable also has a negated form
+starting with *CCACHE_NO*. For example, *CCACHE_COMPRESS* can be set to force
+compression and *CCACHE_NOCOMPRESS* can be set to force no compression.
 
 
 Configuration settings

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -26,6 +26,11 @@ Bug fixes
 - File size and number counters are now updated correctly when files are
   overwritten in the cache, e.g. when using `CCACHE_RECACHE`.
 
+- Boolean configuration settings no longer accept the following
+  (case-insensitive) values: "0", "false", "disable" and "no".  All other
+  values are accepted and taken to mean "true".  This is intended to avoid
+  users setting eg CCACHE_DISABLE=0 and expecting the cache to be used.
+
 
 ccache 3.3.5
 ------------

--- a/conf.c
+++ b/conf.c
@@ -241,8 +241,19 @@ handle_conf_setting(struct conf *conf, const char *key, const char *value,
 	}
 
 	if (from_env_variable && item->parser == parse_bool) {
-		// Special rule for boolean settings from the environment: any value means
-		// true.
+		// Special rule for boolean settings from the environment:
+		// "0", "false", "disable" and "no" (case insensitive) are invalid,
+		// and all other values mean true.
+		//
+		// Previously any value meant true, but this was surprising to
+		// users, who might do something like CCACHE_DISABLE=0 and expect
+		// ccache to be enabled.
+
+		if (!strcmp(value, "0") || !strcasecmp(value, "false") ||
+				!strcasecmp(value, "disable") || !strcasecmp(value, "no")) {
+			fatal("invalid boolean environment variable value \"%s\"", value);
+		}
+
 		bool *value = (bool *)((char *)conf + item->offset);
 		*value = !negate_boolean;
 		goto out;

--- a/test.sh
+++ b/test.sh
@@ -1084,6 +1084,20 @@ EOF
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 0
     expect_stat 'unsupported code directive' 1
+
+    # -------------------------------------------------------------------------
+    TEST "Invalid boolean environment configuration options"
+
+    for invalid_val in 0 false FALSE disable no ; do
+        CCACHE_DISABLE=$invalid_val $CCACHE $COMPILER --version > /dev/null 2>&1
+        if [ $? -eq 0 ] ; then
+            test_failed "'$invalid_val' should be rejected for boolean env vars"
+        fi
+        CCACHE_NODISABLE=$invalid_val $CCACHE $COMPILER --version > /dev/null 2>&1
+        if [ $? -eq 0 ] ; then
+            test_failed "'$invalid_val' should be rejected for boolean env vars"
+        fi
+    done
 }
 
 # =============================================================================


### PR DESCRIPTION
Boolean environment variables have strange semantics: if the variable
is set then the configuration setting is considered "true".  This means
users can easily be mistaken that eg CCACHE_DISABLE=false means that
the "disable" setting is set to false.

To avoid too much backwards-incompatibility, we now exit with an error if
some common negative-sounding (case-insensitive) values:
"0", "false", "disable", "no".

All other values (including the empty string) are still considered to mean
"true".

Resolves https://github.com/ccache/ccache/issues/182