### PR TITLE
Clang emits warnings for unused linker arguments, respect that!

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -1723,19 +1723,24 @@ calculate_object_hash(struct args *args, struct mdfour *hash, int direct_mode)
 		hash_int(hash, MANIFEST_VERSION);
 	}
 
+	// clang will emit warnings for unused linker flags, so we shouldn't
+	// skip those arguments
+	int is_clang = compiler_is_clang(args);
+
 	// First the arguments.
 	for (int i = 1; i < args->argc; i++) {
 		// -L doesn't affect compilation.
-		if (i < args->argc-1 && str_eq(args->argv[i], "-L")) {
+		if (i < args->argc-1 && str_eq(args->argv[i], "-L") && !is_clang) {
 			i++;
 			continue;
 		}
-		if (str_startswith(args->argv[i], "-L")) {
+		if (str_startswith(args->argv[i], "-L") && !is_clang) {
 			continue;
 		}
 
 		// -Wl,... doesn't affect compilation.
-		if (str_startswith(args->argv[i], "-Wl,")) {
+		if (str_startswith(args->argv[i], "-Wl,") && !is_clang) {
+			// ...but it affects warnings with clang
 			continue;
 		}
 


### PR DESCRIPTION
If ccache concludes the invocation with/without linker arguments
is the same as before, then it may show/fail to show a warning
when it should.  I know we're not supposed to rely on the
is clang check, but this solves it in normal cases.

Fixes #189.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>