### PR TITLE
Dev/memcached merge with v3.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
 #          env: HOST="--host=i586-mingw32msvc" TEST="test/main.exe"
         - os: linux
           compiler: clang
+          env: CFLAGS="-fsanitize=undefined" ASAN_OPTIONS="detect_leaks=0"
+        - os: linux
+          compiler: clang
           env: CFLAGS="-fsanitize=address -g" ASAN_OPTIONS="detect_leaks=0"
 
     exclude:

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -7,23 +7,26 @@ maintained by Joel Rosdahl.
 ccache is a collective work with contributions from many people, including:
 
 * Alfred Landrum <alfred.landrum@riverbed.com>
-* Anders Björklund <anders@itension.se>
+* Anders Björklund <anders@psqr.se>
 * Andrea Bittau <a.bittau@cs.ucl.ac.uk>
 * Andrew P Boie <andrew.p.boie@intel.com>
 * Andrew Stubbs <ams@codesourcery.com>
 * Andrew Tridgell <tridge@samba.org>
+* André Klitzing <aklitzing@gmail.com>
 * Bernhard Bauer <bauerb@chromium.org>
 * Björn Jacke <bj@sernet.de>
 * Bo Rydberg <bolry@hotmail.com>
 * Chiaki Ishikawa <ishikawa@yk.rim.or.jp>
 * Chris AtLee <chris@atlee.ca>
-* Clemens Rabe <crabe@gmx.de>
+* Clemens Rabe <clemens.rabe@gmail.com>
 * David Givone <david@givone.net>
 * Eric Blau <Eric.Blau@tekelec.com>
 * Francois Marier <francois@debian.org>
 * Hongli Lai <hongli@phusion.nl>
+* Ivan Vaigult <i.vaigult@gmail.com>
 * Jiang Jiang <jiangj@opera.com>
 * Joel Rosdahl <joel@rosdahl.net>
+* John Basila <jbasila@checkpoint.com>
 * John Coiner <john.coiner@amd.com>
 * Jon Bernard <jbernard@tuxion.com>
 * Justin Lebar <justin.lebar@gmail.com>
@@ -38,19 +41,26 @@ ccache is a collective work with contributions from many people, including:
 * Mark Starovoytov <starovoytov.mark@googlemail.com>
 * Martin Pool <mbp@sourcefrog.net>
 * Matthias Kretz <kretz@kde.org>
+* Melven Roehrig-Zoellner <Melven.Roehrig-Zoellner@DLR.de>
 * Michael Marineau <michael.marineau@coreos.com>
 * Michael Meeks <michael.meeks@suse.com>
+* Mihai Serban <mihai.serban@intel.com>
 * Mike Frysinger <vapier@gentoo.org>
 * Mikhail Kolomeytsev <mkolom@yandex-team.ru>
 * Neil Mushell <nmushell@bloomberg.net>
 * Nick Schultz <nick.schultz@intel.com>
+* Norbert Lange <nolange79@gmail.com>
 * Orgad Shaneh <orgad.shaneh@audiocodes.com>
+* Orion Poplawski <orion@cora.nwra.com>
 * Owen Mann <owen@mann.org>
 * Patrick von Reth <vonreth@kde.org>
 * Paul Griffith <paulg@cse.yorku.ca>
+* Pavel Boldin <pboldin@cloudlinux.com>
+* Philippe Proulx <eeppeliteloop@gmail.com>
 * RW <fbsd06@mlists.homeunix.com>
 * Ramiro Polla <ramiro.polla@gmail.com>
 * Robin H. Johnson <robbat2@gentoo.org>
+* Rolf Bjarne Kvinge <rolf@xamarin.com>
 * Ryan Brown <ryb@ableton.com>
 * Tim Potter <tpot@samba.org>
 * Tor Arne Vestbø <torarnv@gmail.com>

--- a/INSTALL-from-release-archive.md
+++ b/INSTALL-from-release-archive.md
@@ -4,22 +4,14 @@ ccache installation
 Prerequisites
 -------------
 
-To build ccache from the source repository, you need:
+To build ccache, you need:
 
 - A C compiler (for instance GCC)
-- [AsciiDoc](http://www.methods.co.nz/asciidoc/) to build the documentation.
-- [Autoconf](http://www.gnu.org/software/autoconf/)
-- [gperf](http://www.gnu.org/software/gperf/)
-- [xsltproc](http://xmlsoft.org/XSLT/xsltproc2.html)
 
 It is also recommended that you have:
 
 - [zlib](http://www.zlib.net) (if you don't have zlib installed, ccache will
   use a bundled copy)
-
-To debug and run the performance test suite you'll also need:
-
-- [Python](http://www.python.org)
 
 
 Installation
@@ -27,7 +19,6 @@ Installation
 
 To compile and install ccache, run these commands:
 
-    ./autogen.sh
     ./configure
     make
     make install

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -38,7 +38,7 @@ The copyright for ccache as a whole is as follows:
 
 -------------------------------------------------------------------------------
   Copyright (C) 2002-2007 Andrew Tridgell
-  Copyright (C) 2009-2016 Joel Rosdahl
+  Copyright (C) 2009-2017 Joel Rosdahl
 -------------------------------------------------------------------------------
 
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -163,10 +163,11 @@ Extra options
 When run as a compiler, ccache usually just takes the same command line options
 as the compiler you are using. The only exception to this is the option
 *--ccache-skip*. That option can be used to tell ccache to avoid interpreting
-the next option in any way and to pass it along to the compiler as-is. *Note*:
-*--ccache-skip* currently only tells ccache not to interpret the next option as
-a special compiler option -- the option will still be included in the direct
-mode hash.
+the next option in any way and to pass it along to the compiler as-is.
+
+NOTE: *--ccache-skip* currently only tells ccache not to interpret the next
+option as a special compiler option -- the option will still be included in the
+direct mode hash.
 
 The reason this can be important is that ccache does need to parse the command
 line and determine what is an input filename and what is a compiler option, as
@@ -297,8 +298,14 @@ _a command string_::
     separator. Examples:
 +
 --
-* +%compiler% -v+
-* +%compiler% -dumpmachine; %compiler% -dumpversion+
+
+----
+%compiler% -v
+----
+
+----
+%compiler% -dumpmachine; %compiler% -dumpversion
+----
 
 You should make sure that the specified command is as fast as possible since it
 will be run once for each ccache invocation.
@@ -374,15 +381,15 @@ WRAPPERS>>.
     when generating debug info (compiler option *-g* with variations).
     Exception: The CWD will not be included in the hash if *base_dir* is set
     (and matches the CWD) and the compiler option *-fdebug-prefix-map* is used.
-
-    The reason for including the CWD in the hash by default is to prevent a
-    problem with the storage of the current working directory in the debug info
-    of an object file, which can lead ccache to return a cached object file
-    that has the working directory in the debug info set incorrectly.
-
-    You can disable this setting to get cache hits when compiling the same
-    source code in different directories if you don't mind that CWD in the
-    debug info might be incorrect.
++
+The reason for including the CWD in the hash by default is to prevent a problem
+with the storage of the current working directory in the debug info of an
+object file, which can lead ccache to return a cached object file that has the
+working directory in the debug info set incorrectly.
++
+You can disable this setting to get cache hits when compiling the same source
+code in different directories if you don't mind that CWD in the debug info
+might be incorrect.
 
 *ignore_headers_in_manifest* (*CCACHE_IGNOREHEADERS*)::
 
@@ -481,13 +488,13 @@ CCACHE_MEMCACHED_CONF=--SERVER=localhost:11211
     code (see <<_the_preprocessor_mode,THE PREPROCESSOR MODE>>) and then on a
     cache miss run the compiler on the source code to get hold of the object
     file. This is the default.
-
-    If false, ccache will first run preprocessor to preprocess the source code
-    and then on a cache miss run the compiler on the _preprocessed source code_
-    instead of the original source code. This makes cache misses slightly
-    faster since the source code only has to be preprocessed once. The downside
-    is that some compilers won't produce the same result (for instance
-    diagnostics warnings) when compiling preprocessed source code.
++
+If false, ccache will first run preprocessor to preprocess the source code and
+then on a cache miss run the compiler on the _preprocessed source code_ instead
+of the original source code. This makes cache misses slightly faster since the
+source code only has to be preprocessed once. The downside is that some
+compilers won't produce the same result (for instance diagnostics warnings)
+when compiling preprocessed source code.
 
 *sloppiness* (*CCACHE_SLOPPINESS*)::
 
@@ -577,6 +584,116 @@ compression library zlib. While this may involve a tiny performance slowdown,
 it increases the number of files that fit in the cache. You can turn on
 compression with the *compression* configuration setting and you can also tweak
 the compression level with *compression_level*.
+
+
+Cache statistics
+----------------
+
+*ccache -s/--show-stats* can show the following statistics:
+
+[options="header",cols="30%,70%"]
+|==============================================================================
+|Name | Description
+| autoconf compile/link |
+Uncachable compilation or linking by an autoconf test.
+
+| bad compiler arguments |
+Malformed compiler argument, e.g. missing a value for an option that requires
+an argument or failure to read a file specified by an option argument.
+
+| cache file missing |
+A file was unexpectedly missing from the cache. This only happens in rare
+situations, e.g. if one ccache instance is about to get a file from the cache
+while another instance removed the file as part of cache cleanup.
+
+| cache hit (direct) |
+A result was successfully found using <<_the_direct_mode,the direct mode>>.
+
+| cache hit (preprocessed) |
+A result was successfully found using <<_the_preprocessor_mode,the preprocessor
+mode>>.
+
+| cache miss |
+No result was found.
+
+| cache size |
+Current size of the cache.
+
+| called for link |
+The compiler was called for linking, not compiling.
+
+| called for preprocessing |
+The compiler was called for preprocessing, not compiling.
+
+| can't use precompiled header |
+Preconditions for using <<_precompiled_headers,precompiled headers>> were not
+fulfilled.
+
+| ccache internal error |
+Unexpected failure, e.g. due to problems reading/writing the cache.
+
+| cleanups performed |
+Number of cleanups performed, either implicitly due to the cache size limit
+being reached or due to explicit *ccache -c/--cleanup* calls.
+
+| compile failed |
+The compilation failed. No result stored in the cache.
+
+| compiler check failed |
+A compiler check program specified by *compiler_check* (*CCACHE_COMPILERCHECK*)
+failed.
+
+| compiler produced empty output |
+The compiler's output file (typically an object file) was empty after
+compilation.
+
+| compiler produced no output |
+The compiler's output file (typically an object file) was missing after
+compilation.
+
+| compiler produced stdout |
+The compiler wrote data to standard output. This is something that compilers
+normally never do, so ccache is not designed to store such output in the cache.
+
+| couldn't find the compiler |
+The compiler to execute could not be found.
+
+| error hashing extra file |
+Failure reading a file specified by *extra_files_to_hash*
+(*CCACHE_EXTRAFILES*).
+
+| files in cache |
+Current number of files in the cache.
+
+| multiple source files |
+The compiler was called to compile multiple source files in one go. This is not
+supported by ccache.
+
+| no input file |
+No input file was specified to the compiler.
+
+| output to a non-regular file |
+The output path specified with *-o* is not a file (e.g. a directory or a device
+node).
+
+| output to stdout |
+The compiler was instructed to write its output to standard output using *-o
+-*. This is not supported by ccache.
+
+| preprocessor error |
+Preprocessing the source code using the compiler's *-E* option failed.
+
+| unsupported code directive |
+Code like the assembler ``.incbin'' directive was found. This is not supported
+by ccache.
+
+| unsupported compiler option |
+A compiler option not supported by ccache was found.
+
+| unsupported source language |
+A source language e.g. specified with *-x* was unsupported by ccache.
+
+|==============================================================================
 
 
 How ccache works
@@ -760,8 +877,13 @@ conditions should to be met:
   (and that you trust all users of the shared cache).
 * Make sure that the setgid bit is set on all directories in the cache. This
   tells the filesystem to inherit group ownership for new directories. The
-  command ``find $CCACHE_DIR -type d | xargs chmod g+s'' might be useful for
-  this.
+  following command might be useful for this:
++
+--
+----
+find $CCACHE_DIR -type d | xargs chmod g+s
+----
+--
 
 The reason to avoid the hard link mode is that the hard links cause unwanted
 side effects, as all links to a cached file share the file's modification
@@ -834,20 +956,13 @@ size of the other wrapper instead of the real compiler, which means that:
   the other wrapper.
 
 Another minor thing is that if *prefix_command* is used, ccache will not invoke
-the other wrapper when running the preprocessor, which increase performance.
-You can use the *prefix_command_cpp* configuration setting, if you also want to
+the other wrapper when running the preprocessor, which increases performance.
+You can use the *prefix_command_cpp* configuration setting if you also want to
 invoke the other wrapper when doing preprocessing (normally by adding *-E*).
 
 
 Caveats
 -------
-
-* ccache doesn't handle the GNU Assembler's *.incbin* directive correctly. This
-  directive can be embedded in the source code inside an *__asm__* statement in
-  order to include a file verbatim in the object file. If the included file is
-  modified, ccache doesn't pick up the change since the inclusion isn't done by
-  the preprocessor. A workaround of this problem is to set
-  *extra_files_to_hash* to the path of the included file.
 
 * The direct mode fails to pick up new header files in some rare scenarios. See
   <<_the_direct_mode,THE DIRECT MODE>> above.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,9 +1,76 @@
 ccache news
 ===========
 
+ccache 3.3.4
+------------
+Release date: 2017-02-17
 
-Unreleased 3.3
---------------
+New features and improvements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Documented the different cache statistics counters.
+
+
+Bug fixes
+~~~~~~~~~
+
+- Fixed a regression in ccache 3.3 related to potentially bad content of
+  dependency files when compiling identical source code but with different
+  source paths. This was only partially fixed in 3.3.2 and reverts the new
+  ``Names of included files are no longer included in the hash of the
+  compiler's preprocessed output'' feature in 3.3.
+
+- Corrected statistics counter for `-optf`/`--options-file` failure.
+
+- Fixed undefined behavior warnings in ccache found by `-fsanitize=undefined`.
+
+
+ccache 3.3.3
+------------
+Release date: 2016-10-26
+
+Bug fixes
+~~~~~~~~~
+
+- ccache now detects usage of `.incbin` assembler directives in the source code
+  and avoids caching such compilations.
+
+
+ccache 3.3.2
+------------
+Release date: 2016-09-28
+
+Bug fixes
+~~~~~~~~~
+
+- Fixed a regression in ccache 3.3 related to potentially bad content of
+  dependency files when compiling identical source code but with different
+  source paths.
+
+- Fixed a regression in ccache 3.3.1: ccache could get confused when using the
+  compiler option `-Wp,` to pass multiple options to the preprocessor,
+  resulting in missing dependency files from direct mode cache hits.
+
+
+ccache 3.3.1
+------------
+Release date: 2016-09-07
+
+Bug fixes
+~~~~~~~~~
+
+- Fixed a problem in the ``multiple `-arch` options'' support introduced in
+  3.3. When using the direct mode (the default), different combinations of
+  `-arch` options were not detected properly.
+
+- Fixed an issue when compiler option `-Wp,-MT,path` is used instead of `-MT
+  path` (and similar for `-MF`, `-MP` and `-MQ`) and `run_second_cpp`
+  (`CCACHE_CPP2`) is enabled.
+
+
+ccache 3.3
+----------
+Release date: 2016-08-27
 
 Notes
 ~~~~~
@@ -21,22 +88,43 @@ New features and improvements
 
 - The configuration option `hash_dir` (`CCACHE_HASHDIR`) now defaults to true.
 
-- Added support for cuda including the -optf/--options-file option.
+- Added a new `ignore_headers_in_manifest` configuration option, which
+  specifies headers that should be ignored in the direct mode.
 
-- Added new sloppiness option `no_system_headers`, which tells ccache not to
-  include system headers in manifest files.
-
-- Multiple identical `-arch` arguments are now handled without bailing.
-
-- Added new `ignore_headers_in_manifest` configuration option, which specifies
-  headers that should be ignored in the direct mode.
-
-- Added new `prefix_command_cpp` (`CCACHE_PREFIX_CPP`) configuration option,
+- Added a new `prefix_command_cpp` (`CCACHE_PREFIX_CPP`) configuration option,
   which specifies one or several prefixes to add to the command line ccache
   uses when invoking the preprocessor.
 
-- Added new `limit_multiple` (`CCACHE_LIMIT_MULTIPLE`) configuration option,
+- Added a new `limit_multiple` (`CCACHE_LIMIT_MULTIPLE`) configuration option,
   which specifies how much of the cache to remove when cleaning.
+
+- Added a new `keep_comments_cpp` (`CCACHE_COMMENTS`) configuration option,
+  which tells ccache not to discard the comments before hashing preprocessor
+  output. This can be used to check documentation with *-Wdocumentation*.
+
+- Added a new sloppiness option `no_system_headers`, which tells ccache not to
+  include system headers in manifest files.
+
+- Added a new statistics counter that tracks the number of performed cleanups
+  due to the cache size being over the limit. The value is shown in the output
+  of ``ccache -s''.
+
+- Added support for relocating debug info directory using `-fdebug-prefix-map`.
+  This allows for cache hits even when `hash_dir` is used in combination with
+  `base_dir`.
+
+- Added a new ``cache hit rate'' field to the output of ``ccache -s''.
+
+- Added support for caching compilation of assembler code produced by e.g.
+  ``gcc -S file.c''.
+
+- Added support for cuda including the -optf/--options-file option.
+
+- Added support for Fortran 77.
+
+- Added support for multiple `-arch` options to produce "fat binaries".
+
+- Multiple identical `-arch` arguments are now handled without bailing.
 
 - The concatenated form of some long compiler options is now recognized, for
   example when using `-isystemPATH` instead of `-isystem PATH`.
@@ -46,14 +134,6 @@ New features and improvements
 
 - Made the `hash_dir` option only have effect when generating debug info.
 
-- Added support for relocating debug info directory using `-fdebug-prefix-map`.
-  This allows for cache hits even when `hash_dir` is used in combination with
-  `base_dir`.
-
-- Added a new `keep_comments_cpp` (`CCACHE_COMMENTS`) configuration option,
-  which tells ccache not to discard the comments before hashing preprocessor
-  output. This can be used to check documentation with *-Wdocumentation*.
-
 - ccache now knows how to convert absolute paths to relative paths inside
   dependency files when using `base_dir`.
 
@@ -61,22 +141,15 @@ New features and improvements
 
 - Made ccache understand `-Wp,-D*` options.
 
-- Added a new statistics counter that tracks the number of performed cleanups
-  due to the cache size being over the limit. The value is shown in the output
-  of ``ccache -s''.
-
-- Added a new ``cache hit rate'' field to the output of ``ccache -s''.
+- ccache now understands the undocumented `-coverage` (only one dash) GCC
+  option.
 
 - Names of included files are no longer included in the hash of the compiler's
   preprocessed output. This leads to more potential cache hits when not using
   the direct mode.
 
-- Added support for multiple `-arch` options to produce "fat binaries".
-
-- Added support for caching compilation of assembler code produced by e.g.
-  ``gcc -S file.c''.
-
-- Added support for Fortran 77.
+- Increased buffer size used when reading file data. This improves performance
+  slightly.
 
 
 Bug fixes
@@ -89,11 +162,28 @@ Bug fixes
 - Fixed build and test for MinGW32 and Windows.
 
 
-Unreleased 3.2.8
-----------------
+ccache 3.2.9
+------------
+Release date: 2016-09-28
 
 Bug fixes
 ~~~~~~~~~
+
+- Fixed a regression in ccache 3.2.8: ccache could get confused when using the
+  compiler option `-Wp,` to pass multiple options to the preprocessor,
+  resulting in missing dependency files from direct mode cache hits.
+
+
+ccache 3.2.8
+------------
+Release date: 2016-09-07
+
+Bug fixes
+~~~~~~~~~
+
+- Fixed an issue when compiler option `-Wp,-MT,path` is used instead of `-MT
+  path` (and similar for `-MF`, `-MP` and `-MQ`) and `run_second_cpp`
+  (`CCACHE_CPP2`) is enabled.
 
 - ccache now understands the undocumented `-coverage` (only one dash) GCC
   option.

--- a/ccache.h
+++ b/ccache.h
@@ -42,7 +42,7 @@ enum stats {
 	STATS_NOINPUT = 17,
 	STATS_MULTIPLE = 18,
 	STATS_CONFTEST = 19,
-	STATS_UNSUPPORTED = 20,
+	STATS_UNSUPPORTED_OPTION = 20,
 	STATS_OUTSTDOUT = 21,
 	STATS_CACHEHIT_DIR = 22,
 	STATS_NOOUTPUT = 23,
@@ -52,6 +52,7 @@ enum stats {
 	STATS_CANTUSEPCH = 27,
 	STATS_PREPROCESSING = 28,
 	STATS_NUMCLEANUPS = 29,
+	STATS_UNSUPPORTED_DIRECTIVE = 30,
 
 	STATS_END
 };
@@ -74,6 +75,9 @@ enum stats {
 #define str_endswith(s, suffix) \
 	(strlen(s) >= strlen(suffix) \
 	 && str_eq((s) + strlen(s) - strlen(suffix), (suffix)))
+
+// Buffer size for I/O operations. Should be a multiple of 4 KiB.
+#define READ_BUFFER_SIZE 65536
 
 // ----------------------------------------------------------------------------
 // args.c

--- a/conf.c
+++ b/conf.c
@@ -579,7 +579,8 @@ conf_print_items(struct conf *conf,
 	        conf->item_origins[find_conf("ignore_headers_in_manifest")->number],
 	        context);
 
-	reformat(&s, "keep_comments_cpp = %s", bool_to_string(conf->keep_comments_cpp));
+	reformat(&s, "keep_comments_cpp = %s",
+	         bool_to_string(conf->keep_comments_cpp));
 	printer(s, conf->item_origins[find_conf(
 	                                "keep_comments_cpp")->number], context);
 

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,8 @@ AC_SUBST(extra_libs)
 AC_SUBST(include_dev_mk)
 AC_SUBST(test_suites)
 
+m4_include(m4/feature_macros.m4)
+
 dnl Checks for programs.
 AC_PROG_CC_C99
 if test "$ac_cv_prog_cc_c99" = no; then
@@ -34,8 +36,6 @@ AC_CHECK_TOOL(AR, ar)
 if test -z "$AR"; then
     AC_MSG_ERROR(cannot find ar)
 fi
-
-m4_include(m4/feature_macros.m4)
 
 # If GCC, turn on warnings.
 if test "x$GCC" = "xyes"; then

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -59,7 +59,6 @@ source_dist_files = \
     AUTHORS.txt \
     GPL-3.0.txt \
     HACKING.txt \
-    INSTALL.md \
     LICENSE.txt \
     MANUAL.txt \
     Makefile.in \
@@ -111,6 +110,7 @@ $(dist_archives): $(dist_files)
 	mkdir $$dir && \
 	(cd $(srcdir) && \
 	 rsync -r --relative $(source_dist_files) $$dir) && \
+	cp $(srcdir)/INSTALL-from-release-archive.md $$dir/INSTALL.md && \
 	cp $(built_dist_files) $$dir && \
 	echo "Remove this file to enable developer mode." >$$dir/dev_mode_disabled && \
 	(cd $$tmpdir && \

--- a/hash.c
+++ b/hash.c
@@ -97,7 +97,7 @@ hash_int(struct mdfour *md, int x)
 bool
 hash_fd(struct mdfour *md, int fd)
 {
-	char buf[16384];
+	char buf[READ_BUFFER_SIZE];
 	ssize_t n;
 
 	while ((n = read(fd, buf, sizeof(buf))) != 0) {

--- a/lockfile.c
+++ b/lockfile.c
@@ -149,9 +149,10 @@ lockfile_acquire(const char *path, unsigned staleness_limit)
 			if (str_eq(content, initial_content)) {
 				// The lock seems to be stale -- break it.
 				cc_log("lockfile_acquire: breaking %s", lockfile);
+				// Try to acquire path.lock.lock:
 				if (lockfile_acquire(lockfile, staleness_limit)) {
-					lockfile_release(path);
-					lockfile_release(lockfile);
+					lockfile_release(path); // Remove path.lock
+					lockfile_release(lockfile); // Remove path.lock.lock
 					to_sleep = 1000;
 					slept = 0;
 					continue;

--- a/manifest.c
+++ b/manifest.c
@@ -165,15 +165,16 @@ free_manifest(struct manifest *mf)
 
 #define READ_INT(size, var) \
   do { \
-		(var) = 0; \
+		uint64_t u_ = 0; \
 		for (size_t i_ = 0; i_ < (size); i_++) { \
 			int ch_ = gzgetc(f); \
 			if (ch_ == EOF) { \
 				goto error; \
 			} \
-			(var) <<= 8; \
-			(var) |= ch_ & 0xFF; \
+			u_ <<= 8; \
+			u_ |= ch_ & 0xFF; \
 		} \
+		(var) = u_; \
 	} while (false)
 
 #define READ_STR(var) \
@@ -289,10 +290,11 @@ error:
 
 #define WRITE_INT(size, var) \
   do { \
+		uint64_t u_ = (var); \
 		uint8_t ch_; \
 		size_t i_; \
 		for (i_ = 0; i_ < (size); i_++) { \
-			ch_ = ((var) >> (8 * ((size) - i_ - 1))); \
+			ch_ = (u_ >> (8 * ((size) - i_ - 1))); \
 			if (gzputc(f, ch_) == EOF) { \
 				goto error; \
 			} \

--- a/murmurhashneutral2.c
+++ b/murmurhashneutral2.c
@@ -13,9 +13,9 @@ murmurhashneutral2(const void *key, int len, unsigned int seed)
 
 	while (len >= 4) {
 		unsigned int k = data[0];
-		k |= data[1] << 8;
-		k |= data[2] << 16;
-		k |= data[3] << 24;
+		k |= ((unsigned int) data[1]) << 8;
+		k |= ((unsigned int) data[2]) << 16;
+		k |= ((unsigned int) data[3]) << 24;
 
 		k *= m;
 		k ^= k >> r;
@@ -30,9 +30,9 @@ murmurhashneutral2(const void *key, int len, unsigned int seed)
 
 	switch (len)
 	{
-	case 3: h ^= data[2] << 16;
-	case 2: h ^= data[1] << 8;
-	case 1: h ^= data[0];
+	case 3: h ^= ((unsigned int) data[2]) << 16;
+	case 2: h ^= ((unsigned int) data[1]) << 8;
+	case 1: h ^= ((unsigned int) data[0]);
 		h *= m;
 	};
 

--- a/stats.c
+++ b/stats.c
@@ -50,40 +50,192 @@ static struct {
 	void (*fn)(uint64_t);
 	unsigned flags;
 } stats_info[] = {
-	{ STATS_CACHEHIT_DIR, "cache hit (direct)             ", NULL, FLAG_ALWAYS },
-	{ STATS_CACHEHIT_CPP, "cache hit (preprocessed)       ", NULL, FLAG_ALWAYS },
-	{ STATS_TOCACHE,      "cache miss                     ", NULL, FLAG_ALWAYS },
-	{ STATS_LINK,         "called for link                ", NULL, 0 },
-	{ STATS_PREPROCESSING, "called for preprocessing       ", NULL, 0 },
-	{ STATS_MULTIPLE,     "multiple source files          ", NULL, 0 },
-	{ STATS_STDOUT,       "compiler produced stdout       ", NULL, 0 },
-	{ STATS_NOOUTPUT,     "compiler produced no output    ", NULL, 0 },
-	{ STATS_EMPTYOUTPUT,  "compiler produced empty output ", NULL, 0 },
-	{ STATS_STATUS,       "compile failed                 ", NULL, 0 },
-	{ STATS_ERROR,        "ccache internal error          ", NULL, 0 },
-	{ STATS_PREPROCESSOR, "preprocessor error             ", NULL, 0 },
-	{ STATS_CANTUSEPCH,   "can't use precompiled header   ", NULL, 0 },
-	{ STATS_COMPILER,     "couldn't find the compiler     ", NULL, 0 },
-	{ STATS_MISSING,      "cache file missing             ", NULL, 0 },
-	{ STATS_ARGS,         "bad compiler arguments         ", NULL, 0 },
-	{ STATS_SOURCELANG,   "unsupported source language    ", NULL, 0 },
-	{ STATS_COMPCHECK,    "compiler check failed          ", NULL, 0 },
-	{ STATS_CONFTEST,     "autoconf compile/link          ", NULL, 0 },
-	{ STATS_UNSUPPORTED,  "unsupported compiler option    ", NULL, 0 },
-	{ STATS_OUTSTDOUT,    "output to stdout               ", NULL, 0 },
-	{ STATS_DEVICE,       "output to a non-regular file   ", NULL, 0 },
-	{ STATS_NOINPUT,      "no input file                  ", NULL, 0 },
-	{ STATS_BADEXTRAFILE, "error hashing extra file       ", NULL, 0 },
-	{ STATS_NUMCLEANUPS,  "cleanups performed             ", NULL, FLAG_ALWAYS },
-	{ STATS_NUMFILES,     "files in cache                 ", NULL,
-		FLAG_NOZERO|FLAG_ALWAYS },
-	{ STATS_TOTALSIZE,    "cache size                     ",
-		display_size_times_1024, FLAG_NOZERO|FLAG_ALWAYS },
-	{ STATS_OBSOLETE_MAXFILES, "OBSOLETE",                   NULL,
-		FLAG_NOZERO|FLAG_NEVER},
-	{ STATS_OBSOLETE_MAXSIZE, "OBSOLETE",                    NULL,
-		FLAG_NOZERO|FLAG_NEVER},
-	{ STATS_NONE, NULL, NULL, 0 }
+	{
+		STATS_CACHEHIT_DIR,
+		"cache hit (direct)",
+		NULL,
+		FLAG_ALWAYS
+	},
+	{
+		STATS_CACHEHIT_CPP,
+		"cache hit (preprocessed)",
+		NULL,
+		FLAG_ALWAYS
+	},
+	{
+		STATS_TOCACHE,
+		"cache miss",
+		NULL,
+		FLAG_ALWAYS
+	},
+	{
+		STATS_LINK,
+		"called for link",
+		NULL,
+		0
+	},
+	{
+		STATS_PREPROCESSING,
+		"called for preprocessing",
+		NULL,
+		0
+	},
+	{
+		STATS_MULTIPLE,
+		"multiple source files",
+		NULL,
+		0
+	},
+	{
+		STATS_STDOUT,
+		"compiler produced stdout",
+		NULL,
+		0
+	},
+	{
+		STATS_NOOUTPUT,
+		"compiler produced no output",
+		NULL,
+		0
+	},
+	{
+		STATS_EMPTYOUTPUT,
+		"compiler produced empty output",
+		NULL,
+		0
+	},
+	{
+		STATS_STATUS,
+		"compile failed",
+		NULL,
+		0
+	},
+	{
+		STATS_ERROR,
+		"ccache internal error",
+		NULL,
+		0
+	},
+	{
+		STATS_PREPROCESSOR,
+		"preprocessor error",
+		NULL,
+		0
+	},
+	{
+		STATS_CANTUSEPCH,
+		"can't use precompiled header",
+		NULL,
+		0
+	},
+	{
+		STATS_COMPILER,
+		"couldn't find the compiler",
+		NULL,
+		0
+	},
+	{
+		STATS_MISSING,
+		"cache file missing",
+		NULL,
+		0
+	},
+	{
+		STATS_ARGS,
+		"bad compiler arguments",
+		NULL,
+		0
+	},
+	{
+		STATS_SOURCELANG,
+		"unsupported source language",
+		NULL,
+		0
+	},
+	{
+		STATS_COMPCHECK,
+		"compiler check failed",
+		NULL,
+		0
+	},
+	{
+		STATS_CONFTEST,
+		"autoconf compile/link",
+		NULL,
+		0
+	},
+	{
+		STATS_UNSUPPORTED_OPTION,
+		"unsupported compiler option",
+		NULL,
+		0
+	},
+	{
+		STATS_UNSUPPORTED_DIRECTIVE,
+		"unsupported code directive",
+		NULL,
+		0
+	},
+	{
+		STATS_OUTSTDOUT,
+		"output to stdout",
+		NULL,
+		0
+	},
+	{
+		STATS_DEVICE,
+		"output to a non-regular file",
+		NULL,
+		0
+	},
+	{
+		STATS_NOINPUT,
+		"no input file",
+		NULL,
+		0
+	},
+	{
+		STATS_BADEXTRAFILE,
+		"error hashing extra file",
+		NULL,
+		0
+	},
+	{
+		STATS_NUMCLEANUPS,
+		"cleanups performed",
+		NULL,
+		FLAG_ALWAYS
+	},
+	{
+		STATS_NUMFILES,
+		"files in cache",
+		NULL,
+		FLAG_NOZERO|FLAG_ALWAYS
+	},
+	{
+		STATS_TOTALSIZE,
+		"cache size",
+		display_size_times_1024,
+		FLAG_NOZERO|FLAG_ALWAYS
+	},
+	{
+		STATS_OBSOLETE_MAXFILES,
+		"OBSOLETE",
+		NULL,
+		FLAG_NOZERO|FLAG_NEVER
+	},
+	{
+		STATS_OBSOLETE_MAXSIZE,
+		"OBSOLETE",
+		NULL,
+		FLAG_NOZERO|FLAG_NEVER
+	},
+	{
+		STATS_NONE,
+		NULL,
+		NULL,
+		0
+	}
 };
 
 static void
@@ -297,7 +449,7 @@ stats_summary(struct conf *conf)
 			continue;
 		}
 
-		printf("%s ", stats_info[i].message);
+		printf("%-31s ", stats_info[i].message);
 		if (stats_info[i].fn) {
 			stats_info[i].fn(counters->data[stat]);
 			printf("\n");

--- a/test/test_argument_processing.c
+++ b/test/test_argument_processing.c
@@ -81,7 +81,7 @@ TEST(dash_M_should_be_unsupported)
 
 	create_file("foo.c", "");
 	CHECK(!cc_process_args(orig, &preprocessed, &compiler));
-	CHECK_INT_EQ(1, stats_get_pending(STATS_UNSUPPORTED));
+	CHECK_INT_EQ(1, stats_get_pending(STATS_UNSUPPORTED_OPTION));
 
 	args_free(orig);
 }
@@ -90,7 +90,7 @@ TEST(dependency_flags_should_only_be_sent_to_the_preprocessor)
 {
 #define CMD \
 	"cc -MD -MMD -MP -MF foo.d -MT mt1 -MT mt2 -MQ mq1 -MQ mq2" \
-	" -Wp,-MD,wpmd -Wp,-MMD,wpmmd"
+	" -Wp,-MD,wpmd -Wp,-MMD,wpmmd -Wp,-MP -Wp,-MT,wpmt -Wp,-MQ,wpmq -Wp,-MF,wpf"
 	struct args *orig = args_init_from_string(CMD " -c foo.c -o foo.o");
 	struct args *exp_cpp = args_init_from_string(CMD);
 #undef CMD
@@ -112,8 +112,9 @@ TEST(cpp_only_flags_to_preprocessor_if_run_second_cpp_is_false)
 	" -include test.h -include-pch test.pch -iprefix . -iquote ." \
 	" -isysroot . -isystem . -iwithprefix . -iwithprefixbefore ." \
 	" -DTEST_MACRO -DTEST_MACRO2=1 -F. -trigraphs -fworking-directory" \
-	" -fno-working-directory -MD -MMD -MP -MF foo.d -MT mt1 -MT mt2 " \
-	" -MQ mq1 -MQ mq2 -Wp,-MD,wpmd -Wp,-MMD,wpmmd"
+	" -fno-working-directory -MD -MMD -MP -MF foo.d -MT mt1 -MT mt2" \
+	" -MQ mq1 -MQ mq2 -Wp,-MD,wpmd -Wp,-MMD,wpmmd -Wp,-MP -Wp,-MT,wpmt" \
+	" -Wp,-MQ,wpmq -Wp,-MF,wpf"
 	struct args *orig = args_init_from_string(CMD " -c foo.c -o foo.o");
 	struct args *exp_cpp = args_init_from_string(CMD);
 #undef CMD

--- a/util.c
+++ b/util.c
@@ -197,7 +197,7 @@ copy_fd(int fd_in, int fd_out)
 	}
 
 	int n;
-	char buf[10240];
+	char buf[READ_BUFFER_SIZE];
 	while ((n = gzread(gz_in, buf, sizeof(buf))) > 0) {
 		ssize_t written = 0;
 		do {
@@ -297,7 +297,7 @@ copy_file(const char *src, const char *dest, int compress_level)
 	}
 
 	int n;
-	char buf[10240];
+	char buf[READ_BUFFER_SIZE];
 	while ((n = gzread(gz_in, buf, sizeof(buf))) > 0) {
 		int written;
 		if (compress_level > 0) {
@@ -1059,7 +1059,9 @@ parse_size_with_suffix(const char *str, uint64_t *size)
 }
 
 
-#if defined(_WIN32) && !defined(HAVE_GETFINALPATHNAMEBYHANDLEW)
+#if !defined(HAVE_REALPATH) && \
+    defined(_WIN32) && \
+    !defined(HAVE_GETFINALPATHNAMEBYHANDLEW)
 static BOOL GetFileNameFromHandle(HANDLE file_handle, TCHAR *filename,
                                   WORD cch_filename)
 {


### PR DESCRIPTION
I'm starting to the memcached support, but I saw that the changes in the dev/memcached are behind the last release.
I've merged the tag v3.3.4 into dev/memcached.

Can we get this PR accepted with the last stable changes?

Thanks,
Rodrigo