### PR TITLE
Add -Wno-implicit-fallthrough to fix gcc7 builds

### DIFF
--- a/dev.mk.in
+++ b/dev.mk.in
@@ -1,6 +1,6 @@
 # GNU make syntax reigns in this file.
 
-all_cflags += -Werror
+all_cflags += -Werror -Wno-implicit-fallthrough
 all_cppflags += -MD -MP -MF .deps/$(subst .._,,$(subst /,_,$<)).d
 
 ASCIIDOC = asciidoc


### PR DESCRIPTION
gcc-7 has become extremely warny - even for idiomatic code (such as default fallthrough). This does
not fit well with `-Werror` as it causes the build to fail.