### PR TITLE
Fix leaked file descriptor

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -3250,6 +3250,7 @@ static void
 setup_uncached_err(void)
 {
 	int uncached_fd = dup(2);
+	set_cloexec_flag(uncached_fd);
 	if (uncached_fd == -1) {
 		cc_log("dup(2) failed: %s", strerror(errno));
 		failed();

--- a/ccache.h
+++ b/ccache.h
@@ -186,6 +186,7 @@ char *x_readlink(const char *path);
 bool read_file(const char *path, size_t size_hint, char **data, size_t *size);
 char *read_text_file(const char *path, size_t size_hint);
 char *subst_env_in_string(const char *str, char **errmsg);
+void set_cloexec_flag (int fd);
 
 // ----------------------------------------------------------------------------
 // stats.c

--- a/util.c
+++ b/util.c
@@ -51,10 +51,7 @@ init_log(void)
 	if (logfile) {
 #ifndef _WIN32
 		int fd = fileno(logfile);
-		int flags = fcntl(fd, F_GETFD, 0);
-		if (flags >= 0) {
-			fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
-		}
+                set_cloexec_flag(fd);
 #endif
 		return true;
 	} else {
@@ -1197,6 +1194,7 @@ create_tmp_fd(char **fname)
 		fatal("Failed to create temporary file for %s: %s",
 		      *fname, strerror(errno));
 	}
+	set_cloexec_flag(fd);
 
 #ifndef _WIN32
 	fchmod(fd, 0666 & ~get_umask());
@@ -1672,3 +1670,15 @@ subst_env_in_string(const char *str, char **errmsg)
 	reformat(&result, "%s%.*s", result, (int)(q - p), p);
 	return result;
 }
+
+void
+set_cloexec_flag (int fd)
+{
+#ifndef _WIN32
+	int flags = fcntl(fd, F_GETFD, 0);
+	if (flags >= 0) {
+		fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+	}
+#endif
+}
+


### PR DESCRIPTION
A leaked file descriptor caused our setup to stall.

We use *ninja* + *ccache* + *distcc* + *avahi/zeroconf*.
