### PR TITLE
-fdebug-prefix-map is supported in clang 3.8 and newer

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1280,7 +1280,7 @@ EOF
 # =============================================================================
 
 SUITE_debug_prefix_map_PROBE() {
-    if ! $COMPILER_TYPE_GCC || $COMPILER_USES_MINGW; then
+    if $COMPILER_USES_MINGW; then
         echo "-fdebug-prefix-map not supported by compiler"
     fi
 }


### PR DESCRIPTION
It's not documented until newer versions of clang, but support was
added in 3.8: https://reviews.llvm.org/rL250094