### PR TITLE
Add fallthrough statements for GCC 7

### DIFF
--- a/murmurhashneutral2.c
+++ b/murmurhashneutral2.c
@@ -30,9 +30,9 @@ murmurhashneutral2(const void *key, int len, unsigned int seed)
 
 	switch (len)
 	{
-	case 3: h ^= ((unsigned int) data[2]) << 16;
-	case 2: h ^= ((unsigned int) data[1]) << 8;
-	case 1: h ^= ((unsigned int) data[0]);
+	case 3: h ^= ((unsigned int) data[2]) << 16; // fallthrough
+	case 2: h ^= ((unsigned int) data[1]) << 8;  // fallthrough
+	case 1: h ^= ((unsigned int) data[0]);       // fallthrough
 		h *= m;
 	};
 

--- a/util.c
+++ b/util.c
@@ -981,14 +981,14 @@ parse_size_with_suffix(const char *str, uint64_t *size)
 		unsigned multiplier = *(p+1) == 'i' ? 1024 : 1000;
 		switch (*p) {
 		case 'T':
-			x *= multiplier;
+			x *= multiplier; // fallthrough
 		case 'G':
-			x *= multiplier;
+			x *= multiplier; // fallthrough
 		case 'M':
-			x *= multiplier;
+			x *= multiplier; // fallthrough
 		case 'K':
 		case 'k':
-			x *= multiplier;
+			x *= multiplier; // fallthrough
 			break;
 		default:
 			return false;


### PR DESCRIPTION
GCC 7 uses -Werror=implicit-fallthrough= by default.