### PR TITLE
Clean up redundant expression

### DIFF
--- a/getopt_long.c
+++ b/getopt_long.c
@@ -72,14 +72,14 @@ getopt_long(int argc, char *const argv[],
 
 		place++;
 
-		if (place[0] && place[0] == '-' && place[1] == '\0')
+		if (place[0] == '-' && place[1] == '\0')
 		{ /* found "--" */
 			++optind;
 			place = EMSG;
 			return -1;
 		}
 
-		if (place[0] && place[0] == '-' && place[1])
+		if (place[0] == '-' && place[1])
 		{
 			/* long option */
 			size_t namelen;


### PR DESCRIPTION
This cleans up two redundant conditions, found by Cppcheck

```
[getopt_long.c:75]: (style) Redundant condition: If 'EXPR == '-'', the comparison 'EXPR' is always true.
[getopt_long.c:82]: (style) Redundant condition: If 'EXPR == '-'', the comparison 'EXPR' is always true.
```