### PR TITLE
Fix broken UNCACHED_ERR_FD, it shouldn't be closed on exec

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -3131,11 +3131,11 @@ static void
 setup_uncached_err(void)
 {
 	int uncached_fd = dup(2);
-	set_cloexec_flag(uncached_fd);
 	if (uncached_fd == -1) {
 		cc_log("dup(2) failed: %s", strerror(errno));
 		failed();
 	}
+	// Leak the file descriptor.
 
 	// Leak a pointer to the environment.
 	char *buf = format("UNCACHED_ERR_FD=%d", uncached_fd);


### PR DESCRIPTION
Since that's exactly the point, to leak it to whatever ccache calls.