### PR TITLE
issue #219

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -1583,10 +1583,6 @@ calculate_common_hash(struct args *args, struct mdfour *hash)
 		char *dir = dirname(output_obj);
 		if (profile_dir) {
 			dir = x_strdup(profile_dir);
-		} else {
-			char *real_dir = x_realpath(dir);
-			free(dir);
-			dir = real_dir;
 		}
 		if (dir) {
 			char *base_name = basename(output_obj);


### PR DESCRIPTION
This will allow to hash the coverage file with relative path which will increase a lot ccache direct hit between build on different path
Then we will also have a more consistent mechanism, as today path provided with -fprofile-dir is not converted absolute, so we should do the same for the self generated one when not path is provided and object path is used.