### PR TITLE
Fix debug_prefix_map test suite

### DIFF
--- a/test/suites/debug_prefix_map.bash
+++ b/test/suites/debug_prefix_map.bash
@@ -29,7 +29,7 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if grep -E "[^=]`pwd`[^=]" test.o >/dev/null 2>&1; then
+    if objdump -g test.o | grep ": `pwd`$" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
 
@@ -39,7 +39,7 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if grep -E "[^=]`pwd`[^=]" test.o >/dev/null 2>&1; then
+    if objdump -g test.o | grep ": `pwd`$" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
 
@@ -52,10 +52,10 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if grep -E "[^=]`pwd`[^=]" test.o >/dev/null 2>&1; then
+    if objdump -g test.o | grep ": `pwd`$" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
-    if ! grep "name" test.o >/dev/null 2>&1; then
+    if ! objdump -g test.o | grep ": name$" >/dev/null 2>&1; then
         test_failed "Relocation (name) not found in test.o"
     fi
 
@@ -65,7 +65,7 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if grep -E "[^=]`pwd`[^=]" test.o >/dev/null 2>&1; then
+    if objdump -g test.o | grep ": `pwd`$" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
 }

--- a/test/suites/debug_prefix_map.bash
+++ b/test/suites/debug_prefix_map.bash
@@ -29,7 +29,7 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if objdump -g test.o | grep ": `pwd`$" >/dev/null 2>&1; then
+    if objdump -g test.o | grep ": `pwd`[[:space:]]*$" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
 
@@ -39,7 +39,7 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if objdump -g test.o | grep ": `pwd`$" >/dev/null 2>&1; then
+    if objdump -g test.o | grep ": `pwd`[[:space:]]*$" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
 
@@ -52,10 +52,10 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if objdump -g test.o | grep ": `pwd`$" >/dev/null 2>&1; then
+    if objdump -g test.o | grep ": `pwd`[[:space:]]*$" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
-    if ! objdump -g test.o | grep ": name$" >/dev/null 2>&1; then
+    if ! objdump -g test.o | grep ": name[[:space:]]*$" >/dev/null 2>&1; then
         test_failed "Relocation (name) not found in test.o"
     fi
 
@@ -65,7 +65,7 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if objdump -g test.o | grep ": `pwd`$" >/dev/null 2>&1; then
+    if objdump -g test.o | grep ": `pwd`[[:space:]]*$" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
 }

--- a/test/suites/debug_prefix_map.bash
+++ b/test/suites/debug_prefix_map.bash
@@ -19,6 +19,22 @@ EOF
     backdate dir1/include/test.h dir2/include/test.h
 }
 
+objdump_cmd() {
+    if $HOST_OS_APPLE; then
+        xcrun dwarfdump -r0 $1
+    else
+        objdump -g $1
+    fi
+}
+
+grep_cmd() {
+    if $HOST_OS_APPLE; then
+        grep "( \"$1\" )"
+    else
+        grep ": $1[[:space:]]*$"
+    fi
+}
+
 SUITE_debug_prefix_map() {
     # -------------------------------------------------------------------------
     TEST "Mapping of debug info CWD"
@@ -29,7 +45,7 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if objdump -g test.o | grep ": `pwd`[[:space:]]*$" >/dev/null 2>&1; then
+    if objdump_cmd test.o | grep_cmd "`pwd`" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
 
@@ -39,7 +55,7 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if objdump -g test.o | grep ": `pwd`[[:space:]]*$" >/dev/null 2>&1; then
+    if objdump_cmd test.o | grep_cmd "`pwd`" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
 
@@ -52,10 +68,10 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if objdump -g test.o | grep ": `pwd`[[:space:]]*$" >/dev/null 2>&1; then
+    if objdump_cmd test.o | grep_cmd "`pwd`" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
-    if ! objdump -g test.o | grep ": name[[:space:]]*$" >/dev/null 2>&1; then
+    if ! objdump_cmd test.o | grep_cmd "name" >/dev/null 2>&1; then
         test_failed "Relocation (name) not found in test.o"
     fi
 
@@ -65,7 +81,7 @@ SUITE_debug_prefix_map() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
-    if objdump -g test.o | grep ": `pwd`[[:space:]]*$" >/dev/null 2>&1; then
+    if objdump_cmd test.o | grep_cmd "`pwd`" >/dev/null 2>&1; then
         test_failed "Source dir (`pwd`) found in test.o"
     fi
 }


### PR DESCRIPTION
This will fix errors in tests when `.debug_str` section is compressed:
```
PASSED: 483 assertions, 96 tests, 10 suites
CC='gcc' /nix/store/zqh3l3lyw32q1ayb15bnvg9f24j5v2p0-bash-4.4-p12/bin/bash ./test/run
Compiler:         gcc (/nix/store/gqg2vrcq7krqi9rrl6pphvsg81sb8pjw-gcc-wrapper-7.3.0/bin/gcc)
Compiler version: gcc (GCC) 7.3.0
CUDA compiler:    not available

Running test suite base.........................................................
Running test suite nocpp2.........................................................
Running test suite cpp1.
Skipped test suite multi_arch [multiple -arch options not supported on Linux]
Skipped test suite serialize_diagnostics [--serialize-diagnostics not supported by compiler]
Running test suite debug_prefix_map..
FAILED

Test suite:     debug_prefix_map
Test case:      Multiple -fdebug-prefix-map
Failure reason: Relocation (name) not found in test.o

ccache -s:
cache directory                     /tmp/nix-build-ccache-3.4.drv-4/ccache-3.4/testdir.10580/.ccache
primary config                      /tmp/nix-build-ccache-3.4.drv-4/ccache-3.4/testdir.10580/ccache.conf
secondary config      (readonly)    
stats zero time                     Wed Feb 28 04:48:24 2018
cache hit (direct)                     0
cache hit (preprocessed)               0
cache miss                             1
cache hit rate                      0.00 %
cleanups performed                     0
files in cache                         2
cache size                           8.2 kB
max cache size                       5.0 GB

Test data and log file have been left in testdir.10580
make: *** [Makefile:106: test] Error 1
```