### PR TITLE
The Dockerfile was moved to a subdirectory

### DIFF
--- a/dev.mk.in
+++ b/dev.mk.in
@@ -187,6 +187,6 @@ analyze:
 
 .PHONY: docker
 docker: misc/Dockerfile
-	$(DOCKER) build $(srcdir)
+	$(DOCKER) build -f $< $(srcdir)
 
 -include .deps/*.d


### PR DESCRIPTION
Some breakage from the introduction of `misc`