### PR TITLE
build: Enable VPATH builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -132,7 +132,7 @@ unittest/run$(EXEEXT): $(base_objs) $(test_objs) $(extra_libs)
 
 unittest/main.o: unittest/suites.h
 
-unittest/suites.h: $(test_suites) Makefile
+$(srcdir)/unittest/suites.h: $(test_suites) Makefile
 	sed -n 's/TEST_SUITE(\(.*\))/SUITE(\1)/p' $(test_suites) >$@
 
 .PHONY: check

--- a/Makefile.in
+++ b/Makefile.in
@@ -133,7 +133,7 @@ unittest/run$(EXEEXT): $(base_objs) $(test_objs) $(extra_libs)
 unittest/main.o: unittest/suites.h
 
 $(srcdir)/unittest/suites.h: $(test_suites) Makefile
-	sed -n 's/TEST_SUITE(\(.*\))/SUITE(\1)/p' $(test_suites) >$@
+	sed -n 's/TEST_SUITE(\(.*\))/SUITE(\1)/p' $(addprefix $(srcdir)/,$(test_suites)) >$@
 
 .PHONY: check
 check: test

--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,7 @@ if test ! -f $srcdir/src/version.c; then
 fi
 
 dnl Find test suite files.
-test_suites=`ls $srcdir/unittest/test_*.c | egrep -v 'BASE|BACKUP|LOCAL|REMOTE' | xargs echo`
+test_suites=` find ../unittest -name 'test_*.c' -printf 'unittest/%P\n' | egrep -v 'BASE|BACKUP|LOCAL|REMOTE' | xargs echo`
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -161,7 +161,7 @@ if test ! -f $srcdir/dev_mode_disabled && test "$RUN_FROM_BUILD_FARM" != yes; th
     AC_CONFIG_FILES([dev.mk])
     include_dev_mk='include dev.mk'
     version=`(git --git-dir=$srcdir/.git describe --dirty 2>/dev/null || echo vunknown) | sed -e 's/v//' -e 's/-/+/' -e 's/-/_/g'`
-    echo "const char CCACHE_VERSION@<:@@:>@ = \"$version\";" >src/version.c
+    echo "const char CCACHE_VERSION@<:@@:>@ = \"$version\";" >$srcdir/src/version.c
 else
     AC_MSG_NOTICE(Developer mode disabled)
 fi

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -52,7 +52,7 @@ headers = \
     unittest/util.h
 
 files_to_clean += *.tar.bz2 *.tar.gz *.tar.xz *.xml .deps/* perfdir.*
-files_to_distclean += $(built_dist_files) src/version.c unittest/suites.h
+files_to_distclean += $(built_dist_files) src/version.c $(srcdir)/unittest/suites.h
 files_to_distclean += .deps dev.mk
 
 source_dist_files = \

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -24,11 +24,11 @@ ifneq ($(shell uname), Darwin)
 endif
 
 generated_docs = \
-    LICENSE.html \
-    doc/AUTHORS.html \
-    doc/MANUAL.html \
-    doc/NEWS.html \
-    doc/ccache.1
+    $(srcdir)/LICENSE.html \
+    $(srcdir)/doc/AUTHORS.html \
+    $(srcdir)/doc/MANUAL.html \
+    $(srcdir)/doc/NEWS.html \
+    $(srcdir)/doc/ccache.1
 built_dist_files = $(generated_docs)
 
 headers = \
@@ -160,7 +160,7 @@ docs: $(generated_docs)
 	$(ASCIIDOC) -a revnumber=$(version) -d manpage -b docbook -o - $< | \
 	  perl -pe 's!<literal>(.*?)</literal>!<emphasis role="strong">\1</emphasis>!g' >$@
 
-doc/ccache.1: doc/MANUAL.xml
+$(srcdir)/doc/ccache.1: $(srcdir)/doc/MANUAL.xml
 	$(A2X) --doctype manpage --format manpage $<
 
 .PHONY: update-authors


### PR DESCRIPTION
Previously if build tree was not the same as source tree
the generated version.c landed in a build tree. Also the makefile
could not find the generated doc/ccache.1. Finally make distclean
was not removing the generated docs.

This is my first PR to this repo, I hope it matches the guidelines.