### PR TITLE
Support out-of-source builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,5 @@
 srcdir = @srcdir@
+builddir = @builddir@
 VPATH = @srcdir@
 
 prefix = @prefix@
@@ -20,7 +21,7 @@ LIBS = @LIBS@
 RANLIB = @RANLIB@
 
 all_cflags = $(CFLAGS)
-all_cppflags = @DEFS@ -DSYSCONFDIR=$(sysconfdir) -I. -I$(srcdir)/src $(CPPFLAGS)
+all_cppflags = @DEFS@ -DSYSCONFDIR=$(sysconfdir) -I. -I$(srcdir)/src -I$(builddir)/unittest $(CPPFLAGS)
 extra_libs = @extra_libs@
 
 non_3pp_sources = \
@@ -40,7 +41,8 @@ non_3pp_sources = \
     src/mdfour.c \
     src/stats.c \
     src/unify.c \
-    src/util.c \
+    src/util.c
+generated_sources = \
     src/version.c
 3pp_sources = \
     src/getopt_long.c \
@@ -48,7 +50,7 @@ non_3pp_sources = \
     src/hashtable_itr.c \
     src/murmurhashneutral2.c \
     src/snprintf.c
-base_sources = $(non_3pp_sources) $(3pp_sources)
+base_sources = $(non_3pp_sources) $(generated_sources) $(3pp_sources)
 base_objs = $(base_sources:.c=.o)
 
 ccache_sources = src/main.c $(base_sources)
@@ -95,12 +97,15 @@ all: ccache$(EXEEXT)
 ccache$(EXEEXT): $(ccache_objs) $(extra_libs)
 	$(CC) $(all_cflags) -o $@ $(ccache_objs) $(LDFLAGS) $(extra_libs) $(LIBS)
 
+ccache.1: doc/ccache.1
+	cp $< $@
+
 .PHONY: install
-install: all $(srcdir)/doc/ccache.1
+install: ccache$(EXEEXT) ccache.1
 	$(installcmd) -d $(DESTDIR)$(bindir)
 	$(installcmd) -m 755 ccache$(EXEEXT) $(DESTDIR)$(bindir)
 	$(installcmd) -d $(DESTDIR)$(mandir)/man1
-	-$(installcmd) -m 644 $(srcdir)/doc/ccache.1 $(DESTDIR)$(mandir)/man1/
+	-$(installcmd) -m 644 ccache.1 $(DESTDIR)$(mandir)/man1/
 
 .PHONY: clean
 clean:
@@ -133,7 +138,7 @@ unittest/run$(EXEEXT): $(base_objs) $(test_objs) $(extra_libs)
 unittest/main.o: unittest/suites.h
 
 unittest/suites.h: $(test_suites) Makefile
-	sed -n 's/TEST_SUITE(\(.*\))/SUITE(\1)/p' $(test_suites) >$@
+	sed -n 's/TEST_SUITE(\(.*\))/SUITE(\1)/p' $^ | grep ^SUITE >$@
 
 .PHONY: check
 check: test

--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,8 @@ if test "$ac_cv_c_extern_inline" != no ; then
               Define to 1 if your compiler supports extern inline)
 fi
 
+mkdir -p src
+
 dnl Enable developer mode if dev.mk.in exists.
 if test ! -f $srcdir/dev_mode_disabled && test "$RUN_FROM_BUILD_FARM" != yes; then
     AC_MSG_NOTICE(Developer mode enabled)
@@ -166,13 +168,13 @@ else
     AC_MSG_NOTICE(Developer mode disabled)
 fi
 
-if test ! -f $srcdir/src/version.c; then
+if test ! -f $srcdir/src/version.c -a ! -f src/version.c ; then
     AC_MSG_WARN(unable to determine ccache version)
     echo "const char CCACHE_VERSION@<:@@:>@ = \"unknown\";" >src/version.c
 fi
 
 dnl Find test suite files.
-test_suites=`ls $srcdir/unittest/test_*.c | egrep -v 'BASE|BACKUP|LOCAL|REMOTE' | xargs echo`
+test_suites=`cd $srcdir && ls unittest/test_*.c | egrep -v 'BASE|BACKUP|LOCAL|REMOTE' | xargs echo`
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
@@ -185,7 +187,7 @@ cat config.h >>config.h.tmp
 echo '#endif' >>config.h.tmp
 mv config.h.tmp config.h
 
-mkdir -p .deps src unittest
+mkdir -p .deps unittest
 
 
 AC_MSG_NOTICE(now build ccache by running make)

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -29,7 +29,7 @@ generated_docs = \
     doc/MANUAL.html \
     doc/NEWS.html \
     doc/ccache.1
-built_dist_files = $(generated_docs)
+built_dist_files = $(generated_sources) $(generated_docs)
 
 headers = \
     src/ccache.h \
@@ -48,15 +48,17 @@ headers = \
     src/murmurhashneutral2.h \
     src/system.h \
     unittest/framework.h \
-    unittest/suites.h \
     unittest/util.h
+generated_headers = \
+    unittest/suites.h
 
 files_to_clean += *.tar.bz2 *.tar.gz *.tar.xz *.xml .deps/* perfdir.*
 files_to_distclean += $(built_dist_files) src/version.c unittest/suites.h
 files_to_distclean += .deps dev.mk
 
 source_dist_files = \
-    $(base_sources) \
+    $(non_3pp_sources) \
+    $(3pp_sources) \
     $(headers) \
     $(test_sources) \
     CONTRIBUTING.md \
@@ -115,7 +117,8 @@ $(dist_archives): $(dist_files)
 	(cd $(srcdir) && \
 	 rsync -r --relative $(source_dist_files) $$dir) && \
 	cp $(srcdir)/doc/INSTALL-from-release-archive.md $$dir/INSTALL.md && \
-	cp $(built_dist_files) $$dir && \
+	(cd $(builddir) && \
+	 rsync -r --relative $(built_dist_files) $$dir) && \
 	echo "Remove this file to enable developer mode." >$$dir/dev_mode_disabled && \
 	(cd $$tmpdir && \
 	 tarcompression= && \
@@ -133,29 +136,37 @@ distcheck: $(firstword $(dist_archives))
 	(cd $$tmpdir && \
 	 tar xf $(CURDIR)/$< && \
 	 mkdir -p $(dist_dir)/build && \
+	 chmod -R a-w $(dist_dir) && \
+	 chmod u+w $(dist_dir)/build && \
 	 cd $(dist_dir)/build && \
 	 ../configure --prefix=$$tmpdir/root && \
 	 $(MAKE) install && \
 	 $(MAKE) installcheck) && \
+	 chmod -R u+w $$tmpdir/$(dist_dir) && \
 	rm -rf $$tmpdir
 
 	tmpdir=$$(mktemp -d /tmp/tmp-ccache-distcheck.XXXXXX) && \
 	(cd $$tmpdir && \
 	 tar xf $(CURDIR)/$< && \
 	 mkdir -p $(dist_dir)/build && \
+	 chmod -R a-w $(dist_dir) && \
+	 chmod u+w $(dist_dir)/build && \
 	 cd $(dist_dir)/build && \
 	 ../configure --prefix=$$tmpdir/root --with-bundled-zlib && \
 	 $(MAKE) install && \
 	 $(MAKE) installcheck) && \
+	 chmod -R u+w $$tmpdir/$(dist_dir) && \
 	rm -rf $$tmpdir
 
 .PHONY: docs
 docs: $(generated_docs)
 
 %.html: %.adoc
-	$(ASCIIDOC) -a revnumber=$(version) -a toc -b xhtml11 $<
+	@mkdir -p `dirname $@`
+	$(ASCIIDOC) -o $@ -a revnumber=$(version) -a toc -b xhtml11 $<
 
 %.xml: %.adoc
+	@mkdir -p `dirname $@`
 # Make literals stand out as bold in the man page:
 	$(ASCIIDOC) -a revnumber=$(version) -d manpage -b docbook -o - $< | \
 	  perl -pe 's!<literal>(.*?)</literal>!<emphasis role="strong">\1</emphasis>!g' >$@


### PR DESCRIPTION
Separate (read-only)` $srcdir` and (output) `$builddir`

Still support both developer mode and dist (+check).