### PR TITLE
win32: Remove set_cloexec_flag() from win32 builds

### DIFF
--- a/src/ccache.h
+++ b/src/ccache.h
@@ -193,11 +193,12 @@ int tmp_unlink(const char *path);
 int x_unlink(const char *path);
 #ifndef _WIN32
 char *x_readlink(const char *path);
+void set_cloexec_flag(int fd);
 #endif
 bool read_file(const char *path, size_t size_hint, char **data, size_t *size);
 char *read_text_file(const char *path, size_t size_hint);
 char *subst_env_in_string(const char *str, char **errmsg);
-void set_cloexec_flag(int fd);
+
 
 // ----------------------------------------------------------------------------
 // stats.c

--- a/src/util.c
+++ b/src/util.c
@@ -1183,9 +1183,9 @@ create_tmp_fd(char **fname)
 		fatal("Failed to create temporary file for %s: %s",
 		      *fname, strerror(errno));
 	}
-	set_cloexec_flag(fd);
 
 #ifndef _WIN32
+	set_cloexec_flag(fd);
 	fchmod(fd, 0666 & ~get_umask());
 #endif
 
@@ -1661,13 +1661,13 @@ subst_env_in_string(const char *str, char **errmsg)
 	return result;
 }
 
+#ifndef _WIN32
 void
 set_cloexec_flag(int fd)
 {
-#ifndef _WIN32
 	int flags = fcntl(fd, F_GETFD, 0);
 	if (flags >= 0) {
 		fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
 	}
-#endif
 }
+#endif


### PR DESCRIPTION
The function body was anyhow empty, so there is no point of this function in the win32 builds.