### PR TITLE
direct .i mode: Close stderr file explicitly

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1381,6 +1381,8 @@ get_object_name_from_cpp(struct args *args, struct mdfour *hash)
 		// and directly form the correct i_tmpfile.
 		path_stdout = input_file;
 		status = 0;
+		// in direct .i mode close path_stderr_fd explicitely, as it is not used later
+		close(path_stderr_fd);
 	} else {
 		// Run cpp on the input file to obtain the .i.
 


### PR DESCRIPTION
Previously the stderr file has left open, and only `clean_up_pending_tmp_files()` closed it on exit.

The symptom was that when running test case `"Direct .i compile"` test case failed on MSYS2/MINGW64 when executed `hash_file(hash, path_stderr)`. If I understood well, in direct .i mode the temporary stderr file is not used, and although it has been created it stays empty, and then gets hashed. Unfortunately on windows if file is kept open subsequent `open()` calls will fail. In normal cases (when `direct_i_file` is FALSE), the `execute()` call closes this file.

I was thinking moving the whole `tmp.cpp_stderr` creation to the branch where `direct_i_file` is FALSE, but I was not sure that it is the right solution and seemed like a bigger change. Let me know what you think.