### PR TITLE
win32: Fix CCACHE_COMPILERCHECK=mtime test case

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -115,9 +115,10 @@ win32getshell(char *path)
 void add_exe_ext_if_no_to_fullpath(char *full_path_win_ext, size_t max_size,
                                    const char *ext, const char *path) {
 	if (!ext || (!str_eq(".exe", ext)
-	             && !str_eq(".bat", ext)
-	             && !str_eq(".EXE", ext)
-	             && !str_eq(".BAT", ext))) {
+				&& !str_eq(".sh", ext)
+				&& !str_eq(".bat", ext)
+				&& !str_eq(".EXE", ext)
+				&& !str_eq(".BAT", ext))) {
 		snprintf(full_path_win_ext, max_size, "%s.exe", path);
 	} else {
 		snprintf(full_path_win_ext, max_size, "%s", path);


### PR DESCRIPTION
Previously if compiler command was an .sh script, win32 version automatically added an .EXE extension to the command line and then test case failed. With this change .sh files won't get appended by an EXE extension and test case successfully runs.