### PR TITLE
Print compiler's stderr when compiling with memcached_only=true

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1682,7 +1682,10 @@ to_memcached(struct args *args)
 	}
 
 	// Everything OK.
-	send_cached_stderr();
+	if (stderr_l) {
+		safe_write(2, stderr_d, stderr_l);
+	}
+
 	update_manifest_file();
 
 	free(tmp_stderr);

--- a/test/suites/memcached_only.bash
+++ b/test/suites/memcached_only.bash
@@ -52,4 +52,20 @@ SUITE_memcached_only() {
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 1 # manifest file
     expect_equal_object_files reference_test1.o test1.o
+
+    # -------------------------------------------------------------------------
+    TEST "Compiler's stderr should be printed on cache miss"
+
+    cat <<EOF >test2.c
+int stderr(void)
+{
+  // Trigger warning by having no return statement.
+}
+EOF
+
+    $REAL_COMPILER -c -Wall test2.c 2>reference_test2.stderr
+
+    $CCACHE_COMPILE -c -Wall test2.c 2>test2.stderr
+
+    expect_equal_files reference_test2.stderr test2.stderr
 }


### PR DESCRIPTION
In the memcached_only mode no files are created in the local cache. All
compilation results are stored in memcached backend but the routine
responsible for running a compiler and storing its outputs -
to_memcached - still used send_cached_stderr to present compiler's
stderr to the user. The latter function relied on the existence of
cached stderr in the local cache printing nothing.

The fix is to print the stderr data sent to memcached backend instead.