### PR TITLE
Travis: use wine for mingw unittest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,13 @@ matrix:
                       - gcc-multilib
         - os: linux
           compiler: i686-w64-mingw32-gcc
-          env: HOST="--host=i686-w64-mingw32" TEST="unittest/run.exe"
+          env: HOST="--host=i686-w64-mingw32" TEST=unittest WINE=wineconsole
+          sudo: required
           addons:
               apt:
                   packages:
                       - gcc-mingw-w64-i686
+                      - wine
         - os: linux
           compiler: clang
           env: CFLAGS="-fsanitize=undefined" ASAN_OPTIONS="detect_leaks=0"

--- a/Makefile.in
+++ b/Makefile.in
@@ -125,12 +125,12 @@ perf: ccache$(EXEEXT)
 
 .PHONY: test
 test: ccache$(EXEEXT) unittest/run$(EXEEXT)
-	unittest/run$(EXEEXT)
+	$(WINE) unittest/run$(EXEEXT)
 	CC='$(CC)' $(BASH) $(srcdir)/test/run
 
 .PHONY: unittest
 unittest: unittest/run$(EXEEXT)
-	unittest/run$(EXEEXT)
+	$(WINE) unittest/run$(EXEEXT)
 
 unittest/run$(EXEEXT): $(base_objs) $(test_objs) $(extra_libs)
 	$(CC) $(all_cflags) -o $@ $(base_objs) $(test_objs) $(LDFLAGS) $(extra_libs) $(LIBS)

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -277,7 +277,9 @@ typedef int (*COMPAR_FN_T)(const void *, const void *);
 
 // mkstemp() on some versions of cygwin don't handle binary files, so override.
 #ifdef __CYGWIN__
+#ifndef __MSYS__
 #undef HAVE_MKSTEMP
+#endif
 #endif
 
 #ifdef _WIN32

--- a/src/lockfile.c
+++ b/src/lockfile.c
@@ -40,7 +40,7 @@ lockfile_acquire(const char *path, unsigned staleness_limit)
 		free(my_content);
 		my_content = format("%s:%d:%d", hostname, (int)getpid(), (int)time(NULL));
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 		int fd = open(lockfile, O_WRONLY|O_CREAT|O_EXCL|O_BINARY, 0666);
 		if (fd == -1) {
 			int saved_errno = errno;

--- a/test/run
+++ b/test/run
@@ -289,6 +289,7 @@ COMPILER_USES_MINGW=false
 HOST_OS_APPLE=false
 HOST_OS_LINUX=false
 HOST_OS_WINDOWS=false
+HOST_OS_CYGWIN=false
 
 compiler_version="`$COMPILER --version 2>&1 | head -1`"
 case $compiler_version in
@@ -316,6 +317,9 @@ esac
 case $(uname -s) in
     *MINGW*|*mingw*)
         HOST_OS_WINDOWS=true
+        ;;
+    *CYGWIN*|*MSYS*)
+        HOST_OS_CYGWIN=true
         ;;
     *Darwin*)
         HOST_OS_APPLE=true

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -815,6 +815,7 @@ EOF
     expect_stat 'cache miss' 1
 
     # -------------------------------------------------------------------------
+if ! $HOST_OS_WINDOWS && ! $HOST_OS_CYGWIN; then
     TEST "Symlink to source directory"
 
     mkdir dir
@@ -835,7 +836,9 @@ EOF
         test_failed "Incorrect header file used"
     fi
 
+fi
     # -------------------------------------------------------------------------
+if ! $HOST_OS_WINDOWS && ! $HOST_OS_CYGWIN; then
     TEST "Symlink to source file"
 
     mkdir dir
@@ -856,6 +859,7 @@ EOF
         test_failed "Incorrect header file used"
     fi
 
+fi
     # -------------------------------------------------------------------------
     TEST ".incbin"
 

--- a/test/suites/basedir.bash
+++ b/test/suites/basedir.bash
@@ -4,7 +4,7 @@ SUITE_basedir_SETUP() {
     mkdir -p dir1/src dir1/include
     cat <<EOF >dir1/src/test.c
 #include <stdarg.h>
-#include "test.h"
+#include <test.h>
 EOF
     cat <<EOF >dir1/include/test.h
 int test;

--- a/test/suites/basedir.bash
+++ b/test/suites/basedir.bash
@@ -45,6 +45,7 @@ SUITE_basedir() {
     expect_stat 'cache miss' 2
 
     # -------------------------------------------------------------------------
+ if ! $HOST_OS_WINDOWS && ! $HOST_OS_CYGWIN; then
     TEST "Path normalization"
 
     cd dir1
@@ -64,6 +65,7 @@ SUITE_basedir() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
+ fi
     # -------------------------------------------------------------------------
     TEST "Rewriting in stderr"
 

--- a/test/suites/basedir.bash
+++ b/test/suites/basedir.bash
@@ -4,7 +4,7 @@ SUITE_basedir_SETUP() {
     mkdir -p dir1/src dir1/include
     cat <<EOF >dir1/src/test.c
 #include <stdarg.h>
-#include <test.h>
+#include "test.h"
 EOF
     cat <<EOF >dir1/include/test.h
 int test;

--- a/test/suites/masquerading.bash
+++ b/test/suites/masquerading.bash
@@ -3,6 +3,10 @@ SUITE_masquerading_PROBE() {
     if [ "$(dirname $compiler_binary)" != . ]; then
         echo "compiler ($compiler_binary) not taken from PATH"
     fi
+    if $HOST_OS_WINDOWS || $HOST_OS_CYGWIN; then
+        echo "symlinks not supported on $(uname -s)"
+        return
+    fi
 }
 
 SUITE_masquerading_SETUP() {

--- a/test/suites/upgrade.bash
+++ b/test/suites/upgrade.bash
@@ -1,7 +1,7 @@
 SUITE_upgrade() {
     TEST "Keep maxfiles and maxsize settings"
 
-    rm $CCACHE_CONFIGPATH
+    rm -f $CCACHE_CONFIGPATH
     mkdir -p $CCACHE_DIR/0
     echo "0 0 0 0 0 0 0 0 0 0 0 0 0 2000 131072" >$CCACHE_DIR/0/stats
     expect_stat 'max files' 32000

--- a/unittest/test_lockfile.c
+++ b/unittest/test_lockfile.c
@@ -26,7 +26,7 @@ TEST(acquire_should_create_symlink)
 {
 	lockfile_acquire("test", 1000);
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 	CHECK(path_exists("test.lock"));
 #else
 	CHECK(is_symlink("test.lock"));
@@ -45,7 +45,7 @@ TEST(lock_breaking)
 {
 	char *p;
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 	create_file("test.lock", "foo");
 	create_file("test.lock.lock", "foo");
 #else
@@ -54,7 +54,7 @@ TEST(lock_breaking)
 #endif
 	CHECK(lockfile_acquire("test", 1000));
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 	p = read_text_file("test.lock", 0);
 #else
 	p = x_readlink("test.lock");
@@ -66,7 +66,7 @@ TEST(lock_breaking)
 	free(p);
 }
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 TEST(failed_lock_breaking)
 {
 	create_file("test.lock", "");


### PR DESCRIPTION
Investigate if it would be possible to run the `unittest/run.exe`, using [Wine](https://www.winehq.org/) ?

Goes in after #246 (for Cygwin), most likely there could some additional issues.