### PR TITLE
 Add SASL authentication support for memcached

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -451,6 +451,12 @@ might be incorrect.
 -------------------------------------------------------------------------------
 CCACHE_MEMCACHED_CONF=--SERVER=localhost:11211
 -------------------------------------------------------------------------------
++
+To use SASL authentication with your memcached, set the variables:
+*CCACHE_MEMCACHED_USERNAME* and *CCACHE_MEMCACHED_PASSWORD*.
+Note that this also requires using the binary protocol of memcached.
+See: <https://blog.couchbase.com/sasl-memcached-now-available/>.
+If using Couchbase < 5, use the name of the _bucket_ as the username.
 
 *memcached_only* (*CCACHE_MEMCACHED_ONLY*)::
 

--- a/src/memccached.c
+++ b/src/memccached.c
@@ -120,7 +120,11 @@ static memcached_return_t memccached_big_set(memcached_st *ptr,
 			ptr, s, strlen(s), value + x, n, expiration, flags);
 		free(s);
 		if (ret) {
+#if LIBMEMCACHED_VERSION_HEX >= 0x01000017
+			const memcached_instance_st *instance;
+#else
 			memcached_server_instance_st instance;
+#endif
 
 			instance = memcached_server_instance_by_position(memc, 0);
 			cc_log("%s %s", memcached_last_error_message(memc),

--- a/src/memccached.c
+++ b/src/memccached.c
@@ -35,6 +35,10 @@ static memcached_st *memc;
 
 int memccached_init(char *conf)
 {
+	const char *username = getenv("CCACHE_MEMCACHED_USERNAME"); /* Note: bucket */
+	const char *password = getenv("CCACHE_MEMCACHED_PASSWORD"); /* Note: unsafe */
+	memcached_return_t ret;
+
 	memc = memcached(conf, strlen(conf));
 	if (!memc) {
 		char errorbuf[1024];
@@ -46,6 +50,20 @@ int memccached_init(char *conf)
 	// added to the cluster with minimal cache losses.
 	memcached_behavior_set(memc, MEMCACHED_BEHAVIOR_DISTRIBUTION,
 	                       MEMCACHED_DISTRIBUTION_CONSISTENT);
+	if (username && password) {
+		/* the username to use for couchbase is the name of the bucket */
+		ret = memcached_set_sasl_auth_data(memc, username, password);
+		if (memcached_failed(ret)) {
+			if (ret == MEMCACHED_NOT_SUPPORTED) {
+				cc_log("Unsupported SASL authentication");
+			} else {
+				cc_log("%s", memcached_last_error_message(memc));
+			}
+			return -1;
+		}
+		/* SASL authentication requires the binary protocol (not ascii) */
+		memcached_behavior_set(memc, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL, true);
+	}
 	return 0;
 }
 
@@ -102,6 +120,11 @@ static memcached_return_t memccached_big_set(memcached_st *ptr,
 			ptr, s, strlen(s), value + x, n, expiration, flags);
 		free(s);
 		if (ret) {
+			const memcached_instance_st * instance;
+
+			instance = memcached_server_instance_by_position(memc, 0);
+			cc_log("%s %s", memcached_last_error_message(memc),
+			                memcached_server_error(instance));
 			cc_log("Failed to set key in memcached: %s",
 			       memcached_strerror(memc, ret));
 			return ret;

--- a/src/memccached.c
+++ b/src/memccached.c
@@ -120,7 +120,7 @@ static memcached_return_t memccached_big_set(memcached_st *ptr,
 			ptr, s, strlen(s), value + x, n, expiration, flags);
 		free(s);
 		if (ret) {
-			const memcached_instance_st * instance;
+			memcached_server_instance_st instance;
 
 			instance = memcached_server_instance_by_position(memc, 0);
 			cc_log("%s %s", memcached_last_error_message(memc),


### PR DESCRIPTION
Using couchbase for the memcached storage now _requires_ using SASL authentication:

* https://blog.couchbase.com/sasl-memcached-now-available/

* https://developer.couchbase.com/documentation/server/5.0/security/security-bucket-protection.html

Also add some docs and better error diagnostics, when we cannot connect to a server.