### PR TITLE
Add configure option to disable man pages

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -101,11 +101,11 @@ ccache.1: doc/ccache.1
 	cp $< $@
 
 .PHONY: install
-install: ccache$(EXEEXT) ccache.1
+install: ccache$(EXEEXT) @disable_man@ccache.1
 	$(installcmd) -d $(DESTDIR)$(bindir)
 	$(installcmd) -m 755 ccache$(EXEEXT) $(DESTDIR)$(bindir)
-	$(installcmd) -d $(DESTDIR)$(mandir)/man1
-	-$(installcmd) -m 644 ccache.1 $(DESTDIR)$(mandir)/man1/
+@disable_man@	$(installcmd) -d $(DESTDIR)$(mandir)/man1
+@disable_man@	-$(installcmd) -m 644 ccache.1 $(DESTDIR)$(mandir)/man1/
 
 .PHONY: clean
 clean:

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ esac
 AC_SUBST(extra_libs)
 AC_SUBST(include_dev_mk)
 AC_SUBST(test_suites)
+AC_SUBST(disable_man)
 
 m4_include(m4/feature_macros.m4)
 
@@ -124,6 +125,13 @@ if test x${use_bundled_zlib} = xyes; then
     mkdir -p src/zlib
 else
     LIBS="$LIBS -lz"
+fi
+
+AC_ARG_ENABLE(man,
+  [AS_HELP_STRING([--disable-man],
+    [disable installing man pages])])
+if test x${enable_man} = xno; then
+    disable_man='#'
 fi
 
 dnl Linking on Windows needs ws2_32


### PR DESCRIPTION
Building the man page requires asciidoc, if building from the source
repository. Add option to only install the program, but not the man.

When building from the release tarball, the man page is already built.
So we can still default to installing it, and requiring asciidoc/a2x.

Closes #264