### PR TITLE
Add a `-k/--get-config` option to print the value of a configuration key

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -66,6 +66,7 @@ static const char USAGE_TEXT[] =
 	"    -C, --clear           clear the cache completely (except configuration)\n"
 	"    -F, --max-files=N     set maximum number of files in cache to N (use 0 for\n"
 	"                          no limit)\n"
+        "    -k, --get-config=K    get the value of the configuration key K\n"
 	"    -M, --max-size=SIZE   set maximum size of cache to SIZE (use 0 for no\n"
 	"                          limit); available suffixes: k, M, G, T (decimal) and\n"
 	"                          Ki, Mi, Gi, Ti (binary); default suffix: G\n"
@@ -3544,6 +3545,7 @@ ccache_main_options(int argc, char *argv[])
 		{"cleanup",       no_argument,       0, 'c'},
 		{"clear",         no_argument,       0, 'C'},
 		{"dump-manifest", required_argument, 0, DUMP_MANIFEST},
+		{"get-config",    required_argument, 0, 'k'},
 		{"hash-file",     required_argument, 0, HASH_FILE},
 		{"help",          no_argument,       0, 'h'},
 		{"max-files",     required_argument, 0, 'F'},
@@ -3557,7 +3559,8 @@ ccache_main_options(int argc, char *argv[])
 	};
 
 	int c;
-	while ((c = getopt_long(argc, argv, "cChF:M:o:psVz", options, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "cCk:hF:M:o:psVz", options, NULL))
+               != -1) {
 		switch (c) {
 		case DUMP_MANIFEST:
 			manifest_dump(optarg, stdout);
@@ -3594,6 +3597,16 @@ ccache_main_options(int argc, char *argv[])
 		case 'h': // --help
 			fputs(USAGE_TEXT, stdout);
 			x_exit(0);
+
+		case 'k': // --get-config
+		{
+			initialize();
+			char *errmsg;
+			if (!conf_print_value(conf, optarg, stdout, &errmsg)) {
+				fatal("%s", errmsg);
+			}
+		}
+		break;
 
 		case 'F': // --max-files
 		{

--- a/src/conf.c
+++ b/src/conf.c
@@ -629,161 +629,65 @@ conf_set_value_in_file(const char *path, const char *key, const char *value,
 	return true;
 }
 
+static bool
+print_item(struct conf *conf, const char *key,
+           void (*printer)(const char *descr, const char *origin,
+                           void *context),
+           void *context)
+{
+	const struct conf_item *item = find_conf(key);
+	if (!item) {
+		return false;
+	}
+	void *value = (char *)conf + item->offset;
+	char *str = (char *)item->formatter(value);
+	char *buf = x_strdup("");
+	reformat(&buf, "%s = %s", key, str);
+	printer(buf, conf->item_origins[item->number], context);
+	free(buf);
+	free(str);
+	return true;
+}
+
 bool
 conf_print_items(struct conf *conf,
                  void (*printer)(const char *descr, const char *origin,
                                  void *context),
                  void *context)
 {
-	char *s = x_strdup("");
-
-	reformat(&s, "base_dir = %s", conf->base_dir);
-	printer(s, conf->item_origins[find_conf("base_dir")->number], context);
-
-	reformat(&s, "cache_dir = %s", conf->cache_dir);
-	printer(s, conf->item_origins[find_conf("cache_dir")->number], context);
-
-	reformat(&s, "cache_dir_levels = %u", conf->cache_dir_levels);
-	printer(s, conf->item_origins[find_conf("cache_dir_levels")->number],
-	        context);
-
-	reformat(&s, "compiler = %s", conf->compiler);
-	printer(s, conf->item_origins[find_conf("compiler")->number], context);
-
-	reformat(&s, "compiler_check = %s", conf->compiler_check);
-	printer(s, conf->item_origins[find_conf("compiler_check")->number], context);
-
-	reformat(&s, "compression = %s", bool_to_string(conf->compression));
-	printer(s, conf->item_origins[find_conf("compression")->number], context);
-
-	reformat(&s, "compression_level = %u", conf->compression_level);
-	printer(s, conf->item_origins[find_conf("compression_level")->number],
-	        context);
-
-	reformat(&s, "cpp_extension = %s", conf->cpp_extension);
-	printer(s, conf->item_origins[find_conf("cpp_extension")->number], context);
-
-	reformat(&s, "debug = %s", bool_to_string(conf->debug));
-	printer(s, conf->item_origins[find_conf("debug")->number], context);
-
-	reformat(&s, "direct_mode = %s", bool_to_string(conf->direct_mode));
-	printer(s, conf->item_origins[find_conf("direct_mode")->number], context);
-
-	reformat(&s, "disable = %s", bool_to_string(conf->disable));
-	printer(s, conf->item_origins[find_conf("disable")->number], context);
-
-	reformat(&s, "extra_files_to_hash = %s", conf->extra_files_to_hash);
-	printer(s, conf->item_origins[find_conf("extra_files_to_hash")->number],
-	        context);
-
-	reformat(&s, "hard_link = %s", bool_to_string(conf->hard_link));
-	printer(s, conf->item_origins[find_conf("hard_link")->number], context);
-
-	reformat(&s, "hash_dir = %s", bool_to_string(conf->hash_dir));
-	printer(s, conf->item_origins[find_conf("hash_dir")->number], context);
-
-	reformat(&s, "ignore_headers_in_manifest = %s",
-	         conf->ignore_headers_in_manifest);
-	printer(s,
-	        conf->item_origins[find_conf("ignore_headers_in_manifest")->number],
-	        context);
-
-	reformat(&s, "keep_comments_cpp = %s",
-	         bool_to_string(conf->keep_comments_cpp));
-	printer(s,
-	        conf->item_origins[find_conf("keep_comments_cpp")->number],
-	        context);
-
-	reformat(&s, "limit_multiple = %.1f", (double)conf->limit_multiple);
-	printer(s, conf->item_origins[find_conf("limit_multiple")->number], context);
-
-	reformat(&s, "log_file = %s", conf->log_file);
-	printer(s, conf->item_origins[find_conf("log_file")->number], context);
-
-	reformat(&s, "max_files = %u", conf->max_files);
-	printer(s, conf->item_origins[find_conf("max_files")->number], context);
-
-	char *s2 = format_parsable_size_with_suffix(conf->max_size);
-	reformat(&s, "max_size = %s", s2);
-	printer(s, conf->item_origins[find_conf("max_size")->number], context);
-	free(s2);
-
-	reformat(&s, "path = %s", conf->path);
-	printer(s, conf->item_origins[find_conf("path")->number], context);
-
-	reformat(&s, "pch_external_checksum = %s",
-	         bool_to_string(conf->pch_external_checksum));
-	printer(s, conf->item_origins[find_conf("pch_external_checksum")->number],
-	        context);
-
-	reformat(&s, "prefix_command = %s", conf->prefix_command);
-	printer(s, conf->item_origins[find_conf("prefix_command")->number], context);
-
-	reformat(&s, "prefix_command_cpp = %s", conf->prefix_command_cpp);
-	printer(s,
-	        conf->item_origins[find_conf("prefix_command_cpp")->number],
-	        context);
-
-	reformat(&s, "read_only = %s", bool_to_string(conf->read_only));
-	printer(s, conf->item_origins[find_conf("read_only")->number], context);
-
-	reformat(&s, "read_only_direct = %s", bool_to_string(conf->read_only_direct));
-	printer(s, conf->item_origins[find_conf("read_only_direct")->number],
-	        context);
-
-	reformat(&s, "recache = %s", bool_to_string(conf->recache));
-	printer(s, conf->item_origins[find_conf("recache")->number], context);
-
-	reformat(&s, "run_second_cpp = %s", bool_to_string(conf->run_second_cpp));
-	printer(s, conf->item_origins[find_conf("run_second_cpp")->number], context);
-
-	reformat(&s, "sloppiness = ");
-	if (conf->sloppiness & SLOPPY_FILE_MACRO) {
-		reformat(&s, "%sfile_macro, ", s);
-	}
-	if (conf->sloppiness & SLOPPY_INCLUDE_FILE_MTIME) {
-		reformat(&s, "%sinclude_file_mtime, ", s);
-	}
-	if (conf->sloppiness & SLOPPY_INCLUDE_FILE_CTIME) {
-		reformat(&s, "%sinclude_file_ctime, ", s);
-	}
-	if (conf->sloppiness & SLOPPY_TIME_MACROS) {
-		reformat(&s, "%stime_macros, ", s);
-	}
-	if (conf->sloppiness & SLOPPY_PCH_DEFINES) {
-		reformat(&s, "%spch_defines, ", s);
-	}
-	if (conf->sloppiness & SLOPPY_FILE_STAT_MATCHES) {
-		reformat(&s, "%sfile_stat_matches, ", s);
-	}
-	if (conf->sloppiness & SLOPPY_FILE_STAT_MATCHES_CTIME) {
-		reformat(&s, "%sfile_stat_matches_ctime, ", s);
-	}
-	if (conf->sloppiness & SLOPPY_NO_SYSTEM_HEADERS) {
-		reformat(&s, "%sno_system_headers, ", s);
-	}
-	if (conf->sloppiness) {
-		// Strip last ", ".
-		s[strlen(s) - 2] = '\0';
-	}
-	printer(s, conf->item_origins[find_conf("sloppiness")->number], context);
-
-	reformat(&s, "stats = %s", bool_to_string(conf->stats));
-	printer(s, conf->item_origins[find_conf("stats")->number], context);
-
-	reformat(&s, "temporary_dir = %s", conf->temporary_dir);
-	printer(s, conf->item_origins[find_conf("temporary_dir")->number], context);
-
-	if (conf->umask == UINT_MAX) {
-		reformat(&s, "umask = ");
-	} else {
-		reformat(&s, "umask = %03o", conf->umask);
-	}
-	printer(s, conf->item_origins[find_conf("umask")->number], context);
-
-	reformat(&s, "unify = %s", bool_to_string(conf->unify));
-	printer(s, conf->item_origins[find_conf("unify")->number], context);
-
-	free(s);
-	return true;
+	bool ok = true;
+	ok &= print_item(conf, "base_dir", printer, context);
+	ok &= print_item(conf, "cache_dir", printer, context);
+	ok &= print_item(conf, "cache_dir_levels", printer, context);
+	ok &= print_item(conf, "compiler", printer, context);
+	ok &= print_item(conf, "compiler_check", printer, context);
+	ok &= print_item(conf, "compression", printer, context);
+	ok &= print_item(conf, "compression_level", printer, context);
+	ok &= print_item(conf, "cpp_extension", printer, context);
+	ok &= print_item(conf, "debug", printer, context);
+	ok &= print_item(conf, "direct_mode", printer, context);
+	ok &= print_item(conf, "disable", printer, context);
+	ok &= print_item(conf, "extra_files_to_hash", printer, context);
+	ok &= print_item(conf, "hard_link", printer, context);
+	ok &= print_item(conf, "hash_dir", printer, context);
+	ok &= print_item(conf, "ignore_headers_in_manifest", printer, context);
+	ok &= print_item(conf, "keep_comments_cpp", printer, context);
+	ok &= print_item(conf, "limit_multiple", printer, context);
+	ok &= print_item(conf, "log_file", printer, context);
+	ok &= print_item(conf, "max_files", printer, context);
+	ok &= print_item(conf, "max_size", printer, context);
+	ok &= print_item(conf, "path", printer, context);
+	ok &= print_item(conf, "pch_external_checksum", printer, context);
+	ok &= print_item(conf, "prefix_command", printer, context);
+	ok &= print_item(conf, "prefix_command_cpp", printer, context);
+	ok &= print_item(conf, "read_only", printer, context);
+	ok &= print_item(conf, "read_only_direct", printer, context);
+	ok &= print_item(conf, "recache", printer, context);
+	ok &= print_item(conf, "run_second_cpp", printer, context);
+	ok &= print_item(conf, "sloppiness", printer, context);
+	ok &= print_item(conf, "stats", printer, context);
+	ok &= print_item(conf, "temporary_dir", printer, context);
+	ok &= print_item(conf, "umask", printer, context);
+	ok &= print_item(conf, "unify", printer, context);
+	return ok;
 }

--- a/src/conf.c
+++ b/src/conf.c
@@ -629,6 +629,22 @@ conf_set_value_in_file(const char *path, const char *key, const char *value,
 	return true;
 }
 
+bool
+conf_print_value(struct conf *conf, const char *key,
+                 FILE *file, char **errmsg)
+{
+	const struct conf_item *item = find_conf(key);
+	if (!item) {
+		*errmsg = format("unknown configuration option \"%s\"", key);
+		return false;
+	}
+	void *value = (char *)conf + item->offset;
+	char *str = (char *)item->formatter(value);
+	fprintf(file, "%s\n", str);
+	free(str);
+	return true;
+}
+
 static bool
 print_item(struct conf *conf, const char *key,
            void (*printer)(const char *descr, const char *origin,

--- a/src/conf.h
+++ b/src/conf.h
@@ -45,6 +45,8 @@ struct conf *conf_create(void);
 void conf_free(struct conf *conf);
 bool conf_read(struct conf *conf, const char *path, char **errmsg);
 bool conf_update_from_environment(struct conf *conf, char **errmsg);
+bool conf_print_value(struct conf *conf, const char *key,
+                      FILE *file, char **errmsg);
 bool conf_set_value_in_file(const char *path, const char *key,
                             const char *value, char **errmsg);
 bool conf_print_items(struct conf *conf,

--- a/src/confitems.gperf
+++ b/src/confitems.gperf
@@ -4,7 +4,7 @@
 %readonly-tables
 %define hash-function-name confitems_hash
 %define lookup-function-name confitems_get
-%define initializer-suffix ,0,NULL,0,NULL
+%define initializer-suffix ,0,NULL,0,NULL,NULL
 struct conf_item;
 %%
 base_dir,             0, ITEM_V(base_dir, env_string, absolute_path)

--- a/src/confitems_lookup.c
+++ b/src/confitems_lookup.c
@@ -96,20 +96,20 @@ confitems_get (register const char *str, register unsigned int len)
 
   static const struct conf_item wordlist[] =
     {
-      {"",0,NULL,0,NULL}, {"",0,NULL,0,NULL},
-      {"",0,NULL,0,NULL}, {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL}, {"",0,NULL,0,NULL,NULL},
+      {"",0,NULL,0,NULL,NULL}, {"",0,NULL,0,NULL,NULL},
 #line 30 "src/confitems.gperf"
       {"path",                20, ITEM(path, env_string)},
-      {"",0,NULL,0,NULL}, {"",0,NULL,0,NULL},
-      {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL}, {"",0,NULL,0,NULL,NULL},
+      {"",0,NULL,0,NULL,NULL},
 #line 13 "src/confitems.gperf"
       {"compiler",             3, ITEM(compiler, string)},
 #line 11 "src/confitems.gperf"
       {"cache_dir",            1, ITEM(cache_dir, env_string)},
-      {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL},
 #line 15 "src/confitems.gperf"
       {"compression",          5, ITEM(compression, bool)},
-      {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL},
 #line 17 "src/confitems.gperf"
       {"cpp_extension",        7, ITEM(cpp_extension, string)},
 #line 14 "src/confitems.gperf"
@@ -136,7 +136,7 @@ confitems_get (register const char *str, register unsigned int len)
       {"read_only",           24, ITEM(read_only, bool)},
 #line 38 "src/confitems.gperf"
       {"sloppiness",          28, ITEM(sloppiness, sloppiness)},
-      {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL},
 #line 25 "src/confitems.gperf"
       {"keep_comments_cpp",   15, ITEM(keep_comments_cpp, bool)},
 #line 29 "src/confitems.gperf"
@@ -153,26 +153,26 @@ confitems_get (register const char *str, register unsigned int len)
       {"temporary_dir",       30, ITEM(temporary_dir, env_string)},
 #line 37 "src/confitems.gperf"
       {"run_second_cpp",      27, ITEM(run_second_cpp, bool)},
-      {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL},
 #line 19 "src/confitems.gperf"
       {"direct_mode",          9, ITEM(direct_mode, bool)},
-      {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL},
 #line 23 "src/confitems.gperf"
       {"hash_dir",            13, ITEM(hash_dir, bool)},
 #line 22 "src/confitems.gperf"
       {"hard_link",           12, ITEM(hard_link, bool)},
 #line 41 "src/confitems.gperf"
       {"umask",               31, ITEM(umask, umask)},
-      {"",0,NULL,0,NULL}, {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL}, {"",0,NULL,0,NULL,NULL},
 #line 10 "src/confitems.gperf"
       {"base_dir",             0, ITEM_V(base_dir, env_string, absolute_path)},
 #line 21 "src/confitems.gperf"
       {"extra_files_to_hash", 11, ITEM(extra_files_to_hash, env_string)},
-      {"",0,NULL,0,NULL}, {"",0,NULL,0,NULL},
-      {"",0,NULL,0,NULL}, {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL}, {"",0,NULL,0,NULL,NULL},
+      {"",0,NULL,0,NULL,NULL}, {"",0,NULL,0,NULL,NULL},
 #line 26 "src/confitems.gperf"
       {"limit_multiple",      16, ITEM(limit_multiple, float)},
-      {"",0,NULL,0,NULL},
+      {"",0,NULL,0,NULL,NULL},
 #line 24 "src/confitems.gperf"
       {"ignore_headers_in_manifest", 14, ITEM(ignore_headers_in_manifest, env_string)}
     };

--- a/unittest/test_conf.c
+++ b/unittest/test_conf.c
@@ -383,6 +383,50 @@ TEST(conf_set_existing_value)
 	CHECK_STR_EQ_FREE2("path = vanilla\nstats = chocolate\n", data);
 }
 
+TEST(conf_print_existing_value)
+{
+	struct conf *conf = conf_create();
+	conf->max_files = 42;
+	char *errmsg;
+	{
+		FILE *log = fopen("log", "w");
+		CHECK(log);
+		CHECK(conf_print_value(conf, "max_files", log, &errmsg));
+		fclose(log);
+	}
+	{
+		FILE *log = fopen("log", "r");
+		CHECK(log);
+		char buf[100];
+		CHECK(fgets(buf, 100, log));
+		CHECK_STR_EQ("42\n", buf);
+		fclose(log);
+	}
+	conf_free(conf);
+}
+
+TEST(conf_print_unknown_value)
+{
+	struct conf *conf = conf_create();
+	char *errmsg;
+	{
+		FILE *log = fopen("log", "w");
+		CHECK(log);
+		CHECK(!conf_print_value(conf, "foo", log, &errmsg));
+		CHECK_STR_EQ_FREE2("unknown configuration option \"foo\"",
+				   errmsg);
+		fclose(log);
+	}
+	{
+		FILE *log = fopen("log", "r");
+		CHECK(log);
+		char buf[100];
+		CHECK(!fgets(buf, 100, log));
+		fclose(log);
+	}
+	conf_free(conf);
+}
+
 TEST(conf_print_items)
 {
 	size_t i;


### PR DESCRIPTION
For a scripting application I needed to get the `cache_dir` value; this can be grepped from `--print-config` but it is fairly inconvenient. This PR adds a `-k KEY` or `--get-config=KEY` option that prints the value of a given configuration key (and a newline). The origin or the key are not printed.

To do this I had to add a field printer to the `confitem` struct, following the general structure of the per-type parsing functions. See individual commit messages for details.