### PR TITLE
test: Fix various Solaris shell issues

### DIFF
--- a/test/run
+++ b/test/run
@@ -267,7 +267,7 @@ fi
 HOST_CCACHE_DIRS="/usr/lib/ccache/bin
 /usr/lib/ccache"
 for HOST_CCACHE_DIR in $HOST_CCACHE_DIRS; do
-    PATH=$(echo -n $PATH | awk -v RS=: -v ORS=: '$0 != "'$HOST_CCACHE_DIR'"' | sed 's/:$//')
+    PATH="$(echo "$PATH:" | awk -v RS=: -v ORS=: '$0 != "'$HOST_CCACHE_DIR'"' | sed 's/:*$//')"
 done
 export PATH
 

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -495,7 +495,8 @@ EOF
 
     cat >compiler.sh <<EOF
 #!/bin/sh
-export CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+export CCACHE_DISABLE
 exec $COMPILER "\$@"
 # A comment
 EOF
@@ -523,7 +524,8 @@ EOF
 
     cat >compiler.sh <<EOF
 #!/bin/sh
-export CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+export CCACHE_DISABLE
 exec $COMPILER "\$@"
 EOF
     chmod +x compiler.sh
@@ -546,7 +548,8 @@ EOF
 
     cat >compiler.sh <<EOF
 #!/bin/sh
-export CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+export CCACHE_DISABLE
 exec $COMPILER "\$@"
 EOF
     chmod +x compiler.sh
@@ -569,7 +572,8 @@ EOF
 
     cat >compiler.sh <<EOF
 #!/bin/sh
-export CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+export CCACHE_DISABLE
 exec $COMPILER "\$@"
 EOF
     chmod +x compiler.sh
@@ -595,7 +599,8 @@ EOF
 
     cat >compiler.sh <<EOF
 #!/bin/sh
-export CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+export CCACHE_DISABLE
 exec $COMPILER "\$@"
 EOF
     chmod +x compiler.sh
@@ -628,7 +633,8 @@ EOF
 
     cat >compiler.sh <<EOF
 #!/bin/sh
-export CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+export CCACHE_DISABLE
 exec $COMPILER "\$@"
 EOF
     chmod +x compiler.sh
@@ -787,7 +793,8 @@ EOF
 
     cat >buggy-cpp <<EOF
 #!/bin/sh
-export CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+CCACHE_DISABLE=1 # If $COMPILER happens to be a ccache symlink...
+export CCACHE_DISABLE
 if echo "\$*" | grep -- -D >/dev/null; then
   $COMPILER "\$@"
 else

--- a/test/suites/cpp1.bash
+++ b/test/suites/cpp1.bash
@@ -33,7 +33,7 @@ SUITE_cpp1() {
     elif $COMPILER_TYPE_CLANG; then
         cpp_flag="-frewrite-includes"
     fi
-    cpp_flag+=" -DBAZ=3"
+    cpp_flag="$cpp_flag -DBAZ=3"
 
     # -------------------------------------------------------------------------
     TEST "Base case"

--- a/test/suites/direct.bash
+++ b/test/suites/direct.bash
@@ -448,7 +448,7 @@ EOF
     expect_stat 'cache miss' 1
     expect_equal_files test.d expected.d
 
-    find $CCACHE_DIR -name '*.d' -delete
+    find $CCACHE_DIR -name '*.d' -exec rm '{}' +
 
     # Missing file -> consider the cached result broken.
     $CCACHE_COMPILE -c -MD test.c


### PR DESCRIPTION
Change `sh` to `bash`, use `find` with `-exec rm`, and avoid `+=` on strings. These are issues which require source changes, unlike the [missing -D_XPG6 flag](https://github.com/ccache/ccache/issues/148) or the missing `seq` binary.