### PR TITLE
Add support for running ShellCheck on the test suites

### DIFF
--- a/dev.mk.in
+++ b/dev.mk.in
@@ -7,6 +7,8 @@ A2X = a2x
 ASCIIDOC = asciidoc
 CPPCHECK = cppcheck
 CPPCHECK_SUPPRESSIONS = misc/cppcheck-suppressions.txt
+SHELLCHECK = shellcheck
+SHELLCHECK_EXCLUDES = misc/shellcheck-excludes.txt
 SCAN_BUILD = scan-build
 DOCKER = docker
 GPERF = gperf
@@ -190,6 +192,10 @@ cppcheck:
 	$(CPPCHECK) --suppressions-list=$(CPPCHECK_SUPPRESSIONS) \
 	  --inline-suppr -q --enable=all --force \
 	  $(non_3pp_sources) src/main.c $(test_sources)
+
+.PHONY: shellcheck
+shellcheck: test/suites/*.bash
+	$(SHELLCHECK) --shell=bash --exclude=$(shell sed -e 's/:.*//' <$(SHELLCHECK_EXCLUDES) | grep -v '#' | tr '\n' ',' | sed -e 's/,$$//') $^
 
 .PHONY: uncrustify
 uncrustify:

--- a/misc/shellcheck-excludes.txt
+++ b/misc/shellcheck-excludes.txt
@@ -4,7 +4,5 @@ SC2001: See if you can use ${variable//search/replace} instead.
 SC2006: Use $(..) instead of legacy `..`.
 SC2046: Quote this to prevent word splitting.
 SC2086: Double quote to prevent globbing and word splitting.
-SC2094: Make sure not to read and write the same file in the same pipeline.
 SC2103: Consider using ( subshell ), 'cd foo||exit', or pushd/popd instead.
-SC2155: Declare and assign separately to avoid masking return values.
 SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects.

--- a/misc/shellcheck-excludes.txt
+++ b/misc/shellcheck-excludes.txt
@@ -1,0 +1,10 @@
+SC2148: Tips depend on target shell and yours is unknown. Add a shebang.
+#  the below excludes are (mostly) about bourne shell and style issues
+SC2001: See if you can use ${variable//search/replace} instead.
+SC2006: Use $(..) instead of legacy `..`.
+SC2046: Quote this to prevent word splitting.
+SC2086: Double quote to prevent globbing and word splitting.
+SC2094: Make sure not to read and write the same file in the same pipeline.
+SC2103: Consider using ( subshell ), 'cd foo||exit', or pushd/popd instead.
+SC2155: Declare and assign separately to avoid masking return values.
+SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects.

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -298,8 +298,8 @@ base_tests() {
     # -------------------------------------------------------------------------
     TEST "CCACHE_EXTRAFILES"
 
-    echo a >a
-    echo b >b
+    echo "a" >a
+    echo "b" >b
 
     $CCACHE_COMPILE -c test1.c
     expect_stat 'cache hit (preprocessed)' 0

--- a/test/suites/hardlink.bash
+++ b/test/suites/hardlink.bash
@@ -25,7 +25,8 @@ SUITE_hardlink() {
     expect_stat 'files in cache' 1
     expect_equal_object_files reference_test1.o test1.o
 
-    local obj_in_cache=$(find $CCACHE_DIR -name '*.o')
+    local obj_in_cache
+    obj_in_cache=$(find $CCACHE_DIR -name '*.o')
     if [ ! $obj_in_cache -ef test1.o ]; then
         test_failed "Object file not hard-linked to cached object file"
     fi

--- a/test/suites/masquerading.bash
+++ b/test/suites/masquerading.bash
@@ -1,13 +1,16 @@
 SUITE_masquerading_PROBE() {
-    local compiler_binary=$(echo $COMPILER | cut -d' ' -f1)
+    local compiler_binary
+    compiler_binary=$(echo $COMPILER | cut -d' ' -f1)
     if [ "$(dirname $compiler_binary)" != . ]; then
         echo "compiler ($compiler_binary) not taken from PATH"
     fi
 }
 
 SUITE_masquerading_SETUP() {
-    local compiler_binary=$(echo $COMPILER | cut -d' ' -f1)
-    local compiler_args=$(echo $COMPILER | cut -s -d' ' -f2-)
+    local compiler_binary
+    compiler_binary=$(echo $COMPILER | cut -d' ' -f1)
+    local compiler_args
+    compiler_args=$(echo $COMPILER | cut -s -d' ' -f2-)
 
     ln -s "$CCACHE" $compiler_binary
     CCACHE_COMPILE="./$compiler_binary $compiler_args"


### PR DESCRIPTION
See: https://www.shellcheck.net/

I left some of the issues excluded, mostly involving "legacy" (sh) and whitespace issues...

You can comment the excludes out, to see what it is complaining about. Ditto for test/run.

``` console
$ shellcheck test/run | grep -c ^In
54
```