### PR TITLE
Fix compiling and testing on FreeBSD

### DIFF
--- a/m4/feature_macros.m4
+++ b/m4/feature_macros.m4
@@ -120,7 +120,7 @@ then
                 Define to the level of X/Open that your system supports)
       ;;
     *)
-      AC_DEFINE(_XOPEN_SOURCE, 600,
+      AC_DEFINE(_XOPEN_SOURCE, 700,
                 Define to the level of X/Open that your system supports)
       ;;
   esac
@@ -142,6 +142,6 @@ then
       ;;
   esac
 
-  AC_DEFINE(_POSIX_C_SOURCE, 200112L, Define to activate features from IEEE Stds 1003.1-2001)
+  AC_DEFINE(_POSIX_C_SOURCE, 200809L, Define to activate features from IEEE Stds 1003.1-2001)
 
 fi

--- a/misc/freebsd/README
+++ b/misc/freebsd/README
@@ -1,0 +1,12 @@
+How to use Vagrant to test ccache on FreeBSD
+============================================
+
+vagrant up
+vagrant ssh
+
+vagrant@freebsd:~ % git clone https://github.com/ccache/ccache.git
+vagrant@freebsd:~ % cd ccache
+vagrant@freebsd:~/ccache % ./autogen.sh
+vagrant@freebsd:~/ccache % ./configure
+vagrant@freebsd:~/ccache % gmake
+vagrant@freebsd:~/ccache % gmake test

--- a/misc/freebsd/Vagrantfile
+++ b/misc/freebsd/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.guest = :freebsd
+  config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+  config.vm.box = "freebsd/FreeBSD-12.0-CURRENT"
+  config.ssh.shell = "sh"
+  config.vm.base_mac = "080027D14C66"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--cpus", "1"]
+    vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
+    vb.customize ["modifyvm", :id, "--audio", "none"]
+    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+    vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    pkg install -y git gmake bash autoconf
+  SHELL
+end

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1710,7 +1710,7 @@ calculate_object_hash(struct args *args, struct mdfour *hash, int direct_mode)
 
 	// clang will emit warnings for unused linker flags, so we shouldn't skip
 	// those arguments.
-	int is_clang = guessed_compiler == GUESSED_CLANG;
+	int is_clang = (guessed_compiler == GUESSED_CLANG || guessed_compiler == GUESSED_UNKNOWN);
 
 	// First the arguments.
 	for (int i = 1; i < args->argc; i++) {
@@ -1968,7 +1968,7 @@ from_cache(enum fromcache_call_mode mode, bool put_object_in_manifest)
 	//
 	//     file 'foo.h' has been modified since the precompiled header 'foo.pch'
 	//     was built
-	if (guessed_compiler == GUESSED_CLANG
+	if ((guessed_compiler == GUESSED_CLANG || guessed_compiler == GUESSED_UNKNOWN)
 	    && output_is_precompiled_header
 	    && mode == FROMCACHE_CPP_MODE) {
 		cc_log("Not considering cached precompiled header in preprocessor mode");

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -383,7 +383,7 @@ verify_object(struct conf *conf, struct manifest *mf, struct object *obj,
 
 		// Clang stores the mtime of the included files in the precompiled header,
 		// and will error out if that header is later used without rebuilding.
-		if (guessed_compiler == GUESSED_CLANG
+		if ((guessed_compiler == GUESSED_CLANG || guessed_compiler == GUESSED_UNKNOWN)
 		    && output_is_precompiled_header
 		    && fi->mtime != st->mtime) {
 			cc_log("Precompiled header includes %s, which has a new mtime", path);

--- a/test/run
+++ b/test/run
@@ -158,6 +158,11 @@ expect_equal_object_files() {
             test_failed "Please install elfutils to get eu-elfcmp"
         fi
         eu-elfcmp -q "$1" "$2"
+    elif $HOST_OS_FREEBSD && $COMPILER_TYPE_CLANG; then
+        elfdump -a -w "$1".dump "$1"
+        elfdump -a -w "$2".dump "$2"
+        # these were the elfdump fields that seemed to differ (empirically)
+        diff -I e_shoff -I sh_size -I st_name "$1".dump "$2".dump > /dev/null
     else
         cmp -s "$1" "$2"
     fi
@@ -288,6 +293,7 @@ COMPILER_USES_MINGW=false
 
 HOST_OS_APPLE=false
 HOST_OS_LINUX=false
+HOST_OS_FREEBSD=false
 HOST_OS_WINDOWS=false
 
 compiler_version="`$COMPILER --version 2>&1 | head -1`"
@@ -322,6 +328,9 @@ case $(uname -s) in
         ;;
     *Linux*)
         HOST_OS_LINUX=true
+        ;;
+    *FreeBSD*)
+        HOST_OS_FREEBSD=true
         ;;
 esac
 

--- a/test/suites/debug_prefix_map.bash
+++ b/test/suites/debug_prefix_map.bash
@@ -23,6 +23,8 @@ EOF
 objdump_cmd() {
     if $HOST_OS_APPLE; then
         xcrun dwarfdump -r0 $1
+    elif $HOST_OS_FREEBSD; then
+        objdump -W $1
     else
         objdump -g $1
     fi


### PR DESCRIPTION
Lifted a compilation patch from ports,
https://svnweb.freebsd.org/ports/head/devel/ccache/files/patch-configure.ac?revision=434319&view=markup

And added some FreeBSD OS checks, and a workaround for CC=cc:
```
PASSED: 497 assertions, 97 tests, 10 suites
CC='cc' /usr/local/bin/bash ./test/run
Compiler:         cc (/usr/bin/cc)
Compiler version: FreeBSD clang version 6.0.0 (tags/RELEASE_600/final 326565) (based on LLVM 6.0.0)
CUDA compiler:    not available

Running test suite base.........................................................
Running test suite nocpp2.........................................................
Running test suite cpp1.
Skipped test suite multi_arch [multiple -arch options not supported on FreeBSD]
Running test suite serialize_diagnostics...
Running test suite sanitize_blacklist..
Running test suite debug_prefix_map..
Running test suite masquerading.
Running test suite hardlink.
Running test suite direct........................................
Running test suite basedir......
Running test suite compression.
Running test suite readonly...
Running test suite readonly_direct..
Running test suite cleanup............
Running test suite pch................
Running test suite upgrade.
Skipped test suite input_charset [compiler doesn't support -finput-charset]
Skipped test suite nvcc [nvcc is not available]
Skipped test suite nvcc_direct [nvcc is not available]
Skipped test suite nvcc_ldir [nvcc is not available]
Skipped test suite nvcc_nocpp2 [nvcc is not available]
PASSED
```

Tested with [Vagrant](https://forums.freebsd.org/threads/official-vagrant-freebsd-images.52717/)/VirtualBox, and FreeBSD 12.0-CURRENT

``` ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  config.vm.guest = :freebsd
  config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
  config.vm.box = "freebsd/FreeBSD-12.0-CURRENT"
  config.ssh.shell = "sh"
  config.vm.base_mac = "080027D14C66"

  config.vm.provider :virtualbox do |vb|
    vb.customize ["modifyvm", :id, "--memory", "1024"]
    vb.customize ["modifyvm", :id, "--cpus", "1"]
    vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
    vb.customize ["modifyvm", :id, "--audio", "none"]
    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
    vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
  end

  config.vm.provision "shell", inline: <<-SHELL
    pkg install -y git gmake bash autoconf
  SHELL
end
```

Possibly we should add that Vagrantfile to "misc" or something ?