### PR TITLE
Add command to show compression statistics, and a tool to compress

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,6 +29,7 @@ non_3pp_sources = \
     src/ccache.c \
     src/cleanup.c \
     src/compopt.c \
+    src/compress.c \
     src/conf.c \
     src/counters.c \
     src/execute.c \

--- a/misc/ccache-compress
+++ b/misc/ccache-compress
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# This will compress (or recompress) the ccache cache directory,
+# using the best compression method (level 9) available with gzip.
+
+CCACHE=${CCACHE:-ccache}
+CCACHE_DIR=${CCACHE_DIR:-$HOME/.ccache}
+
+# Set RECOMPRESS=false to avoid recompressing less compressed files.
+# Set DECOMPRESS=true to reverse the process and decompress cache.
+
+RECOMPRESS=${RECOMPRESS:-true}
+DECOMPRESS=${DECOMPRESS:-false}
+
+VERBOSE=${VERBOSE:-false}
+BEST=9
+
+# check for required programs, they should be present in the $PATH
+if ! file --version >/dev/null; then echo "missing file"; exit 1; fi
+if ! gzip --version >/dev/null; then echo "missing gzip"; exit 1; fi
+
+find $CCACHE_DIR -mindepth 2 -type f |
+grep -v CACHEDIR.TAG | grep -v stats | grep -v manifest |
+while read file; do
+  magic=`file $file`
+  if ! $DECOMPRESS && echo "$magic" | grep -v "compressed data" >/dev/null; then
+    ! $VERBOSE || echo "Compressing $file"
+    gzip -n -$BEST <$file >$file.$$ && mv $file.$$ $file
+  elif $DECOMPRESS && echo "$magic" | grep "compressed data" >/dev/null; then
+    ! $VERBOSE || echo "Decompressing $file"
+    gzip -d <$file >$file.$$ && mv $file.$$ $file
+  elif $DECOMPRESS; then
+    continue
+  elif $RECOMPRESS && echo "$magic" | grep -v "max compression" >/dev/null; then
+    ! $VERBOSE || echo "Recompressing $file"
+    gzip -d <$file | gzip -n -$BEST >$file.$$ && mv $file.$$ $file
+  fi
+done

--- a/misc/ccache-compress
+++ b/misc/ccache-compress
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This will compress (or recompress) the ccache cache directory,
 # using the fast compression method (level 1) available with gzip.
@@ -22,9 +22,8 @@ if ! gzip --version >/dev/null; then echo "missing gzip"; exit 1; fi
 # use parallel gzip (pigz) program for compression, if it's available
 if pigz --version >/dev/null 2>&1; then pigz=pigz; else pigz=gzip; fi
 
-find $CCACHE_DIR -mindepth 2 -type f | grep -v $CCACHE_DIR/tmp |
-grep -v CACHEDIR.TAG | grep -v stats | grep -v manifest |
-while read file; do
+ccache_compress() {
+  file=$1
   magic=`file $file`
   if ! $DECOMPRESS && echo "$magic" | grep -v "compressed data" >/dev/null; then
     ! $VERBOSE || echo "Compressing $file"
@@ -33,9 +32,17 @@ while read file; do
     ! $VERBOSE || echo "Decompressing $file"
     gzip -d <$file >$file.$$ && mv $file.$$ $file
   elif $DECOMPRESS; then
-    continue
+    return
   elif $RECOMPRESS && echo "$magic" | grep -v "max compression" >/dev/null; then
     ! $VERBOSE || echo "Recompressing $file"
     gzip -d <$file | $pigz -n -9 >$file.$$ && mv $file.$$ $file
   fi
-done
+}
+export -f ccache_compress
+export CCACHE CCACHE_DIR RECOMPRESS DECOMPRESS VERBOSE LEVEL
+
+parallel=`which parallel`
+find $CCACHE_DIR -mindepth 2 -type f | grep -v $CCACHE_DIR/tmp |
+grep -v CACHEDIR.TAG | grep -v stats | grep -v manifest |
+if [ "$parallel" != "" ]; then pigz=gzip parallel ccache_compress
+else while read file; do ccache_compress $file; done; fi

--- a/misc/ccache-compress
+++ b/misc/ccache-compress
@@ -1,19 +1,19 @@
 #!/bin/sh
 
 # This will compress (or recompress) the ccache cache directory,
-# using the best compression method (level 9) available with gzip.
+# using the fast compression method (level 1) available with gzip.
 
 CCACHE=${CCACHE:-ccache}
 CCACHE_DIR=${CCACHE_DIR:-$HOME/.ccache}
 
-# Set RECOMPRESS=false to avoid recompressing less compressed files.
+# Set RECOMPRESS=true to do a recompress of less compressed files.
 # Set DECOMPRESS=true to reverse the process and decompress cache.
 
-RECOMPRESS=${RECOMPRESS:-true}
+RECOMPRESS=${RECOMPRESS:-false}
 DECOMPRESS=${DECOMPRESS:-false}
 
 VERBOSE=${VERBOSE:-false}
-BEST=9
+LEVEL=${LEVEL:-1}
 
 # check for required programs, they should be present in the $PATH
 if ! file --version >/dev/null; then echo "missing file"; exit 1; fi
@@ -28,7 +28,7 @@ while read file; do
   magic=`file $file`
   if ! $DECOMPRESS && echo "$magic" | grep -v "compressed data" >/dev/null; then
     ! $VERBOSE || echo "Compressing $file"
-    $pigz -n -$BEST <$file >$file.$$ && mv $file.$$ $file
+    $pigz -n -$LEVEL <$file >$file.$$ && mv $file.$$ $file
   elif $DECOMPRESS && echo "$magic" | grep "compressed data" >/dev/null; then
     ! $VERBOSE || echo "Decompressing $file"
     gzip -d <$file >$file.$$ && mv $file.$$ $file
@@ -36,6 +36,6 @@ while read file; do
     continue
   elif $RECOMPRESS && echo "$magic" | grep -v "max compression" >/dev/null; then
     ! $VERBOSE || echo "Recompressing $file"
-    gzip -d <$file | $pigz -n -$BEST >$file.$$ && mv $file.$$ $file
+    gzip -d <$file | $pigz -n -9 >$file.$$ && mv $file.$$ $file
   fi
 done

--- a/misc/ccache-compress
+++ b/misc/ccache-compress
@@ -19,13 +19,16 @@ BEST=9
 if ! file --version >/dev/null; then echo "missing file"; exit 1; fi
 if ! gzip --version >/dev/null; then echo "missing gzip"; exit 1; fi
 
+# use parallel gzip (pigz) program for compression, if it's available
+if pigz --version >/dev/null 2>&1; then pigz=pigz; else pigz=gzip; fi
+
 find $CCACHE_DIR -mindepth 2 -type f |
 grep -v CACHEDIR.TAG | grep -v stats | grep -v manifest |
 while read file; do
   magic=`file $file`
   if ! $DECOMPRESS && echo "$magic" | grep -v "compressed data" >/dev/null; then
     ! $VERBOSE || echo "Compressing $file"
-    gzip -n -$BEST <$file >$file.$$ && mv $file.$$ $file
+    $pigz -n -$BEST <$file >$file.$$ && mv $file.$$ $file
   elif $DECOMPRESS && echo "$magic" | grep "compressed data" >/dev/null; then
     ! $VERBOSE || echo "Decompressing $file"
     gzip -d <$file >$file.$$ && mv $file.$$ $file
@@ -33,6 +36,6 @@ while read file; do
     continue
   elif $RECOMPRESS && echo "$magic" | grep -v "max compression" >/dev/null; then
     ! $VERBOSE || echo "Recompressing $file"
-    gzip -d <$file | gzip -n -$BEST >$file.$$ && mv $file.$$ $file
+    gzip -d <$file | $pigz -n -$BEST >$file.$$ && mv $file.$$ $file
   fi
 done

--- a/misc/ccache-compress
+++ b/misc/ccache-compress
@@ -22,7 +22,7 @@ if ! gzip --version >/dev/null; then echo "missing gzip"; exit 1; fi
 # use parallel gzip (pigz) program for compression, if it's available
 if pigz --version >/dev/null 2>&1; then pigz=pigz; else pigz=gzip; fi
 
-find $CCACHE_DIR -mindepth 2 -type f |
+find $CCACHE_DIR -mindepth 2 -type f | grep -v $CCACHE_DIR/tmp |
 grep -v CACHEDIR.TAG | grep -v stats | grep -v manifest |
 while read file; do
   magic=`file $file`

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -61,6 +61,7 @@ static const char USAGE_TEXT[] =
   "                          Ki, Mi, Gi, Ti (binary); default suffix: G\n"
   "    -o, --set-config=K=V  set configuration key K to value V\n"
   "    -p, --print-config    print current configuration options\n"
+  "    -x, --comp-stats      show compression statistics\n"
   "    -s, --show-stats      show statistics summary\n"
   "    -z, --zero-stats      zero statistics counters\n"
   "\n"
@@ -3463,6 +3464,7 @@ ccache_main_options(int argc, char *argv[])
 		{"max-size",      required_argument, 0, 'M'},
 		{"set-config",    required_argument, 0, 'o'},
 		{"print-config",  no_argument,       0, 'p'},
+		{"comp-stats",    no_argument,       0, 'x'},
 		{"show-stats",    no_argument,       0, 's'},
 		{"version",       no_argument,       0, 'V'},
 		{"zero-stats",    no_argument,       0, 'z'},
@@ -3470,7 +3472,7 @@ ccache_main_options(int argc, char *argv[])
 	};
 
 	int c;
-	while ((c = getopt_long(argc, argv, "cChF:M:o:psVz", options, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "cChF:M:o:pxsVz", options, NULL)) != -1) {
 		switch (c) {
 		case DUMP_MANIFEST:
 			manifest_dump(optarg, stdout);
@@ -3553,6 +3555,11 @@ ccache_main_options(int argc, char *argv[])
 		case 'p': // --print-config
 			initialize();
 			conf_print_items(conf, configuration_printer, stdout);
+			break;
+
+		case 'x': // --comp-stats
+			initialize();
+			compress_stats(conf);
 			break;
 
 		case 's': // --show-stats

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -145,6 +145,7 @@ int move_file(const char *src, const char *dest, int compress_level);
 int move_uncompressed_file(const char *src, const char *dest,
                            int compress_level);
 bool file_is_compressed(const char *filename);
+size_t uncompressed_size(const char *filename);
 int create_dir(const char *dir);
 int create_parent_dirs(const char *path);
 const char *get_hostname(void);
@@ -236,6 +237,11 @@ void exitfn_call(void);
 void clean_up_dir(struct conf *conf, const char *dir, double limit_multiple);
 void clean_up_all(struct conf *conf);
 void wipe_all(struct conf *conf);
+
+// ----------------------------------------------------------------------------
+// compress.c
+
+void compress_stats(struct conf *conf);
 
 // ----------------------------------------------------------------------------
 // execute.c

--- a/src/compress.c
+++ b/src/compress.c
@@ -1,0 +1,84 @@
+// Copyright (C) 2002-2006 Andrew Tridgell
+// Copyright (C) 2009-2018 Joel Rosdahl
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "ccache.h"
+
+static unsigned num_files;
+static unsigned comp_files;
+
+static uint64_t cache_size;
+static uint64_t real_size;
+
+// This measures the size of files in the cache.
+static void
+measure_fn(const char *fname, struct stat *st)
+{
+	if (!S_ISREG(st->st_mode)) {
+		return;
+	}
+
+	char *p = basename(fname);
+	if (str_eq(p, "stats")) {
+		return;
+	}
+
+	if (str_startswith(p, ".nfs")) {
+		// Ignore temporary NFS files that may be left for open but deleted files.
+		return;
+	}
+
+	if (strstr(p, "CACHEDIR.TAG")) {
+		return;
+	}
+
+	cache_size += st->st_size;
+	num_files++;
+	if (file_is_compressed(fname)) {
+		real_size += uncompressed_size(fname);
+		comp_files++;
+	} else {
+		real_size += st->st_size;
+	}
+}
+
+// Process up all cache subdirectories.
+void compress_stats(struct conf *conf)
+{
+	num_files = 0;
+	comp_files = 0;
+	cache_size = 0;
+	real_size = 0;
+
+	for (int i = 0; i <= 0xF; i++) {
+		char *dname = format("%s/%1x", conf->cache_dir, i);
+		traverse(dname, measure_fn);
+		free(dname);
+	}
+
+	printf("Compressed size: %.1f KiB, %.0f files\n",
+	       (double)cache_size / 1024,
+	       (double)comp_files);
+	printf("Uncompressed size: %.1f KiB, %.0f files\n",
+	       (double)real_size / 1024,
+	       (double)num_files);
+
+	double percent = real_size > 0 ? (100.0f * comp_files) / num_files : 0.0f;
+	printf("Compressed files: %.2f %%\n", percent);
+	double ratio = real_size > 0 ? (100.0f * cache_size) / real_size : 0.0f;
+	printf("Compression ratio: %.2f %%\n", ratio);
+}
+

--- a/src/compress.c
+++ b/src/compress.c
@@ -69,12 +69,14 @@ void compress_stats(struct conf *conf)
 		free(dname);
 	}
 
-	printf("Compressed size: %.1f KiB, %.0f files\n",
-	       (double)cache_size / 1024,
-	       (double)comp_files);
-	printf("Uncompressed size: %.1f KiB, %.0f files\n",
-	       (double)real_size / 1024,
-	       (double)num_files);
+	char *cache_str = format_human_readable_size(cache_size);
+	printf("Compressed size: %s, %.0f files\n",
+	       cache_str, (double)comp_files);
+	free(cache_str);
+	char *real_str = format_human_readable_size(real_size);
+	printf("Uncompressed size: %s, %.0f files\n",
+	       real_str, (double)num_files);
+	free(real_str);
 
 	double percent = real_size > 0 ? (100.0f * comp_files) / num_files : 0.0f;
 	printf("Compressed files: %.2f %%\n", percent);

--- a/src/compress.c
+++ b/src/compress.c
@@ -78,9 +78,10 @@ void compress_stats(struct conf *conf)
 	       real_str, (double)num_files);
 	free(real_str);
 
-	double percent = real_size > 0 ? (100.0f * comp_files) / num_files : 0.0f;
+	double percent = real_size > 0 ? (100.0 * comp_files) / num_files : 0.0;
 	printf("Compressed files: %.2f %%\n", percent);
-	double ratio = real_size > 0 ? (100.0f * cache_size) / real_size : 0.0f;
-	printf("Compression ratio: %.2f %%\n", ratio);
+	double ratio = cache_size > 0 ? ((double) real_size) / cache_size : 0.0;
+	double savings = ratio > 0.0 ? 100.0 - (100.0 / ratio) : 0.0;
+	printf("Compression ratio: %.2f %% (%.1fx)\n", savings, ratio);
 }
 


### PR DESCRIPTION
By default only the .manifest files are compressed, but add a tool to measure the amount of compression.

Also do a small wrapper to help compress all files with `--fast`, optionally to recompress using `--best`.

``` console
$ ccache -x
Compressed size: 9.8 MB, 22 files
Uncompressed size: 10.0 MB, 68 files
Compressed files: 32.35 %
Compression ratio: 1.34 % (1.0x)
$ ccache-compress 
$ ccache -x
Compressed size: 2.5 MB, 68 files
Uncompressed size: 10.0 MB, 68 files
Compressed files: 100.00 %
Compression ratio: 75.41 % (4.0x)
```

For large cache directories, compressing will take a *long* time... But decompression should be fast.

Once the benchmarking tools have been updated, they should have more compress options as well...


Part of #274 