### PR TITLE
Improve printing of “stats zeroed” statistics

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -736,6 +736,12 @@ The compiler was instructed to write its output to standard output using *-o
 | preprocessor error |
 Preprocessing the source code using the compiler's *-E* option failed.
 
+| stats updated |
+When statistics were updated the last time.
+
+| stats zeroed |
+When *ccache -z* was called the last time.
+
 | unsupported code directive |
 Code like the assembler *.incbin* directive was found. This is not supported
 by ccache.

--- a/doc/NEWS.adoc
+++ b/doc/NEWS.adoc
@@ -19,6 +19,10 @@ New features and enhancements
 - Added ``stats updated'' timestamp in `ccache -s` output. This can be useful
   if you wonder whether ccache actually was used for your last build.
 
+- Renamed ``stats zero time'' to ``stats zeroed'' and documented it. The
+  counter is also now only present in `ccache -s` output when `ccache -z`
+  actually has been called.
+
 - The content of the `-fsanitize-blacklist` file is now included in the hash,
   so updates to the file will now correctly result in separate cache entries.
 

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -3568,7 +3568,7 @@ ccache_main_options(int argc, char *argv[])
 		case 'z': // --zero-stats
 			initialize();
 			stats_zero();
-			printf("Statistics cleared\n");
+			printf("Statistics zeroed\n");
 			break;
 
 		default:


### PR DESCRIPTION
* Refactored how formatting functions work in “ccache -s” output. They now return a formatted string (or NULL for “don’t print statistics line at all”) instead of printing the value.
* Added a new format_timestamp function.
* Added STATS_ZEROTIMESTAMP to the common stats_info array instead of being a special case.
* Let the STATS_ZEROTIMESTAMP be 0 for new caches so that the “stats zeroed statistics line only shows up when “ccache -z” actually has been called.

@afbjorklund: What do you think?