### PR TITLE
Bail out on compiler option -save-temps=obj

### DIFF
--- a/src/compopt.c
+++ b/src/compopt.c
@@ -35,6 +35,8 @@ static const struct compopt compopts[] = {
 	{"--output-directory", AFFECTS_CPP | TAKES_ARG}, // nvcc
 	{"--param",         TAKES_ARG},
 	{"--save-temps",    TOO_HARD},
+	{"--save-temps=cwd",TOO_HARD},
+	{"--save-temps=obj",TOO_HARD},
 	{"--serialize-diagnostics", TAKES_ARG | TAKES_PATH},
 	{"-A",              TAKES_ARG},
 	{"-B",              TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
@@ -85,6 +87,8 @@ static const struct compopt compopts[] = {
 	{"-odir",           AFFECTS_CPP | TAKES_ARG}, // nvcc
 	{"-remap",          AFFECTS_CPP},
 	{"-save-temps",     TOO_HARD},
+	{"-save-temps=cwd", TOO_HARD},
+	{"-save-temps=obj", TOO_HARD},
 	{"-stdlib=",        AFFECTS_CPP | TAKES_CONCAT_ARG},
 	{"-trigraphs",      AFFECTS_CPP},
 	{"-u",              TAKES_ARG | TAKES_CONCAT_ARG},

--- a/unittest/test_compopt.c
+++ b/unittest/test_compopt.c
@@ -55,6 +55,21 @@ TEST(dash_MM_too_hard)
 	CHECK(compopt_too_hard("-MM"));
 }
 
+TEST(dash_save_temps_too_hard)
+{
+	CHECK(compopt_too_hard("-save-temps"));
+}
+
+TEST(dash_save_temps_cwd_too_hard)
+{
+	CHECK(compopt_too_hard("-save-temps=cwd"));
+}
+
+TEST(dash_save_temps_obj_too_hard)
+{
+	CHECK(compopt_too_hard("-save-temps=obj"));
+}
+
 TEST(dash_MD_not_too_hard)
 {
 	CHECK(!compopt_too_hard("-MD"));


### PR DESCRIPTION
Also add a test, and handle default (=cwd)

Closes #299