### PR TITLE
Minor fixes for cygwin/msys2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ case $host in
 esac
 
 AC_SUBST(extra_libs)
+AC_SUBST(extra_cflags)
 AC_SUBST(include_dev_mk)
 AC_SUBST(test_suites)
 AC_SUBST(disable_man)
@@ -172,6 +173,17 @@ if test ! -f $srcdir/dev_mode_disabled && test "$RUN_FROM_BUILD_FARM" != yes; th
     include_dev_mk='include dev.mk'
     version=`(git --git-dir=$srcdir/.git describe --dirty 2>/dev/null || echo vunknown) | sed -e 's/v//' -e 's/-/+/' -e 's/-/_/g'`
     echo "const char CCACHE_VERSION@<:@@:>@ = \"$version\";" >src/version.c
+
+    dnl Check for -Wimplicit-fallthrough and disable if exists
+    AC_MSG_CHECKING([whether C compiler supports -Wimplicit-fallthrough])
+    saved_cflags=$CFLAGS
+    CFLAGS=-Wimplicit-fallthrough
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
+        [AC_MSG_RESULT([yes])]
+        [extra_cflags="-Wno-error=implicit-fallthrough"],
+        [AC_MSG_RESULT([no])]
+    )
+    CFLAGS=$saved_cflags
 else
     AC_MSG_NOTICE(developer mode disabled)
 fi

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -1,6 +1,6 @@
 # GNU make syntax reigns in this file.
 
-all_cflags += -Werror
+all_cflags += -Werror @extra_cflags@
 all_cppflags += -MD -MP -MF .deps/$(subst .._,,$(subst /,_,$<)).d
 
 A2X = a2x

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -278,11 +278,6 @@ typedef int (*COMPAR_FN_T)(const void *, const void *);
 #define O_BINARY 0
 #endif
 
-// mkstemp() on some versions of cygwin don't handle binary files, so override.
-#ifdef __CYGWIN__
-#undef HAVE_MKSTEMP
-#endif
-
 #ifdef _WIN32
 char *win32argvtos(char *prefix, char **argv);
 char *win32getshell(char *path);

--- a/src/util.c
+++ b/src/util.c
@@ -216,7 +216,14 @@ copy_fd(int fd_in, int fd_out)
 int
 mkstemp(char *template)
 {
+#ifdef __GNUC__
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 	mktemp(template);
+#ifdef __GNUC__
+    #pragma GCC diagnostic pop
+#endif
 	return open(template, O_RDWR | O_CREAT | O_EXCL | O_BINARY, 0600);
 }
 #endif

--- a/src/zlib/gzguts.h
+++ b/src/zlib/gzguts.h
@@ -39,7 +39,7 @@
 #  include <io.h>
 #endif
 
-#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32)
 #  define WIDECHAR
 #endif
 

--- a/src/zlib/zlib.h
+++ b/src/zlib/zlib.h
@@ -1893,7 +1893,7 @@ ZEXTERN int            ZEXPORT inflateValidate OF((z_streamp, int));
 ZEXTERN unsigned long  ZEXPORT inflateCodesUsed OF ((z_streamp));
 ZEXTERN int            ZEXPORT inflateResetKeep OF((z_streamp));
 ZEXTERN int            ZEXPORT deflateResetKeep OF((z_streamp));
-#if (defined(_WIN32) || defined(__CYGWIN__)) && !defined(Z_SOLO)
+#if defined(_WIN32) && !defined(Z_SOLO)
 ZEXTERN gzFile         ZEXPORT gzopen_w OF((const wchar_t *path,
                                             const char *mode));
 #endif

--- a/src/zlib/zutil.h
+++ b/src/zlib/zutil.h
@@ -147,7 +147,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  define OS_CODE 13
 #endif
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(WIN32)
 #  define OS_CODE  10
 #endif
 


### PR DESCRIPTION
Add -Wno-error=implicit-fallthrough to dev.mk so that zlib will compile
with -Werror.

Disable -Wdeprecated-declarations in the mkstemp() shim in util.c so
that it compiles with -Werror.

Fix a couple of erroneous checks in zlib that assume cygwin is the same
as win32.