### PR TITLE
Add option for enabling more compiler warnings

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -45,7 +45,7 @@ non_3pp_sources = \
 generated_sources = \
     src/version.c
 3pp_sources = \
-    src/getopt_long.c \
+    @getopt_long_c@ \
     src/hashtable.c \
     src/hashtable_itr.c \
     src/murmurhashneutral2.c \

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,19 @@ else
     CFLAGS="$CFLAGS -O"
 fi
 
+AC_ARG_ENABLE(more_warnings,
+  [AS_HELP_STRING([--enable-more-warnings],
+    [enable more compiler warnings])])
+if test x${enable_more_warnings} = xyes; then
+    CFLAGS="$CFLAGS -Wextra -Wpedantic"
+    if test "$ac_compiler_clang" = yes; then
+        CFLAGS="$CFLAGS -Weverything"
+        CFLAGS="$CFLAGS -Wno-padded -Wno-disabled-macro-expansion -Wno-format-nonliteral"
+        CFLAGS="$CFLAGS -Wno-double-promotion -Wno-float-conversion"
+        CFLAGS="$CFLAGS -Wno-conversion -Wno-shorten-64-to-32 -Wno-sign-conversion"
+    fi
+fi
+
 AC_HEADER_DIRENT
 AC_HEADER_TIME
 AC_HEADER_SYS_WAIT

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ case $host in
 esac
 
 AC_SUBST(extra_libs)
+AC_SUBST(getopt_long_c)
 AC_SUBST(include_dev_mk)
 AC_SUBST(test_suites)
 AC_SUBST(disable_man)
@@ -66,6 +67,10 @@ AC_CHECK_FUNCS(strndup)
 AC_CHECK_FUNCS(strtok_r)
 AC_CHECK_FUNCS(unsetenv)
 AC_CHECK_FUNCS(utimes)
+
+if test x"$ac_cv_func_getopt_long" != x"yes"; then
+    getopt_long_c="src/getopt_long.c"
+fi
 
 AC_CACHE_CHECK([for compar_fn_t in stdlib.h],ccache_cv_COMPAR_FN_T, [
     AC_TRY_COMPILE(

--- a/configure.ac
+++ b/configure.ac
@@ -213,7 +213,9 @@ cat <<EOF >config.h.tmp
 #define CCACHE_CONFIG_H
 #ifdef __clang__
 #pragma clang diagnostic push
+#if __clang_major__ >= 4
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#endif
 #endif
 
 EOF

--- a/configure.ac
+++ b/configure.ac
@@ -176,14 +176,14 @@ if test ! -f $srcdir/dev_mode_disabled && test "$RUN_FROM_BUILD_FARM" != yes; th
     AC_CONFIG_FILES([dev.mk])
     include_dev_mk='include dev.mk'
     version=`(git --git-dir=$srcdir/.git describe --dirty 2>/dev/null || echo vunknown) | sed -e 's/v//' -e 's/-/+/' -e 's/-/_/g'`
-    echo "const char CCACHE_VERSION@<:@@:>@ = \"$version\";" >src/version.c
+    echo "extern const char CCACHE_VERSION@<:@@:>@; const char CCACHE_VERSION@<:@@:>@ = \"$version\";" >src/version.c
 else
     AC_MSG_NOTICE(developer mode disabled)
 fi
 
 if test ! -f $srcdir/src/version.c -a ! -f src/version.c ; then
     AC_MSG_WARN(unable to determine ccache version)
-    echo "const char CCACHE_VERSION@<:@@:>@ = \"unknown\";" >src/version.c
+    echo "extern const char CCACHE_VERSION@<:@@:>@; const char CCACHE_VERSION@<:@@:>@ = \"unknown\";" >src/version.c
 fi
 
 dnl Find test suite files.

--- a/configure.ac
+++ b/configure.ac
@@ -195,9 +195,20 @@ AC_OUTPUT
 cat <<EOF >config.h.tmp
 #ifndef CCACHE_CONFIG_H
 #define CCACHE_CONFIG_H
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#endif
+
 EOF
 cat config.h >>config.h.tmp
-echo '#endif' >>config.h.tmp
+cat <<EOF >>config.h.tmp
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#endif // ifndef CCACHE_CONFIG_H
+EOF
 mv config.h.tmp config.h
 
 AC_MSG_NOTICE(now build ccache by running make)

--- a/configure.ac
+++ b/configure.ac
@@ -23,8 +23,11 @@ AC_SUBST(test_suites)
 AC_SUBST(disable_man)
 
 m4_include(m4/feature_macros.m4)
+m4_include(m4/clang.m4)
 
 dnl Checks for programs.
+AC_PROG_CC
+_AC_LANG_COMPILER_CLANG
 AC_PROG_CC_C99
 if test "$ac_cv_prog_cc_c99" = no; then
     AC_MSG_ERROR(cannot find a C99-compatible compiler)
@@ -41,8 +44,8 @@ fi
 # Prefer bash, needed for test.sh
 AC_PATH_TOOL(BASH, bash, "/bin/bash")
 
-# If GCC, turn on warnings.
-if test "x$GCC" = "xyes"; then
+# If GCC (or clang), turn on warnings.
+if test "$ac_compiler_gnu" = yes; then
     CFLAGS="$CFLAGS -Wall -W"
 else
     CFLAGS="$CFLAGS -O"

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -102,7 +102,7 @@ uncrustify_exclude_files = \
     src/snprintf.c
 
 ifneq ($(shell sed 's/.*"\(.*\)".*/\1/' src/version.c 2>/dev/null),$(version))
-  $(shell echo 'const char CCACHE_VERSION[] = "$(version)";' >src/version.c)
+  $(shell echo 'extern const char CCACHE_VERSION[]; const char CCACHE_VERSION[] = "$(version)";' >src/version.c)
 endif
 src/version.o: src/version.c
 

--- a/m4/clang.m4
+++ b/m4/clang.m4
@@ -1,0 +1,19 @@
+# _AC_LANG_COMPILER_CLANG
+# ---------------------
+# Check whether the compiler for the current language is clang.
+# Adapted from standard autoconf function: _AC_LANG_COMPILER_GNU
+#
+# Note: clang also identifies itself as a GNU compiler (gcc 4.2.1)
+# for compatibility reasons, so that cannot be used to determine
+m4_define([_AC_LANG_COMPILER_CLANG],
+[AC_CACHE_CHECK([whether we are using the clang _AC_LANG compiler],
+                [ac_cv_[]_AC_LANG_ABBREV[]_compiler_clang],
+[_AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[#ifndef __clang__
+       choke me
+#endif
+]])],
+                   [ac_compiler_clang=yes],
+                   [ac_compiler_clang=no])
+ac_cv_[]_AC_LANG_ABBREV[]_compiler_clang=$ac_compiler_clang
+])])# _AC_LANG_COMPILER_CLANG
+

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -33,6 +33,15 @@
 #define STRINGIFY(x) #x
 #define TO_STRING(x) STRINGIFY(x)
 
+extern struct conf *conf;
+extern char *primary_config_path;
+extern char *secondary_config_path;
+extern char *current_working_dir;
+extern char *stats_file;
+extern unsigned lock_staleness_limit;
+
+int ccache_main(int argc, char *argv[]);
+
 static const char VERSION_TEXT[] =
   MYNAME " version %s\n"
   "\n"
@@ -1157,7 +1166,8 @@ send_cached_stderr(void)
 }
 
 // Create or update the manifest file.
-void update_manifest_file(void)
+static void
+update_manifest_file(void)
 {
 	if (!conf->direct_mode
 	    || !included_files

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -934,10 +934,10 @@ process_preprocessed_file(struct mdfour *hash, const char *path, bool pump)
 	// Explicitly check the .gch/.pch/.pth file, Clang does not include any
 	// mention of it in the preprocessed output.
 	if (included_pch_file) {
-		char *path = x_strdup(included_pch_file);
-		path = make_relative_path(path);
-		hash_string(hash, path);
-		remember_include_file(path, hash, false);
+		char *pch_path = x_strdup(included_pch_file);
+		pch_path = make_relative_path(pch_path);
+		hash_string(hash, pch_path);
+		remember_include_file(pch_path, hash, false);
 	}
 
 	return true;
@@ -1042,8 +1042,7 @@ do_copy_or_move_file_to_cache(const char *source, const char *dest, bool copy)
 		if (do_link) {
 			x_unlink(dest);
 			int ret = link(source, dest);
-			if (ret == 0) {
-			} else {
+			if (ret != 0) {
 				cc_log("Failed to link %s to %s: %s", source, dest, strerror(errno));
 				cc_log("Falling back to copying");
 				do_link = false;
@@ -3121,7 +3120,7 @@ out:
 }
 
 static void
-create_initial_config_file(struct conf *conf, const char *path)
+create_initial_config_file(const char *path)
 {
 	if (create_parent_dirs(path) != 0) {
 		return;
@@ -3212,7 +3211,7 @@ initialize(void)
 	}
 
 	if (should_create_initial_config) {
-		create_initial_config_file(conf, primary_config_path);
+		create_initial_config_file(primary_config_path);
 	}
 
 	exitfn_init();

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1619,9 +1619,9 @@ calculate_common_hash(struct args *args, struct mdfour *hash)
 	// Also hash the compiler name as some compilers use hard links and behave
 	// differently depending on the real name.
 	hash_delimiter(hash, "cc_name");
-	char *p = basename(args->argv[0]);
-	hash_string(hash, p);
-	free(p);
+	char *base = basename(args->argv[0]);
+	hash_string(hash, base);
+	free(base);
 
 	// Possibly hash the current working directory.
 	if (generating_debuginfo && conf->hash_dir) {
@@ -1662,7 +1662,7 @@ calculate_common_hash(struct args *args, struct mdfour *hash)
 		}
 		if (dir) {
 			char *base_name = basename(output_obj);
-			p = remove_extension(base_name);
+			char *p = remove_extension(base_name);
 			free(base_name);
 			char *gcda_path = format("%s/%s.gcda", dir, p);
 			cc_log("Hashing coverage path %s", gcda_path);
@@ -3586,7 +3586,7 @@ ccache_main_options(int argc, char *argv[])
 
 		case 's': // --show-stats
 			initialize();
-			stats_summary(conf);
+			stats_summary();
 			break;
 
 		case 'V': // --version

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -40,6 +40,9 @@ extern char *current_working_dir;
 extern char *stats_file;
 extern unsigned lock_staleness_limit;
 
+static void failed(void) ATTR_NORETURN;
+static void ccache(int argc, char *argv[]) ATTR_NORETURN;
+
 int ccache_main(int argc, char *argv[]);
 
 static const char VERSION_TEXT[] =
@@ -3624,5 +3627,4 @@ ccache_main(int argc, char *argv[])
 	free(program_name);
 
 	ccache(argc, argv);
-	return 1;
 }

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -207,7 +207,7 @@ void stats_update(enum stats stat);
 void stats_flush(void);
 unsigned stats_get_pending(enum stats stat);
 void stats_zero(void);
-void stats_summary(struct conf *conf);
+void stats_summary(void);
 void stats_update_size(int64_t size, int files);
 void stats_get_obsolete_limits(const char *dir, unsigned *maxfiles,
                                uint64_t *maxsize);

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -8,7 +8,7 @@
 
 #ifdef __GNUC__
 #define ATTR_FORMAT(x, y, z) __attribute__((format (x, y, z)))
-#define ATTR_NORETURN __attribute__((noreturn));
+#define ATTR_NORETURN __attribute__((noreturn))
 #else
 #define ATTR_FORMAT(x, y, z)
 #define ATTR_NORETURN

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -264,7 +264,7 @@ bool is_precompiled_header(const char *path);
 
 // ----------------------------------------------------------------------------
 
-#if HAVE_COMPAR_FN_T
+#ifdef HAVE_COMPAR_FN_T
 #define COMPAR_FN_T __compar_fn_t
 #else
 typedef int (*COMPAR_FN_T)(const void *, const void *);

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -164,9 +164,10 @@ clean_up_dir(struct conf *conf, const char *dir, double limit_multiple)
 	// When "max files" or "max cache size" is reached, one of the 16 cache
 	// subdirectories is cleaned up. When doing so, files are deleted (in LRU
 	// order) until the levels are below limit_multiple.
-	cache_size_threshold = (uint64_t)round(conf->max_size * limit_multiple / 16);
-	files_in_cache_threshold =
-		(size_t)round(conf->max_files * limit_multiple / 16);
+	double cache_size_float = round(conf->max_size * limit_multiple / 16);
+	cache_size_threshold = (uint64_t)cache_size_float;
+	double files_in_cache_float = round(conf->max_files * limit_multiple / 16);
+	files_in_cache_threshold = (size_t)files_in_cache_float;
 
 	num_files = 0;
 	cache_size = 0;

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -238,7 +238,7 @@ static void wipe_fn(const char *fname, struct stat *st)
 }
 
 // Wipe one cache subdirectory.
-void
+static void
 wipe_dir(const char *dir)
 {
 	cc_log("Clearing out cache directory %s", dir);

--- a/src/compopt.c
+++ b/src/compopt.c
@@ -142,6 +142,8 @@ compopt_short(bool (*fn)(const char *), const char *option)
 	return retval;
 }
 
+extern bool compopt_verify_sortedness(void);
+
 // For test purposes.
 bool
 compopt_verify_sortedness(void)

--- a/src/conf.c
+++ b/src/conf.c
@@ -253,8 +253,8 @@ handle_conf_setting(struct conf *conf, const char *key, const char *value,
 			fatal("invalid boolean environment variable value \"%s\"", value);
 		}
 
-		bool *value = (bool *)((char *)conf + item->offset);
-		*value = !negate_boolean;
+		bool *boolvalue = (bool *)((char *)conf + item->offset);
+		*boolvalue = !negate_boolean;
 		goto out;
 	}
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -28,7 +28,7 @@ hash_start(struct mdfour *md)
 void
 hash_buffer(struct mdfour *md, const void *s, size_t len)
 {
-	mdfour_update(md, (unsigned char *)s, len);
+	mdfour_update(md, (const unsigned char *)s, len);
 }
 
 // Return the hash result as a hex string. Caller frees.

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -77,7 +77,7 @@ create_hashtable(unsigned int minsize,
     h->entrycount   = 0;
     h->hashfn       = hashf;
     h->eqfn         = eqf;
-    h->loadlimit    = (unsigned int) ceil(size * max_load_factor);
+    h->loadlimit    = (unsigned int) ceilf((float) size * max_load_factor);
     return h;
 }
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -30,11 +30,15 @@
 */
 
 #include "hashtable.h"
+#define HASHTABLE_INDEXFOR
 #include "hashtable_private.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+
+extern const unsigned int prime_table_length;
+extern const float max_load_factor;
 
 /*
 Credit for primes table: Aaron Krowne

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -81,7 +81,8 @@ create_hashtable(unsigned int minsize,
     h->entrycount   = 0;
     h->hashfn       = hashf;
     h->eqfn         = eqf;
-    h->loadlimit    = (unsigned int) ceilf((float) size * max_load_factor);
+    double loadlimit_float = ceil((double)size * (double)max_load_factor);
+    h->loadlimit    = (unsigned int)loadlimit_float;
     return h;
 }
 
@@ -154,7 +155,8 @@ hashtable_expand(struct hashtable *h)
         }
     }
     h->tablelength = newsize;
-    h->loadlimit   = (unsigned int) ceil(newsize * max_load_factor);
+    double loadlimit_float = ceil((double)newsize* (double)max_load_factor);
+    h->loadlimit   = (unsigned int) loadlimit_float;
     return -1;
 }
 

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -29,8 +29,8 @@
   POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef __HASHTABLE_CWC22_H__
-#define __HASHTABLE_CWC22_H__
+#ifndef HASHTABLE_CWC22_H
+#define HASHTABLE_CWC22_H
 
 #include "config.h"
 
@@ -194,7 +194,7 @@ hashtable_count(struct hashtable *h);
 void
 hashtable_destroy(struct hashtable *h, int free_values);
 
-#endif /* __HASHTABLE_CWC22_H__ */
+#endif /* HASHTABLE_CWC22_H */
 
 /*
  * Copyright (c) 2002, Christopher Clark

--- a/src/hashtable_itr.c
+++ b/src/hashtable_itr.c
@@ -1,6 +1,7 @@
 /* Copyright (C) 2002, 2004 Christopher Clark  <firstname.lastname@cl.cam.ac.uk> */
 
 #include "hashtable.h"
+#define HASHTABLE_INDEXFOR
 #include "hashtable_private.h"
 #include "hashtable_itr.h"
 #include <stdlib.h> /* defines NULL */

--- a/src/hashtable_itr.h
+++ b/src/hashtable_itr.h
@@ -1,7 +1,7 @@
 /* Copyright (C) 2002, 2004 Christopher Clark <firstname.lastname@cl.cam.ac.uk> */
 
-#ifndef __HASHTABLE_ITR_CWC22__
-#define __HASHTABLE_ITR_CWC22__
+#ifndef HASHTABLE_ITR_CWC22_H
+#define HASHTABLE_ITR_CWC22_H
 #include "hashtable.h"
 #include "hashtable_private.h" /* needed to enable inlining */
 
@@ -86,7 +86,7 @@ int fnname (struct hashtable_itr *i, struct hashtable *h, keytype *k) \
 
 
 
-#endif /* __HASHTABLE_ITR_CWC22__*/
+#endif /* HASHTABLE_ITR_CWC22_H */
 
 /*
  * Copyright (c) 2002, 2004, Christopher Clark

--- a/src/hashtable_private.h
+++ b/src/hashtable_private.h
@@ -1,7 +1,7 @@
 /* Copyright (C) 2002, 2004 Christopher Clark <firstname.lastname@cl.cam.ac.uk> */
 
-#ifndef __HASHTABLE_PRIVATE_CWC22_H__
-#define __HASHTABLE_PRIVATE_CWC22_H__
+#ifndef HASHTABLE_PRIVATE_CWC22_H
+#define HASHTABLE_PRIVATE_CWC22_H
 
 #include "hashtable.h"
 
@@ -49,7 +49,7 @@ indexFor(unsigned int tablelength, unsigned int hashvalue)
 
 /*****************************************************************************/
 
-#endif /* __HASHTABLE_PRIVATE_CWC22_H__*/
+#endif /* HASHTABLE_PRIVATE_CWC22_H */
 
 /*
  * Copyright (c) 2002, Christopher Clark

--- a/src/hashtable_private.h
+++ b/src/hashtable_private.h
@@ -28,6 +28,7 @@ unsigned int
 hash(struct hashtable *h, void *k);
 
 /*****************************************************************************/
+#ifdef HASHTABLE_INDEXFOR
 /* indexFor */
 static inline unsigned int
 indexFor(unsigned int tablelength, unsigned int hashvalue) {
@@ -41,6 +42,7 @@ indexFor(unsigned int tablelength, unsigned int hashvalue)
     return (hashvalue & (tablelength - 1u));
 }
 */
+#endif
 
 /*****************************************************************************/
 #define freekey(X) free(X)

--- a/src/language.c
+++ b/src/language.c
@@ -16,6 +16,8 @@
 
 #include "ccache.h"
 
+#include "language.h"
+
 // Supported file extensions and corresponding languages (as in parameter to
 // the -x option).
 static const struct {

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -168,7 +168,7 @@
 #include <config.h>
 #endif	/* HAVE_CONFIG_H */
 
-#if TEST_SNPRINTF
+#ifdef TEST_SNPRINTF
 #include <math.h>	/* For pow(3), NAN, and INFINITY. */
 #include <string.h>	/* For strcmp(3). */
 #if defined(__NetBSD__) || \
@@ -1574,7 +1574,7 @@ rpl_asprintf(va_alist) va_dcl
 int main(void);
 #endif	/* !HAVE_SNPRINTF || !HAVE_VSNPRINTF || !HAVE_ASPRINTF || [...] */
 
-#if TEST_SNPRINTF
+#ifdef TEST_SNPRINTF
 int
 main(void)
 {

--- a/src/stats.c
+++ b/src/stats.c
@@ -445,7 +445,7 @@ stats_get_pending(enum stats stat)
 
 // Sum and display the total stats for all cache dirs.
 void
-stats_summary(struct conf *conf)
+stats_summary(void)
 {
 	struct counters *counters = counters_init(STATS_END);
 	time_t updated = 0;

--- a/src/unify.c
+++ b/src/unify.c
@@ -218,8 +218,8 @@ unify(struct mdfour *hash, unsigned char *p, size_t size)
 			unsigned char q = p[ofs];
 			int i;
 			for (i = 0; i < tokens[q].num_toks; i++) {
-				unsigned char *s = (unsigned char *)tokens[q].toks[i];
-				int len = strlen((char *)s);
+				const unsigned char *s = (const unsigned char *)tokens[q].toks[i];
+				int len = strlen((const char *)s);
 				if (size >= ofs+len && memcmp(&p[ofs], s, len) == 0) {
 					int j;
 					for (j = 0; s[j]; j++) {

--- a/src/util.c
+++ b/src/util.c
@@ -578,7 +578,7 @@ format_hash_as_string(const unsigned char *hash, int size)
 	return ret;
 }
 
-char const CACHEDIR_TAG[] =
+static char const CACHEDIR_TAG[] =
   "Signature: 8a477f597d28d172789f06886806bc55\n"
   "# This file is a cache directory tag created by ccache.\n"
   "# For information about cache directory tags, see:\n"

--- a/src/util.c
+++ b/src/util.c
@@ -99,6 +99,8 @@ path_max(const char *path)
 #endif
 }
 
+static void warn_log_fail(void) ATTR_NORETURN;
+
 // Warn about failure writing to the log file and then exit.
 static void
 warn_log_fail(void)

--- a/unittest/framework.c
+++ b/unittest/framework.c
@@ -211,8 +211,8 @@ cct_check_int_eq(const char *file, int line, const char *expression,
 
 bool
 cct_check_str_eq(const char *file, int line, const char *expression,
-                 const char *expected, const char *actual, bool free1,
-                 bool free2)
+                 char *expected, char *actual,
+		 bool free1, bool free2)
 {
 	bool result;
 
@@ -229,10 +229,10 @@ cct_check_str_eq(const char *file, int line, const char *expression,
 	}
 
 	if (free1) {
-		free((char *)expected);
+		free(expected);
 	}
 	if (free2) {
-		free((char *)actual);
+		free(actual);
 	}
 	return result;
 }

--- a/unittest/framework.h
+++ b/unittest/framework.h
@@ -22,6 +22,7 @@
 // ============================================================================
 
 #define TEST_SUITE(name) \
+	extern unsigned suite_##name(unsigned _start_point); \
 	unsigned suite_##name(unsigned _start_point) \
 	{ \
 		unsigned _test_counter = 0; \

--- a/unittest/framework.h
+++ b/unittest/framework.h
@@ -140,8 +140,8 @@ bool cct_check_float_eq(const char *file, int line, const char *expression,
 bool cct_check_int_eq(const char *file, int line, const char *expression,
                       int64_t expected, int64_t actual);
 bool cct_check_str_eq(const char *file, int line, const char *expression,
-                      const char *expected, const char *actual, bool free1,
-                      bool free2);
+                      char *expected, char *actual,
+		      bool free1, bool free2);
 bool cct_check_args_eq(const char *file, int line, const char *expression,
                        struct args *expected, struct args *actual,
                        bool free1, bool free2);

--- a/unittest/main.c
+++ b/unittest/main.c
@@ -27,7 +27,7 @@
 #undef SUITE
 // *INDENT-ON* enable uncrustify
 
-const char USAGE_TEXT[] =
+static const char USAGE_TEXT[] =
   "Usage:\n"
   "    test [options]\n"
   "\n"

--- a/unittest/test_compopt.c
+++ b/unittest/test_compopt.c
@@ -24,7 +24,7 @@ TEST_SUITE(compopt)
 
 TEST(option_table_should_be_sorted)
 {
-	bool compopt_verify_sortedness();
+	extern bool compopt_verify_sortedness(void);
 	CHECK(compopt_verify_sortedness());
 }
 

--- a/unittest/test_conf.c
+++ b/unittest/test_conf.c
@@ -21,7 +21,7 @@
 #define N_CONFIG_ITEMS 32
 static struct {
 	char *descr;
-	const char *origin;
+	char *origin;
 } received_conf_items[N_CONFIG_ITEMS];
 static size_t n_received_conf_items = 0;
 
@@ -30,7 +30,7 @@ conf_item_receiver(const char *descr, const char *origin, void *context)
 {
 	(void)context;
 	received_conf_items[n_received_conf_items].descr = x_strdup(descr);
-	received_conf_items[n_received_conf_items].origin = origin;
+	received_conf_items[n_received_conf_items].origin = x_strdup(origin);
 	++n_received_conf_items;
 }
 
@@ -40,6 +40,7 @@ free_received_conf_items(void)
 	while (n_received_conf_items > 0) {
 		--n_received_conf_items;
 		free(received_conf_items[n_received_conf_items].descr);
+		free(received_conf_items[n_received_conf_items].origin);
 	}
 }
 


### PR DESCRIPTION
`./configure --enable-more-warnings`

Address most warnings, except those about conversion between float/double and int32_t/int64_t.

We also get some warnings from included system headers, that we need to suppress (for `-Werror`)

Now passes `gcc -Wextra` (including pedantic) and `clang -Weverything` (with some exceptions)