### PR TITLE
Add configure option for silent make rules

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,3 +1,5 @@
+verbose = @verbose@
+
 srcdir = @srcdir@
 builddir = @builddir@
 VPATH = @srcdir@
@@ -23,6 +25,11 @@ RANLIB = @RANLIB@
 all_cflags = $(CFLAGS)
 all_cppflags = @DEFS@ -DSYSCONFDIR=$(sysconfdir) -I. -I$(srcdir)/src -I$(builddir)/unittest $(CPPFLAGS)
 extra_libs = @extra_libs@
+
+v_at_0 = yes
+v_at_ = $(v_at_$(verbose))
+quiet := $(v_at_$(V))
+Q=$(if $(quiet),@)
 
 non_3pp_sources = \
     src/args.c \
@@ -95,7 +102,8 @@ files_to_distclean = Makefile config.h config.log config.status
 all: ccache$(EXEEXT)
 
 ccache$(EXEEXT): $(ccache_objs) $(extra_libs)
-	$(CC) $(all_cflags) -o $@ $(ccache_objs) $(LDFLAGS) $(extra_libs) $(LIBS)
+	$(if $(quiet),@echo "    [LD] $@")
+	$(Q)$(CC) $(all_cflags) -o $@ $(ccache_objs) $(LDFLAGS) $(extra_libs) $(LIBS)
 
 ccache.1: doc/ccache.1
 	cp $< $@
@@ -116,8 +124,10 @@ conf.c: confitems_lookup.c envtoconfitems_lookup.c
 $(zlib_objs): CPPFLAGS += -include config.h
 
 src/zlib/libz.a: $(zlib_objs)
-	$(AR) cr $@ $(zlib_objs)
-	$(RANLIB) $@
+	$(if $(quiet),@echo "    [AR] $@")
+	$(Q)$(AR) cr $@ $(zlib_objs)
+	$(if $(quiet),@echo "    [RANLIB] $@")
+	$(Q)$(RANLIB) $@
 
 .PHONY: perf
 perf: ccache$(EXEEXT)
@@ -133,12 +143,14 @@ unittest: unittest/run$(EXEEXT)
 	unittest/run$(EXEEXT)
 
 unittest/run$(EXEEXT): $(base_objs) $(test_objs) $(extra_libs)
-	$(CC) $(all_cflags) -o $@ $(base_objs) $(test_objs) $(LDFLAGS) $(extra_libs) $(LIBS)
+	$(if $(quiet),@echo "    [LD] $@")
+	$(Q)$(CC) $(all_cflags) -o $@ $(base_objs) $(test_objs) $(LDFLAGS) $(extra_libs) $(LIBS)
 
 unittest/main.o: unittest/suites.h
 
 unittest/suites.h: $(test_suites) Makefile
-	ls $^ | grep -v Makefile | xargs sed -n 's/TEST_SUITE(\(.*\))/SUITE(\1)/p' >$@
+	$(if $(quiet),@echo "    [GEN] $@")
+	$(Q)ls $^ | grep -v Makefile | xargs sed -n 's/TEST_SUITE(\(.*\))/SUITE(\1)/p' >$@
 
 .PHONY: check
 check: test
@@ -153,6 +165,7 @@ installcheck: ccache$(EXEEXT) unittest/run$(EXEEXT)
 	CCACHE=$(bindir)/ccache CC='$(CC)' $(BASH) $(srcdir)/test/run
 
 .c.o:
-	$(CC) $(all_cppflags) $(all_cflags) -c -o $@ $<
+	$(if $(quiet),@echo "    [CC] $@")
+	$(Q)$(CC) $(all_cppflags) $(all_cflags) -c -o $@ $<
 
 @include_dev_mk@

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,16 @@ case $host in
         ;;
 esac
 
+AC_ARG_ENABLE([silent-rules],
+  [AS_HELP_STRING([--enable-silent-rules],
+    [less verbose build output (undo: `make V=1')])])
+case $enable_silent_rules in
+	 yes) verbose=0;;
+	 no)  verbose=1;;
+	 *)   verbose=1;;
+esac
+
+AC_SUBST(verbose)
 AC_SUBST(extra_libs)
 AC_SUBST(getopt_long_c)
 AC_SUBST(include_dev_mk)


### PR DESCRIPTION
Adopted from AM_SILENT_RULES, default to no

``` console
$ make V=0
    [CC] src/main.o
    [CC] src/args.o
    [CC] src/ccache.o
    [CC] src/cleanup.o
    [CC] src/compopt.o
    [CC] src/conf.o
    [CC] src/counters.o
    [CC] src/execute.o
    [CC] src/exitfn.o
    [CC] src/hash.o
    [CC] src/hashutil.o
    [CC] src/language.o
    [CC] src/lockfile.o
    [CC] src/manifest.o
    [CC] src/mdfour.o
    [CC] src/stats.o
    [CC] src/unify.o
    [CC] src/util.o
    [CC] src/version.o
    [CC] src/hashtable.o
    [CC] src/hashtable_itr.o
    [CC] src/murmurhashneutral2.o
    [CC] src/snprintf.o
    [LD] ccache
```

https://www.gnu.org/software/automake/manual/html_node/Automake-Silent-Rules.html