### PR TITLE
Fix missing header include / prototype

### DIFF
--- a/src/unify.c
+++ b/src/unify.c
@@ -29,6 +29,7 @@
 
 #include "ccache.h"
 #include "hash.h"
+#include "unify.h"
 
 static bool print_unified = true;
 


### PR DESCRIPTION
`no previous prototype for function 'unify_hash'`

When running with `--enable-more-warnings` that is