### PR TITLE
Fix the build on IBM i / PASE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,7 @@ case $host in
         ;;
     *os400* | *aix*)
         AR="ar -X64"
+        ;;
 esac
 
 AC_SUBST(disable_man)

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,8 @@ case $host in
         windows_os=yes
         AC_DEFINE(_WIN32_WINNT,0x0600, Windows Vista or newer is required)
         ;;
+    *os400* | *aix*)
+        AR="ar -X64"
 esac
 
 AC_SUBST(disable_man)

--- a/src/lockfile.c
+++ b/src/lockfile.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2018 Joel Rosdahl
+// Copyright (C) 2010-2019 Joel Rosdahl
 //
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the Free
@@ -15,13 +15,6 @@
 // Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include "ccache.h"
-
-// AIX/PASE does not properly define usleep within its headers, however, the
-// function is available in libc.a. This extern define ensures it is usable 
-// within the ccache code base.
-#ifdef _AIX
-	extern int              usleep(useconds_t);
-#endif
 
 // This function acquires a lockfile for the given path. Returns true if the
 // lock was acquired, otherwise false. If the lock has been considered stale

--- a/src/lockfile.c
+++ b/src/lockfile.c
@@ -16,6 +16,13 @@
 
 #include "ccache.h"
 
+// AIX/PASE does not properly define usleep within its headers, however, the
+// function is available in libc.a. This extern define ensures it is usable 
+// within the ccache code base.
+#ifdef _AIX
+	extern int              usleep(useconds_t);
+#endif
+
 // This function acquires a lockfile for the given path. Returns true if the
 // lock was acquired, otherwise false. If the lock has been considered stale
 // for the number of microseconds specified by staleness_limit, the function

--- a/src/system.h
+++ b/src/system.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2016 Joel Rosdahl
+// Copyright (C) 2010-2019 Joel Rosdahl
 //
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the Free
@@ -47,6 +47,13 @@
 #include <time.h>
 #include <unistd.h>
 #include <utime.h>
+
+// AIX/PASE does not properly define usleep within its headers. However, the
+// function is available in libc.a. This extern define ensures that it is
+// usable within the ccache code base.
+#ifdef _AIX
+extern int usleep(useconds_t);
+#endif
 
 extern char **environ;
 


### PR DESCRIPTION
ccache building was broken on IBM i/PASE.

PASE is the Unix subsystem within IBM i (which is a development of the legacy OS/400 product line). PASE is binary compatible with AIX, however, subtle differences exist due to the operating system not being Unix-like _at all_. Applications which compile and run also run on IBM i, and most source trees which build on AIX will also build on IBM i.

The build was broken on IBM i for two reasons:

_ar needs -X64 on AIX and i_
`ar` on AIX and IBM i needs to explicitly define if the archive being created is for 32 or for 64 bit code. When this parameter is not specified, `ar` on AIX and IBM i fails hard without any output since GCC on AIX and IBM i does not rely on binutils for `ld` and `ar`.  I have updated the `configure.ac` script to check if it's being run on IBM i (which identifies as `OS400` through `uname`) or AIX and then use the right parameter. I've defaulted on `-X64` because 32 bit code is only rarely being used anymore and should not be used anymore for new applications. 

_IBM i does not properly define usleep_
The `usleep()` routine is available in PASE/IBM i since it's a direct port of AIX, however, it is not directly accessible due to the PASE headers not including the right definition. This PR adds an ifdef to add this extern so the linker fixes this up automatically.

