### PR TITLE
Skip '-index-store-path' when building with Xcode

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -550,6 +550,11 @@ still has to do _some_ preprocessing (like macros).
     <<_precompiled_headers,PRECOMPILED HEADERS>> for more information.
 *time_macros*::
     Ignore `__DATE__` and `__TIME__` being present in the source code.
+*clang_index_store*::
+    Ignore the Clang compiler option *-index-store-path* and its argument when
+    computing the manifest hash. This is useful if you use Xcode, which uses an
+    index store path derived from the local project path. Note that the index
+    store won't be updated correctly on cache hits if you enable this option.
 --
 +
 See the discussion under <<_troubleshooting,TROUBLESHOOTING>> for more

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2779,7 +2779,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			continue;
 		}
 
-		if (conf->sloppiness & SLOPPY_NO_CLANG_INDEX_STORE) {
+		if (conf->sloppiness & SLOPPY_CLANG_INDEX_STORE) {
 			// Xcode 9 or later calls clang with this option.
 			// The given path has a UUID path which might break the manifest
 			// especially when cache is shared among multple machines.

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2779,6 +2779,13 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			continue;
 		}
 
+		// Xcode 9 or later clang
+		if (str_eq(argv[i], "-index-store-path")) {
+			i++;
+			cc_log("Skip argument -index-store-path %s", argv[i]);
+			continue;
+		}
+
 		// Options taking an argument that we may want to rewrite to relative paths
 		// to get better hit rate. A secondary effect is that paths in the standard
 		// error output produced by the compiler will be normalized.

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2779,11 +2779,15 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			continue;
 		}
 
-		// Xcode 9 or later clang
-		if (str_eq(argv[i], "-index-store-path")) {
-			i++;
-			cc_log("Skip argument -index-store-path %s", argv[i]);
-			continue;
+		if (conf->sloppiness & SLOPPY_NO_CLANG_INDEX_STORE) {
+			// Xcode 9 or later calls clang with this option.
+			// The given path has a UUID path which might break the manifest
+			// especially when cache is shared among multple machines.
+			if (str_eq(argv[i], "-index-store-path")) {
+				i++;
+				cc_log("Skip argument -index-store-path %s", argv[i]);
+				continue;
+			}
 		}
 
 		// Options taking an argument that we may want to rewrite to relative paths

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -100,7 +100,7 @@ extern enum guessed_compiler guessed_compiler;
 #define SLOPPY_FILE_STAT_MATCHES_CTIME 128
 // Allow us to not include -index-store-path option in the manifest,
 // so that ccache can use with Xcode build.
-#define SLOPPY_NO_CLANG_INDEX_STORE 256
+#define SLOPPY_CLANG_INDEX_STORE 256
 
 #define str_eq(s1, s2) (strcmp((s1), (s2)) == 0)
 #define str_startswith(s, prefix) \

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -98,6 +98,9 @@ extern enum guessed_compiler guessed_compiler;
 // Allow us to ignore ctimes when comparing file stats, so we can fake mtimes
 // if we want to (it is much harder to fake ctimes, requires changing clock)
 #define SLOPPY_FILE_STAT_MATCHES_CTIME 128
+// Allow us to not include -index-store-path option in the manifest,
+// so that ccache can use with Xcode build.
+#define SLOPPY_NO_CLANG_INDEX_STORE 256
 
 #define str_eq(s1, s2) (strcmp((s1), (s2)) == 0)
 #define str_startswith(s, prefix) \

--- a/src/confitems.c
+++ b/src/confitems.c
@@ -136,8 +136,8 @@ confitem_parse_sloppiness(const char *str, void *result, char **errmsg)
 			*value |= SLOPPY_PCH_DEFINES;
 		} else if (str_eq(word, "time_macros")) {
 			*value |= SLOPPY_TIME_MACROS;
-		} else if (str_eq(word, "no_clang_index_store")) {
-			*value |= SLOPPY_NO_CLANG_INDEX_STORE;
+		} else if (str_eq(word, "clang_index_store")) {
+			*value |= SLOPPY_CLANG_INDEX_STORE;
 		} else {
 			*errmsg = format("unknown sloppiness: \"%s\"", word);
 			free(p);
@@ -178,8 +178,8 @@ confitem_format_sloppiness(void *value)
 	if (*sloppiness & SLOPPY_NO_SYSTEM_HEADERS) {
 		reformat(&s, "%sno_system_headers, ", s);
 	}
-	if (*sloppiness & SLOPPY_NO_CLANG_INDEX_STORE) {
-		reformat(&s, "%sno_clang_index_store, ", s);
+	if (*sloppiness & SLOPPY_CLANG_INDEX_STORE) {
+		reformat(&s, "%sclang_index_store, ", s);
 	}	
 	if (*sloppiness) {
 		// Strip last ", ".

--- a/src/confitems.c
+++ b/src/confitems.c
@@ -136,6 +136,8 @@ confitem_parse_sloppiness(const char *str, void *result, char **errmsg)
 			*value |= SLOPPY_PCH_DEFINES;
 		} else if (str_eq(word, "time_macros")) {
 			*value |= SLOPPY_TIME_MACROS;
+		} else if (str_eq(word, "no_clang_index_store")) {
+			*value |= SLOPPY_NO_CLANG_INDEX_STORE;
 		} else {
 			*errmsg = format("unknown sloppiness: \"%s\"", word);
 			free(p);
@@ -176,6 +178,9 @@ confitem_format_sloppiness(void *value)
 	if (*sloppiness & SLOPPY_NO_SYSTEM_HEADERS) {
 		reformat(&s, "%sno_system_headers, ", s);
 	}
+	if (*sloppiness & SLOPPY_NO_CLANG_INDEX_STORE) {
+		reformat(&s, "%sno_clang_index_store, ", s);
+	}	
 	if (*sloppiness) {
 		// Strip last ", ".
 		s[strlen(s) - 2] = '\0';

--- a/unittest/test_conf.c
+++ b/unittest/test_conf.c
@@ -130,7 +130,7 @@ TEST(conf_read_valid_config)
 		"read_only_direct = true\n"
 		"recache = true\n"
 		"run_second_cpp = false\n"
-		"sloppiness =     file_macro   ,time_macros,  include_file_mtime,include_file_ctime,file_stat_matches,file_stat_matches_ctime,pch_defines ,  no_system_headers  \n"
+		"sloppiness =     file_macro   ,time_macros,  include_file_mtime,include_file_ctime,file_stat_matches,file_stat_matches_ctime,pch_defines ,  no_system_headers,no_clang_index_store\n"
 		"stats = false\n"
 		"temporary_dir = ${USER}_foo\n"
 		"umask = 777\n"
@@ -172,7 +172,7 @@ TEST(conf_read_valid_config)
 	CHECK_INT_EQ(SLOPPY_INCLUDE_FILE_MTIME|SLOPPY_INCLUDE_FILE_CTIME|
 	             SLOPPY_FILE_MACRO|SLOPPY_TIME_MACROS|
 	             SLOPPY_FILE_STAT_MATCHES|SLOPPY_FILE_STAT_MATCHES_CTIME|
-	             SLOPPY_NO_SYSTEM_HEADERS|SLOPPY_PCH_DEFINES,
+	             SLOPPY_NO_SYSTEM_HEADERS|SLOPPY_PCH_DEFINES|SLOPPY_NO_CLANG_INDEX_STORE,
 	             conf->sloppiness);
 	CHECK(!conf->stats);
 	CHECK_STR_EQ_FREE1(format("%s_foo", user), conf->temporary_dir);
@@ -462,7 +462,7 @@ TEST(conf_print_items)
 		SLOPPY_FILE_MACRO|SLOPPY_INCLUDE_FILE_MTIME|
 		SLOPPY_INCLUDE_FILE_CTIME|SLOPPY_TIME_MACROS|
 		SLOPPY_FILE_STAT_MATCHES|SLOPPY_FILE_STAT_MATCHES_CTIME|
-		SLOPPY_PCH_DEFINES|SLOPPY_NO_SYSTEM_HEADERS,
+		SLOPPY_PCH_DEFINES|SLOPPY_NO_SYSTEM_HEADERS|SLOPPY_NO_CLANG_INDEX_STORE,
 		false,
 		"td",
 		022,
@@ -513,7 +513,7 @@ TEST(conf_print_items)
 	CHECK_STR_EQ("run_second_cpp = false", received_conf_items[n++].descr);
 	CHECK_STR_EQ("sloppiness = file_macro, include_file_mtime,"
 	             " include_file_ctime, time_macros, pch_defines,"
-	             " file_stat_matches, file_stat_matches_ctime, no_system_headers",
+	             " file_stat_matches, file_stat_matches_ctime, no_system_headers, no_clang_index_store",
 	             received_conf_items[n++].descr);
 	CHECK_STR_EQ("stats = false", received_conf_items[n++].descr);
 	CHECK_STR_EQ("temporary_dir = td", received_conf_items[n++].descr);

--- a/unittest/test_conf.c
+++ b/unittest/test_conf.c
@@ -130,7 +130,7 @@ TEST(conf_read_valid_config)
 		"read_only_direct = true\n"
 		"recache = true\n"
 		"run_second_cpp = false\n"
-		"sloppiness =     file_macro   ,time_macros,  include_file_mtime,include_file_ctime,file_stat_matches,file_stat_matches_ctime,pch_defines ,  no_system_headers,no_clang_index_store\n"
+		"sloppiness =     file_macro   ,time_macros,  include_file_mtime,include_file_ctime,file_stat_matches,file_stat_matches_ctime,pch_defines ,  no_system_headers,clang_index_store\n"
 		"stats = false\n"
 		"temporary_dir = ${USER}_foo\n"
 		"umask = 777\n"
@@ -172,7 +172,7 @@ TEST(conf_read_valid_config)
 	CHECK_INT_EQ(SLOPPY_INCLUDE_FILE_MTIME|SLOPPY_INCLUDE_FILE_CTIME|
 	             SLOPPY_FILE_MACRO|SLOPPY_TIME_MACROS|
 	             SLOPPY_FILE_STAT_MATCHES|SLOPPY_FILE_STAT_MATCHES_CTIME|
-	             SLOPPY_NO_SYSTEM_HEADERS|SLOPPY_PCH_DEFINES|SLOPPY_NO_CLANG_INDEX_STORE,
+	             SLOPPY_NO_SYSTEM_HEADERS|SLOPPY_PCH_DEFINES|SLOPPY_CLANG_INDEX_STORE,
 	             conf->sloppiness);
 	CHECK(!conf->stats);
 	CHECK_STR_EQ_FREE1(format("%s_foo", user), conf->temporary_dir);
@@ -462,7 +462,7 @@ TEST(conf_print_items)
 		SLOPPY_FILE_MACRO|SLOPPY_INCLUDE_FILE_MTIME|
 		SLOPPY_INCLUDE_FILE_CTIME|SLOPPY_TIME_MACROS|
 		SLOPPY_FILE_STAT_MATCHES|SLOPPY_FILE_STAT_MATCHES_CTIME|
-		SLOPPY_PCH_DEFINES|SLOPPY_NO_SYSTEM_HEADERS|SLOPPY_NO_CLANG_INDEX_STORE,
+		SLOPPY_PCH_DEFINES|SLOPPY_NO_SYSTEM_HEADERS|SLOPPY_CLANG_INDEX_STORE,
 		false,
 		"td",
 		022,
@@ -513,7 +513,7 @@ TEST(conf_print_items)
 	CHECK_STR_EQ("run_second_cpp = false", received_conf_items[n++].descr);
 	CHECK_STR_EQ("sloppiness = file_macro, include_file_mtime,"
 	             " include_file_ctime, time_macros, pch_defines,"
-	             " file_stat_matches, file_stat_matches_ctime, no_system_headers, no_clang_index_store",
+	             " file_stat_matches, file_stat_matches_ctime, no_system_headers, clang_index_store",
 	             received_conf_items[n++].descr);
 	CHECK_STR_EQ("stats = false", received_conf_items[n++].descr);
 	CHECK_STR_EQ("temporary_dir = td", received_conf_items[n++].descr);


### PR DESCRIPTION
This option is used to enable 'Indexing while Building' in Xcode9,
which does not affect the build output.

The reason we have to skip it is it introduces a path contains
uuid, for example:

-index-store-path /Users/lanya/Library/Developer/Xcode/DerivedData/NEUer-bjvoyplxzoxgkpgkiodfvurkgzwn/Index/DataStore

This causes build command is different between builds. So skip it in manifest hashing.