### PR TITLE
Handle bug where clang doesn't unlink output file

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1242,6 +1242,9 @@ to_cache(struct args *args)
 	args_add(args, "-o");
 	args_add(args, output_obj);
 
+	if (conf->hard_link)
+		x_unlink(output_obj);
+
 	if (generating_diagnostics) {
 		args_add(args, "--serialize-diagnostics");
 		args_add(args, output_dia);


### PR DESCRIPTION
When using assembler, clang doesn't unlink output.

On the other hand, gcc seems to handle this fine ?

Closes #331