### PR TITLE
Add missing getopt_long.c source file to dist

### DIFF
--- a/dev.mk.in
+++ b/dev.mk.in
@@ -89,6 +89,7 @@ source_dist_files = \
     src/confitems_lookup.c \
     src/envtoconfitems.gperf \
     src/envtoconfitems_lookup.c \
+    src/getopt_long.c \
     src/main.c \
     src/zlib/*.c \
     src/zlib/*.h \


### PR DESCRIPTION
Missed to include this, when making compilation optional

Closes #340