### PR TITLE
Fix clang warning with older compiler versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,7 +236,7 @@ cat <<EOF >config.h.tmp
 #define CCACHE_CONFIG_H
 #ifdef __clang__
 #pragma clang diagnostic push
-#if __clang_major__ >= 4
+#if __has_warning("-Wreserved-id-macro")
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 #endif
 #endif


### PR DESCRIPTION
Don't hardcode the clang version, apparently clang-3.8
did have the warning even though clang-3.4 did not...