### PR TITLE
Spelling

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2915,7 +2915,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		    && str_eq(argv[i], "-index-store-path")) {
 			// Xcode 9 or later calls Clang with this option. The given path includes
 			// a UUID that might lead to cache misses, especially when cache is
-			// shared among multple users.
+			// shared among multiple users.
 			i++;
 			if (i <= argc - 1) {
 				cc_log("Skipping argument -index-store-path %s", argv[i]);

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -3304,7 +3304,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		args_add(*compiler_args, arch_args[i]);
 	}
 
-	// Only pass dependency arguments to the preprocesor since Intel's C++
+	// Only pass dependency arguments to the preprocessor since Intel's C++
 	// compiler doesn't produce a correct .d file when compiling preprocessed
 	// source.
 	args_extend(cpp_args, dep_args);

--- a/src/compopt.c
+++ b/src/compopt.c
@@ -208,7 +208,7 @@ compopt_takes_concat_arg(const char *option)
 bool
 compopt_prefix_affects_cpp(const char *option)
 {
-	// Prefix options have to take concatentated args.
+	// Prefix options have to take concatenated args.
 	const struct compopt *co = find_prefix(option);
 	return co && (co->type & TAKES_CONCAT_ARG) && (co->type & AFFECTS_CPP);
 }

--- a/src/conf.c
+++ b/src/conf.c
@@ -187,7 +187,7 @@ conf_free(struct conf *conf)
 
 // Note: The path pointer is stored in conf, so path must outlive conf.
 //
-// On failure, if an I/O error occured errno is set approriately, otherwise
+// On failure, if an I/O error occured errno is set appropriately, otherwise
 // errno is set to zero indicating that config itself was invalid.
 bool
 conf_read(struct conf *conf, const char *path, char **errmsg)

--- a/unittest/test_argument_processing.c
+++ b/unittest/test_argument_processing.c
@@ -366,7 +366,7 @@ TEST(fprofile_flag_with_existing_dir_should_be_rewritten_to_real_path)
 	args_free(orig);
 }
 
-TEST(fprofile_flag_with_nonexisting_dir_should_not_be_rewritten)
+TEST(fprofile_flag_with_nonexistent_dir_should_not_be_rewritten)
 {
 	struct args *orig = args_init_from_string(
 		"gcc -c -fprofile-generate=some/dir foo.c");

--- a/unittest/test_compopt.c
+++ b/unittest/test_compopt.c
@@ -45,7 +45,7 @@ TEST(dash_V_doesnt_affect_cpp)
 	CHECK(!compopt_affects_cpp("-V"));
 }
 
-TEST(dash_doesnexist_doesnt_affect_cpp)
+TEST(dash_doesntexist_doesnt_affect_cpp)
 {
 	CHECK(!compopt_affects_cpp("-doesntexist"));
 }
@@ -90,7 +90,7 @@ TEST(dash_fstack_usage_not_too_hard)
 	CHECK(!compopt_too_hard("-fstack-usage"));
 }
 
-TEST(dash_doesnexist_not_too_hard)
+TEST(dash_doesntexist_not_too_hard)
 {
 	CHECK(!compopt_too_hard("-doesntexist"));
 }


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`

I can rewrite the commit messages if that's a problem (or squash them if requested).

The vast majority are comments, with a couple being names of tests.
I think all of the changes are correct, but I could be wrong.