### PR TITLE
Allow treating "/dev/null" as an input file

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -3044,8 +3044,12 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 
 		// If an argument isn't a plain file then assume its an option, not an
 		// input file. This allows us to cope better with unusual compiler options.
+		//
+		// NOTE that "/dev/null" is an exception that is sometimes used as an input
+		// file when code is testing compiler flags.
 		struct stat st;
-		if (stat(argv[i], &st) != 0 || !S_ISREG(st.st_mode)) {
+		if (!str_eq(argv[i], "/dev/null") &&
++		    (stat(argv[i], &st) != 0 || !S_ISREG(st.st_mode))) {
 			cc_log("%s is not a regular file, not considering as input file",
 			       argv[i]);
 			args_add(stripped_args, argv[i]);


### PR DESCRIPTION
One of the slow things for incremental Linux kernel builds is that
during the single-threaded parsing stage of the Makefile the kernel
calls into the C compiler to test which options the compiler supports.
A lot.  Specifically there are snippets like this all over the
Makefile:

$(call cc-option,-Oz,-Os)

...which translates into a call to the C compiler:

${CC} ... -Oz -c -x c /dev/null -o .178435.tmp

One of the contributing factors to the overall slowness is that the
input file for this test is "/dev/null".  This trips a check in ccache
because "/dev/null" "isn't a plain file".

As far as I understand it it should be totally fine to cache the
result of compiling "/dev/null".  It's basically just compiling an
empty file.

On my setup this improves the parsing stage of the kernel Makefile
from 3.25 seconds to 2.0 seconds (so saves 1.25 seconds for each of
build, install, and modules_install for 3.75 seconds total).