### PR TITLE
Enable generating relative paths in dependency file in depend mode.

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1040,7 +1040,7 @@ use_relative_paths_in_depfile(const char *depfile)
 		cc_log("Base dir not set, skip using relative paths");
 		return; // nothing to do
 	}
-	if (!has_absolute_include_headers) {
+	if (!has_absolute_include_headers && !conf->depend_mode) {
 		cc_log("No absolute path for included files found, skip using relative"
 		       " paths");
 		return; // nothing to do

--- a/test/suites/depend.bash
+++ b/test/suites/depend.bash
@@ -67,6 +67,14 @@ SUITE_depend() {
     expect_stat 'files in cache' 3
 
     # -------------------------------------------------------------------------
+    TEST "Dependency file paths converted to relative if CCACHE_BASEDIR specified"
+        
+    CCACHE_DEPEND=1 CCACHE_BASEDIR="`pwd`" $CCACHE_COMPILE $DEPSFLAGS_CCACHE -c "`pwd`/test.c"
+    if grep -q "[^.]/test.c" "test.d"; then
+        test_failed "Dependency file does not contain relative path to test.c"
+    fi
+
+    # -------------------------------------------------------------------------
     TEST "stderr from both preprocessor and compiler"
 
     cat <<EOF >cpp-warning.c


### PR DESCRIPTION
This was previously only done if preprocessor was run.

Added test case.