### PR TITLE
Include the presence of "-fxxx-prefix-map=" options in the hash

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1950,15 +1950,22 @@ calculate_object_hash(struct args *args, struct hash *hash, int direct_mode)
 		}
 
 		// The -fdebug-prefix-map option may be used in combination with
-		// CCACHE_BASEDIR to reuse results across different directories. Skip it
-		// from hashing.
+		// CCACHE_BASEDIR to reuse results across different directories. Skip using
+		// the value of the option from hashing but still hash the existence of the
+		// option.
 		if (str_startswith(args->argv[i], "-fdebug-prefix-map=")) {
+			hash_delimiter(hash, "arg");
+			hash_string(hash, "-fdebug-prefix-map=");
 			continue;
 		}
 		if (str_startswith(args->argv[i], "-ffile-prefix-map=")) {
+			hash_delimiter(hash, "arg");
+			hash_string(hash, "-ffile-prefix-map=");
 			continue;
 		}
 		if (str_startswith(args->argv[i], "-fmacro-prefix-map=")) {
+			hash_delimiter(hash, "arg");
+			hash_string(hash, "-fmacro-prefix-map=");
 			continue;
 		}
 


### PR DESCRIPTION
Recently I landed commit 980e032d14ba ("Allow treating "/dev/null" as
an input file (#365)") which sped up my kernel build a bunch.

Unfortunately I tested my change in isolation on the newest ccache
(AKA I constructed a simple test case and saw that it worked).  I only
tested it together with the Linux kernel when backported to an older
version of ccache.  A bit later I managed to get the newer version of
ccache fully integrated into my build system and tested my path there.
Then I noticed a problem because the new ccache contained the commit
919af39ccaca ("Support gcc-8 -ffile-prefix-map")

Specifically my compiler doesn't support the
-fmacro-prefix-map=... option and thus my change and the ccache change
to support -fmacro-prefix-map caused caused my kernel build to fail.
It couldn't detect that -fmacro-prefix-map wasn't supported.  The
kernel effectively will make these two calls:

  $(CC) $(opts)
  $(CC) $(opts) -fmacro-prefix-map=...

Since the newer ccache doesn't use "-fmacro-prefix-map=" when
computing its hash it will return the cached results from the first
call: AKA no compiler error.  Now the kernel Makefile will decide that
the "-fmacro-prefix-map=" is supported and will continue to use it,
which is bad.

It seems like an easy fix to all this is to add the _presence_ of the
"-fxxx-prefix-map=" options into the hash.  Those that want to use
these options to reuse cache objects still can--they just need to make
sure that none of the invocations of the compiler totally omit the
option.