### PR TITLE
Improve CMake+CUDA compatibility: add "cu" language, recognize -dc as compilation only argument

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -3183,7 +3183,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		goto out;
 	}
 
-	if (!conf->run_second_cpp && str_eq(actual_language, "cuda")) {
+	if (!conf->run_second_cpp && str_eq(actual_language, "cu")) {
 		cc_log("Using CUDA compiler; not compiling preprocessed code");
 		conf->run_second_cpp = true;
 	}

--- a/src/language.c
+++ b/src/language.c
@@ -88,6 +88,7 @@ static const struct {
 	{"objc++-cpp-output",        "objective-c++-cpp-output"},
 	{"objective-c++-header",     "objective-c++-cpp-output"},
 	{"objective-c++-cpp-output", "objective-c++-cpp-output"},
+	{"cu"  ,                     "cuda-output"},
 	{"cuda",                     "cuda-output"},
 	{"assembler-with-cpp",       "assembler"},
 	{"assembler",                "assembler"},

--- a/src/language.c
+++ b/src/language.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2018 Joel Rosdahl and other contributors
+// Copyright (C) 2010-2019 Joel Rosdahl and other contributors
 //
 // See doc/AUTHORS.adoc for a complete list of contributors.
 //
@@ -64,8 +64,7 @@ static const struct {
 	{".HXX", "c++-header"},
 	{".tcc", "c++-header"},
 	{".TCC", "c++-header"},
-	{".cu",  "cuda"},
-	{".ic",  "cuda-output"},
+	{".cu",  "cu"},
 	{NULL,  NULL}
 };
 
@@ -80,6 +79,7 @@ static const struct {
 	{"c++",                      "c++-cpp-output"},
 	{"c++-cpp-output",           "c++-cpp-output"},
 	{"c++-header",               "c++-cpp-output"},
+	{"cu",                       "cpp-output"},
 	{"objective-c",              "objective-c-cpp-output"},
 	{"objective-c-header",       "objective-c-cpp-output"},
 	{"objc-cpp-output",          "objective-c-cpp-output"},
@@ -88,8 +88,6 @@ static const struct {
 	{"objc++-cpp-output",        "objective-c++-cpp-output"},
 	{"objective-c++-header",     "objective-c++-cpp-output"},
 	{"objective-c++-cpp-output", "objective-c++-cpp-output"},
-	{"cu"  ,                     "cuda-output"},
-	{"cuda",                     "cuda-output"},
 	{"assembler-with-cpp",       "assembler"},
 	{"assembler",                "assembler"},
 	{NULL,  NULL}

--- a/test/suites/nvcc.bash
+++ b/test/suites/nvcc.bash
@@ -53,7 +53,7 @@ nvcc_tests() {
     # instead of comparing the binary object files, we compare the dumps of
     # "cuobjdump -all -elf -symbols -ptx -sass test1.o".
     nvcc_opts_cpp="-Wno-deprecated-gpu-targets -c --x c++"
-    nvcc_opts_cuda="-Wno-deprecated-gpu-targets -c"
+    nvcc_opts_cuda="-Wno-deprecated-gpu-targets -c -x cu"
     nvcc_opts_gpu1="--generate-code arch=compute_50,code=compute_50"
     nvcc_opts_gpu2="--generate-code arch=compute_52,code=sm_52"
     ccache_nvcc_cpp="$CCACHE $REAL_NVCC $nvcc_opts_cpp"
@@ -127,6 +127,26 @@ nvcc_tests() {
     expect_stat 'files in cache' 3
     $cuobjdump test_cuda.o > test1.dump
     expect_equal_files reference_test3.dump test1.dump
+    
+    # -------------------------------------------------------------------------
+    TEST "Option -dc"
+    
+    $REAL_NVCC $nvcc_opts_cuda -dc -o reference_test4.o test_cuda.cu
+    $cuobjdump reference_test4.o > reference_test4.dump
+
+    $ccache_nvcc_cuda -dc -o test_cuda.o test_cuda.cu
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+    $cuobjdump test_cuda.o > test4.dump
+    expect_equal_files test4.dump reference_test4.dump
+
+    $ccache_nvcc_cuda -dc -o test_cuda.o test_cuda.cu
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+    $cuobjdump test_cuda.o > test4.dump
+    expect_equal_files test4.dump reference_test4.dump
 
     # -------------------------------------------------------------------------
     TEST "Different defines"


### PR DESCRIPTION
Hi, I was trying to use ccache from a CMake project to compile CUDA files and ran into two issues:

First, CMake always passes `-x cu` to NVCC. This is recognized by ccache as an explicit language setting, but the language "cu" is not understood by ccache. The first commit add the "cu" language as an alias to "cuda".

Second, we use [separable compilation](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#using-separate-compilation-in-cuda) which requires CMake to pass the `-dc` or `--device-c` option. This option as stated [here](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-specifying-compilation-phase-device-c) implies the `-c` option already.
Previously, the `-c` option was missing and ccache didn't cache the compiled files. The second commit makes ccache accept `-dc`  instead of `-c` if the compiler is recognized as NVCC.

I don't know if this is The Right Way™ to repair this, but it definitely fixes my use case.