### PR TITLE
Add possibility to export manifest as json

### DIFF
--- a/misc/check-manifest.py
+++ b/misc/check-manifest.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import json
+import hashlib
+
+try:
+    md4 = hashlib.md4
+except AttributeError:
+    from Crypto.Hash.MD4 import MD4Hash as md4
+except ImportError:
+    raise Error("please install pycrypto")
+
+
+def hash(file):
+    return md4(file.read()).hexdigest()
+
+mf = json.load(open(sys.argv[1]))
+for object in mf['objects']:
+    print "%s-%d" % (object['hash'], object['size'])
+    ok = True
+    sloppy = False
+    for file in object['files']:
+        path = file['path']
+        if os.path.exists(path):
+            st = os.stat(path)
+            if st.st_size != file['size']:
+                status = 'S'
+                reason = " (%d != %d)" % (st.st_size, file['size'])
+            elif sloppy and int(st.st_mtime) != file['mtime']:
+                status = 'M'
+                reason = " (%d != %d)" % (st.st_mtime, file['mtime'])
+            elif sloppy and int(st.st_ctime) != file['ctime']:
+                status = 'C'
+                reason = " (%d != %d)" % (st.st_ctime, file['ctime'])
+            elif hash(open(path)) != file['hash']:
+                status = 'H'
+                reason = " (%s != %s)" % (hash(open(path)), file['hash'])
+            else:
+                status = '-'
+                reason = ""
+        else:
+            status = '?'
+            reason = " (file not found)"
+        print "  %c %s%s" % (status, path, reason)
+        if status != '-':
+            ok = False
+    if ok:
+        print "  = PASS"
+    else:
+        print "  = FAIL"

--- a/misc/manifest.schema
+++ b/misc/manifest.schema
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "integer"
+        },
+        "hash_size": {
+            "type": "integer"
+        },
+        "reserved": {
+            "type": "integer"
+        },
+        "objects": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "files": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "hash": {
+                                    "type": "string"
+                                },
+                                "size": {
+                                    "type": "integer"
+                                },
+                                "mtime": {
+                                    "type": "integer"
+                                },
+                                "ctime": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "path",
+                                "hash",
+                                "size",
+                                "mtime",
+                                "ctime"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "hash": {
+                        "type": "string"
+                    },
+                    "size": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "files",
+                    "hash",
+                    "size"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": [
+        "version",
+        "hash_size",
+        "reserved",
+        "objects"
+    ],
+    "additionalProperties": false
+}

--- a/misc/manifest_schema.py
+++ b/misc/manifest_schema.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# JSON schema for ccache manifest.json
+
+import jsl
+import json
+
+
+class File(jsl.Document):
+    path = jsl.StringField(required=True)
+    hash = jsl.StringField(required=True)
+    size = jsl.IntField(required=True)
+    mtime = jsl.IntField(required=True)
+    ctime = jsl.IntField(required=True)
+
+
+class Object(jsl.Document):
+    files = jsl.ArrayField(jsl.DocumentField(File), required=True)
+    hash = jsl.StringField(required=True)
+    size = jsl.IntField(required=True)
+
+
+class Manifest(jsl.Document):
+    version = jsl.IntField(required=True)
+    hash_size = jsl.IntField(required=True)
+    reserved = jsl.IntField(required=True)
+    objects = jsl.ArrayField(jsl.DocumentField(Object), required=True)
+
+if __name__ == '__main__':
+    schema = Manifest.get_schema(ordered=True)
+    print json.dumps(schema, indent=4).replace(" \n", "\n")

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -4000,6 +4000,7 @@ ccache_main_options(int argc, char *argv[])
 	enum longopts {
 		DUMP_MANIFEST,
 		HASH_FILE,
+		JSON_MANIFEST,
 		PRINT_STATS,
 	};
 	static const struct option options[] = {
@@ -4008,6 +4009,7 @@ ccache_main_options(int argc, char *argv[])
 		{"dump-manifest", required_argument, 0, DUMP_MANIFEST},
 		{"get-config",    required_argument, 0, 'k'},
 		{"hash-file",     required_argument, 0, HASH_FILE},
+		{"json-manifest", required_argument, 0, JSON_MANIFEST},
 		{"help",          no_argument,       0, 'h'},
 		{"max-files",     required_argument, 0, 'F'},
 		{"max-size",      required_argument, 0, 'M'},
@@ -4043,6 +4045,10 @@ ccache_main_options(int argc, char *argv[])
 			hash_free(hash);
 			break;
 		}
+
+		case JSON_MANIFEST:
+			manifest_json(optarg, stdout);
+			break;
 
 		case PRINT_STATS:
 			initialize();

--- a/src/manifest.h
+++ b/src/manifest.h
@@ -11,5 +11,6 @@ struct file_hash *manifest_get(struct conf *conf, const char *manifest_path);
 bool manifest_put(const char *manifest_path, struct file_hash *object_hash,
                   struct hashtable *included_files);
 bool manifest_dump(const char *manifest_path, FILE *stream);
+bool manifest_json(const char *manifest_path, FILE *stream);
 
 #endif

--- a/test/suites/direct.bash
+++ b/test/suites/direct.bash
@@ -860,6 +860,22 @@ EOF
     fi
 
     # -------------------------------------------------------------------------
+    TEST "--json-manifest"
+
+    $CCACHE_COMPILE test.c -c -o test.o
+
+    manifest=`find $CCACHE_DIR -name '*.manifest'`
+    $CCACHE --json-manifest $manifest >manifest.json
+
+    if grep '"hash": "d4de2f956b4a386c6660990a7a1ab13f"' manifest.json >/dev/null 2>&1 && \
+       grep '"hash": "e94ceb9f1b196c387d098a5f1f4fe862"' manifest.json >/dev/null 2>&1 && \
+       grep '"hash": "ba753bebf9b5eb99524bb7447095e2e6"' manifest.json >/dev/null 2>&1; then
+        : OK
+    else
+        test_failed "Unexpected output of --json-manifest"
+    fi
+
+    # -------------------------------------------------------------------------
     TEST "Argument-less -B and -L"
 
     cat <<EOF >test.c


### PR DESCRIPTION
The manifest format is binary and optimized for performance and storage...
When discussing the manifest, it can be useful to export it to simple JSON.

Note that this format potentially duplicates both file strings and file entries.
If you are concerned about that (even for debug output), you can try gzip.

----
Includes sample python program, and a [JSON Schema](http://json-schema.org/) for the format used.