### PR TITLE
Correctly handle @file on Windows

### DIFF
--- a/src/ccache.h
+++ b/src/ccache.h
@@ -252,7 +252,7 @@ void wipe_all(struct conf *conf);
 // ----------------------------------------------------------------------------
 // execute.c
 
-int execute(char **argv, int fd_out, int fd_err, pid_t *pid);
+int realexecute(char **argv, int fd_out, int fd_err, pid_t *pid);
 char *find_executable(const char *name, const char *exclude_name);
 void print_command(FILE *fp, char **argv);
 char *format_command(char **argv);
@@ -289,10 +289,10 @@ typedef int (*COMPAR_FN_T)(const void *, const void *);
 #endif
 
 #ifdef _WIN32
-char *win32argvtos(char *prefix, char **argv);
+char *win32argvtos(char *prefix, char **argv, int *length);
 char *win32getshell(char *path);
 int win32execute(char *path, char **argv, int doreturn,
-                 int fd_stdout, int fd_stderr);
+                 int fd_stdout, int fd_stderr, bool use_atfile);
 void add_exe_ext_if_no_to_fullpath(char *full_path_win_ext, size_t max_size,
                                    const char *ext, const char *path);
 #    ifndef _WIN32_WINNT
@@ -302,13 +302,14 @@ void add_exe_ext_if_no_to_fullpath(char *full_path_win_ext, size_t max_size,
 #    define mkdir(a,b) mkdir(a)
 #    define link(src,dst) (CreateHardLink(dst,src,NULL) ? 0 : -1)
 #    define lstat(a,b) stat(a,b)
-#    define execv(a,b) win32execute(a,b,0,-1,-1)
-#    define execute(a,b,c,d) win32execute(*(a),a,1,b,c)
+#    define execv(a,b) win32execute(a,b,0,-1,-1,false)
+#    define execute(a,b,c,d,e) win32execute(*(a),a,1,b,c,e)
 #    define DIR_DELIM_CH '\\'
 #    define PATH_DELIM ";"
 #    define F_RDLCK 0
 #    define F_WRLCK 0
 #else
+#    define execute(a,b,c,d,e) realexecute(a,b,c,d)
 #    define DIR_DELIM_CH '/'
 #    define PATH_DELIM ":"
 #endif

--- a/src/hashutil.c
+++ b/src/hashutil.c
@@ -212,7 +212,8 @@ hash_command_output(struct hash *hash, const char *command,
 
 	char *win32args;
 	if (!cmd) {
-		win32args = win32argvtos(sh, args->argv);
+                int length;
+		win32args = win32argvtos(sh, args->argv, &length);
 	} else {
 		win32args = (char *)command;  // quoted
 	}


### PR DESCRIPTION
the @file syntax means that the process reads command arguments from the
specified file. this is commonly used in order to shorten commands which
would otherwise be longer than the maximum length limit: many build systems
do this in all cases to avoid hitting this limit.

when @file is used on Windows, the original arguments must be preserved exactly
without any modification; this means that expansion can occur, but the original
args must be passed through in the command in order to continue using the
@file syntax

fixes #95