### PR TITLE
 correctly handle @file syntax on Windows

### DIFF
--- a/src/ccache.h
+++ b/src/ccache.h
@@ -289,7 +289,7 @@ typedef int (*COMPAR_FN_T)(const void *, const void *);
 #endif
 
 #ifdef _WIN32
-char *win32argvtos(char *prefix, char **argv);
+char *win32argvtos(char *prefix, char **argv, int *length);
 char *win32getshell(char *path);
 int win32execute(char *path, char **argv, int doreturn,
                  int fd_stdout, int fd_stderr);

--- a/src/execute.c
+++ b/src/execute.c
@@ -26,10 +26,11 @@ find_executable_in_path(const char *name, const char *exclude_name, char *path);
 // Re-create a win32 command line string based on **argv.
 // http://msdn.microsoft.com/en-us/library/17w5ykft.aspx
 char *
-win32argvtos(char *prefix, char **argv)
+win32argvtos(char *prefix, char **argv, int *length)
 {
 	int i = 0;
 	int k = 0;
+        *length = 0;
 	char *arg = prefix ? prefix : argv[i++];
 	do {
 		int bs = 0;
@@ -54,6 +55,7 @@ win32argvtos(char *prefix, char **argv)
 	if (!str) {
 		return NULL;
 	}
+        *length = k;
 
 	i = 0;
 	arg = prefix ? prefix : argv[i++];
@@ -162,7 +164,8 @@ win32execute(char *path, char **argv, int doreturn,
 		}
 	}
 
-	char *args = win32argvtos(sh, argv);
+	int length;
+	char *args = win32argvtos(sh, argv, &length);
 	const char *ext = strrchr(path, '.');
 	char full_path_win_ext[MAX_PATH] = {0};
 	add_exe_ext_if_no_to_fullpath(full_path_win_ext, MAX_PATH, ext, path);

--- a/src/hashutil.c
+++ b/src/hashutil.c
@@ -212,7 +212,8 @@ hash_command_output(struct hash *hash, const char *command,
 
 	char *win32args;
 	if (!cmd) {
-		win32args = win32argvtos(sh, args->argv);
+		int length;
+		win32args = win32argvtos(sh, args->argv, &length);
 	} else {
 		win32args = (char *)command;  // quoted
 	}


### PR DESCRIPTION
the @file syntax means that the process reads command arguments from the
specified file. this is commonly used in order to shorten commands which
would otherwise be longer than the maximum length limit: many build systems
do this in all cases to avoid hitting this limit.

when a command exceeds 8192 characters on on Windows, ccache now writes
the parsed/modified arguments to a tmpfile and then runs the command using
that tmpfile with @tmpfile in order to preserve this mechanism and avoid hitting
the length limit

fixes #95