### PR TITLE
Fix NULL argument in profile directory trace

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2972,7 +2972,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 					result = false;
 					goto out;
 				} else if (arg_profile_dir) {
-					cc_log("Setting profile directory to %s", profile_dir);
+					cc_log("Setting profile directory to %s", arg_profile_dir);
 					profile_dir = x_strdup(arg_profile_dir);
 				}
 				continue;


### PR DESCRIPTION
With -fprofile-*=path, we currently print :
"Setting profile directory to (null)".

This fixes the build with gcc 9, which failed with :
error: ‘%s’ directive argument is null [-Werror=format-overflow=]