### PR TITLE
Make sure to cache the missing dep file

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2043,10 +2043,15 @@ calculate_object_hash(struct args *args, struct hash *hash, int direct_mode)
 				hash_delimiter(hash, "arg");
 				hash_string_buffer(hash, args->argv[i], 3);
 
-				bool separate_argument = (strlen(args->argv[i]) == 3);
-				if (separate_argument) {
-					// Next argument is dependency name, so skip it.
-					i++;
+				if (!str_eq(output_dep, "/dev/null")) {
+					bool separate_argument = (strlen(args->argv[i]) == 3);
+					if (separate_argument) {
+						// Next argument is dependency name, so skip it.
+						i++;
+					}
+				} else {
+					// Hash that we don't have a .d file.
+					hash_string(hash, output_dep);
 				}
 				continue;
 			}

--- a/test/suites/direct.bash
+++ b/test/suites/direct.bash
@@ -453,6 +453,22 @@ EOF
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
 
+    $CCACHE_COMPILE -c -MD -MF test.d test.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+    expect_stat 'files in cache' 5
+    expect_equal_files test.d expected.d
+
+    rm -f test.d
+
+    $CCACHE_COMPILE -c -MD -MF test.d test.c
+    expect_stat 'cache hit (direct)' 2
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+    expect_stat 'files in cache' 5
+    expect_equal_files test.d expected.d
+
     # -------------------------------------------------------------------------
     TEST "Missing .d file"
 


### PR DESCRIPTION
If we first run with -MF /dev/null, then we will get a
"cache file missing" error on the next run - avoid that.

Make sure to cache the special /dev/null value, so that
it differs from the normal (ignored) dep file name...

From #397