### PR TITLE
Misc. source comment and documentation typos

### DIFF
--- a/doc/DEVELOPER.md
+++ b/doc/DEVELOPER.md
@@ -21,7 +21,7 @@ script:
     misc/combine-trace-files *.o.ccache-trace | gzip > ccache.trace.gz
 
 (The gzip step is optional; Chrome supports both plain trace files and gzipped
-trace files.) The script will offset each invididual trace by its start time in
+trace files.) The script will offset each individual trace by its start time in
 the combined file.
 
 There is also a script called `summarize-trace-files` that generates a summary

--- a/doc/NEWS.adoc
+++ b/doc/NEWS.adoc
@@ -34,7 +34,7 @@ Changes
 
 - Compilations with /dev/null as the input file are now cached.
 
-- ccache has learned how to contruct the object filename if no `-o` option is
+- ccache has learned how to construct the object filename if no `-o` option is
   given and the source filename does not include a `.` or ends with a `.`.
 
 - Fixed a temporary file leak when the depend mode is enabled and the compiler

--- a/m4/feature_macros.m4
+++ b/m4/feature_macros.m4
@@ -5,25 +5,25 @@ dnl For license information, see
 dnl <http://www.python.org/download/releases/2.6.2/license/>.
 dnl ===========================================================================
 
-# The later defininition of _XOPEN_SOURCE disables certain features
+# The later definition of _XOPEN_SOURCE disables certain features
 # on Linux, so we need _GNU_SOURCE to re-enable them (makedev, tm_zone).
 AC_DEFINE(_GNU_SOURCE, 1, [Define on Linux to activate all library features])
 
-# The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
+# The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on NetBSD, so we need _NETBSD_SOURCE to re-enable
 # them.
 AC_DEFINE(_NETBSD_SOURCE, 1, [Define on NetBSD to activate all library features])
 
-# The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
+# The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on FreeBSD, so we need __BSD_VISIBLE to re-enable
 # them.
 AC_DEFINE(__BSD_VISIBLE, 1, [Define on FreeBSD to activate all library features])
 
-# The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
+# The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # u_int on Irix 5.3. Defining _BSD_TYPES brings it back.
 AC_DEFINE(_BSD_TYPES, 1, [Define on Irix to enable u_int])
 
-# The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
+# The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on Mac OS X, so we need _DARWIN_C_SOURCE to re-enable
 # them.
 AC_DEFINE(_DARWIN_C_SOURCE, 1, [Define on Darwin to activate all library features])

--- a/m4/feature_macros.m4
+++ b/m4/feature_macros.m4
@@ -5,25 +5,25 @@ dnl For license information, see
 dnl <http://www.python.org/download/releases/2.6.2/license/>.
 dnl ===========================================================================
 
-# The later definition of _XOPEN_SOURCE disables certain features
+# The later defininition of _XOPEN_SOURCE disables certain features
 # on Linux, so we need _GNU_SOURCE to re-enable them (makedev, tm_zone).
 AC_DEFINE(_GNU_SOURCE, 1, [Define on Linux to activate all library features])
 
-# The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
+# The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on NetBSD, so we need _NETBSD_SOURCE to re-enable
 # them.
 AC_DEFINE(_NETBSD_SOURCE, 1, [Define on NetBSD to activate all library features])
 
-# The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
+# The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on FreeBSD, so we need __BSD_VISIBLE to re-enable
 # them.
 AC_DEFINE(__BSD_VISIBLE, 1, [Define on FreeBSD to activate all library features])
 
-# The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
+# The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # u_int on Irix 5.3. Defining _BSD_TYPES brings it back.
 AC_DEFINE(_BSD_TYPES, 1, [Define on Irix to enable u_int])
 
-# The later definition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
+# The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on Mac OS X, so we need _DARWIN_C_SOURCE to re-enable
 # them.
 AC_DEFINE(_DARWIN_C_SOURCE, 1, [Define on Darwin to activate all library features])

--- a/src/conf.c
+++ b/src/conf.c
@@ -192,7 +192,7 @@ conf_free(struct conf *conf)
 
 // Note: The path pointer is stored in conf, so path must outlive conf.
 //
-// On failure, if an I/O error occured errno is set appropriately, otherwise
+// On failure, if an I/O error occurred errno is set appropriately, otherwise
 // errno is set to zero indicating that config itself was invalid.
 bool
 conf_read(struct conf *conf, const char *path, char **errmsg)


### PR DESCRIPTION
Found via `codespell -q 3 -L uint,thru -S ./src/zlib`