### PR TITLE
Update the correct stats file, for manifest

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -499,6 +499,9 @@ stats_flush(void)
 
 	free(subdir);
 	counters_free(counters);
+
+	free(counter_updates);
+	counter_updates = NULL;
 }
 
 // Update a normal stat.


### PR DESCRIPTION
There are global variables used for updating stats,
and those were wrong for the manifest file update.

So make sure to reset those variables, before adding
the manifest (this means flushing the pending updates)

Closes #402