### PR TITLE
Allow using BLAKE2b checksum instead of bundled MD4

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -150,7 +150,7 @@ test: ccache$(EXEEXT) unittest/run$(EXEEXT)
 	$(if $(quiet),@echo "  TEST     unittest/run$(EXEEXT)")
 	$(Q)unittest/run$(EXEEXT)
 	$(if $(quiet),@echo "  TEST     $(srcdir)/test/run")
-	$(Q)CC='$(CC)' $(BASH) $(srcdir)/test/run
+	$(Q)CC='$(CC)' @ccache_checksum@$(BASH) $(srcdir)/test/run
 
 .PHONY: unittest
 unittest: unittest/run$(EXEEXT)

--- a/configure.ac
+++ b/configure.ac
@@ -178,6 +178,19 @@ if test x${enable_tracing} = xyes; then
     extra_sources="src/minitrace.c"
 fi
 
+
+ccache_checksum='CCACHE_CHECKSUM=md4 '
+AC_ARG_ENABLE(blake2,
+  [AS_HELP_STRING([--enable-blake2],
+    [use blake2b checksum instead of md4])])
+if test x${enable_blake2} = xyes; then
+    CPPFLAGS="$CPPFLAGS -DUSE_BLAKE2"
+    ccache_checksum='CCACHE_CHECKSUM=blake2b '
+    AC_CHECK_HEADERS(blake2.h)
+    AC_CHECK_LIB([b2],[blake2b])
+fi
+AC_SUBST(ccache_checksum)
+
 dnl Linking on Windows needs ws2_32
 if test x${windows_os} = xyes; then
     LIBS="$LIBS -lws2_32"

--- a/test/run
+++ b/test/run
@@ -234,6 +234,8 @@ run_suite() {
 TEST() {
     CURRENT_TEST=$1
 
+    checksum=$CCACHE_CHECKSUM
+
     while read name; do
         unset $name
     done <<EOF
@@ -246,6 +248,9 @@ EOF
     export CCACHE_DIR=$ABS_TESTDIR/.ccache
     export CCACHE_LOGFILE=$ABS_TESTDIR/ccache.log
     export CCACHE_NODIRECT=1
+
+    # export current checksum used
+    export CCACHE_CHECKSUM=$checksum
 
     # Many tests backdate files, which updates their ctimes. In those tests, we
     # must ignore ctimes. Might as well do so everywhere.

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -1061,8 +1061,18 @@ EOF
     $CCACHE --hash-file /dev/null > hash.out
     printf "a" | $CCACHE --hash-file - >> hash.out
 
-    if grep '31d6cfe0d16ae931b73c59d7e0c089c000000000' hash.out >/dev/null && \
-       grep 'bde52cb31de33e46245e05fbdbd6fb2400000001' hash.out >/dev/null; then
+    if [ "$CCACHE_CHECKSUM" = "blake2b" ]; then
+        hash_0='3345524abf6bbe1809449224b5972c41790b6cf2'
+        hash_1='948caa2db61bc4cdb4faf7740cd491f195043914'
+    elif [ "$CCACHE_CHECKSUM" = "md4" ]; then
+        hash_0='31d6cfe0d16ae931b73c59d7e0c089c000000000'
+        hash_1='bde52cb31de33e46245e05fbdbd6fb2400000001'
+    else
+        test_failed "unknown checksum: $CCACHE_CHECKSUM"
+    fi
+
+    if grep "$hash_0" hash.out >/dev/null 2>&1 && \
+       grep "$hash_1" hash.out >/dev/null 2>&1; then
         : OK
     else
         test_failed "Unexpected output of --hash-file"

--- a/test/suites/direct.bash
+++ b/test/suites/direct.bash
@@ -883,9 +883,21 @@ EOF
     manifest=`find $CCACHE_DIR -name '*.manifest'`
     $CCACHE --dump-manifest $manifest >manifest.dump
 
-    if grep 'Hash: d4de2f956b4a386c6660990a7a1ab13f0000001e' manifest.dump >/dev/null && \
-       grep 'Hash: e94ceb9f1b196c387d098a5f1f4fe8620000000b' manifest.dump >/dev/null && \
-       grep 'Hash: ba753bebf9b5eb99524bb7447095e2e60000000b' manifest.dump >/dev/null; then
+    if [ "$CCACHE_CHECKSUM" = "blake2b" ]; then
+        checksum_test1_h='7706603374730d6e19c22f607768040f13be686d'
+        checksum_test2_h='0f1d0cf7d790a6a31248d8a52e826dad433d191c'
+        checksum_test3_h='d07f2a91a649bc56a1b008279b326201077d341b'
+    elif [ "$CCACHE_CHECKSUM" = "md4" ]; then
+        checksum_test1_h='d4de2f956b4a386c6660990a7a1ab13f'
+        checksum_test2_h='e94ceb9f1b196c387d098a5f1f4fe862'
+        checksum_test3_h='ba753bebf9b5eb99524bb7447095e2e6'
+    else
+        test_failed "unknown checksum: $CCACHE_CHECKSUM"
+    fi
+
+    if grep "Hash: $checksum_test1_h" manifest.dump >/dev/null 2>&1 && \
+       grep "Hash: $checksum_test2_h" manifest.dump >/dev/null 2>&1 && \
+       grep "Hash: $checksum_test3_h" manifest.dump >/dev/null 2>&1; then
         : OK
     else
         test_failed "Unexpected output of --dump-manifest"

--- a/unittest/test_hash.c
+++ b/unittest/test_hash.c
@@ -30,7 +30,11 @@ TEST(test_vectors_from_rfc_1320_should_be_correct)
 		struct hash *h = hash_init();
 		hash_string(h, "");
 		hash_result_as_string(h, d);
+#ifdef USE_BLAKE2
+		CHECK_STR_EQ("3345524abf6bbe1809449224b5972c41790b6cf2", d);
+#else
 		CHECK_STR_EQ("31d6cfe0d16ae931b73c59d7e0c089c000000000", d);
+#endif
 		hash_free(h);
 	}
 
@@ -38,7 +42,11 @@ TEST(test_vectors_from_rfc_1320_should_be_correct)
 		struct hash *h = hash_init();
 		hash_string(h, "a");
 		hash_result_as_string(h, d);
+#ifdef USE_BLAKE2
+		CHECK_STR_EQ("948caa2db61bc4cdb4faf7740cd491f195043914", d);
+#else
 		CHECK_STR_EQ("bde52cb31de33e46245e05fbdbd6fb2400000001", d);
+#endif
 		hash_free(h);
 	}
 
@@ -46,7 +54,11 @@ TEST(test_vectors_from_rfc_1320_should_be_correct)
 		struct hash *h = hash_init();
 		hash_string(h, "message digest");
 		hash_result_as_string(h, d);
+#ifdef USE_BLAKE2
+		CHECK_STR_EQ("6bfec6f65e52962be863d6ea1005fc5e4cc8478c", d);
+#else
 		CHECK_STR_EQ("d9130a8164549fe818874806e1c7014b0000000e", d);
+#endif
 		hash_free(h);
 	}
 
@@ -57,7 +69,11 @@ TEST(test_vectors_from_rfc_1320_should_be_correct)
 			"12345678901234567890123456789012345678901234567890123456789012345678901"
 			"234567890");
 		hash_result_as_string(h, d);
+#ifdef USE_BLAKE2
+		CHECK_STR_EQ("c2be0e534a67d25947f0c7e78527b2f82abd260f", d);
+#else
 		CHECK_STR_EQ("e33b4ddc9c38f2199c3e7b164fcc053600000050", d);
+#endif
 		hash_free(h);
 	}
 }
@@ -70,7 +86,11 @@ TEST(hash_result_should_not_alter_state)
 	hash_result_as_string(h, d);
 	hash_string(h, " digest");
 	hash_result_as_string(h, d);
+#ifdef USE_BLAKE2
+	CHECK_STR_EQ("6bfec6f65e52962be863d6ea1005fc5e4cc8478c", d);
+#else
 	CHECK_STR_EQ("d9130a8164549fe818874806e1c7014b0000000e", d);
+#endif
 	hash_free(h);
 }
 
@@ -79,10 +99,17 @@ TEST(hash_result_should_be_idempotent)
 	char d[DIGEST_STRING_BUFFER_SIZE];
 	struct hash *h = hash_init();
 	hash_string(h, "");
+#ifdef USE_BLAKE2
+	hash_result_as_string(h, d);
+	CHECK_STR_EQ("3345524abf6bbe1809449224b5972c41790b6cf2", d);
+	hash_result_as_string(h, d);
+	CHECK_STR_EQ("3345524abf6bbe1809449224b5972c41790b6cf2", d);
+#else
 	hash_result_as_string(h, d);
 	CHECK_STR_EQ("31d6cfe0d16ae931b73c59d7e0c089c000000000", d);
 	hash_result_as_string(h, d);
 	CHECK_STR_EQ("31d6cfe0d16ae931b73c59d7e0c089c000000000", d);
+#endif
 
 	hash_free(h);
 }
@@ -94,8 +121,13 @@ TEST(hash_result_as_bytes)
 	struct digest d;
 	hash_result_as_bytes(h, &d);
 	uint8_t expected[sizeof(d.bytes)] = {
+#ifdef USE_BLAKE2
+		0x6b, 0xfe, 0xc6, 0xf6, 0x5e, 0x52, 0x96, 0x2b, 0xe8, 0x63, 0xd6, 0xea,
+		0x10, 0x05, 0xfc, 0x5e, 0x4c, 0xc8, 0x47, 0x8c
+#else
 		0xd9, 0x13, 0x0a, 0x81, 0x64, 0x54, 0x9f, 0xe8, 0x18, 0x87, 0x48, 0x06,
 		0xe1, 0xc7, 0x01, 0x4b, 0x00, 0x00, 0x00, 0x0e
+#endif
 	};
 	CHECK_DATA_EQ(d.bytes, expected, sizeof(d.bytes));
 	hash_free(h);


### PR DESCRIPTION
This is mostly for doing performance comparisons, before switching the default checksum.

As discussed, we might want to use more than just 128 bits (out of the available 512 bits).