### PR TITLE
Fix object size verification

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -742,13 +742,13 @@ remember_include_file(char *path, struct hash *cpp_hash, bool system,
 
 		struct file_hash *h = x_malloc(sizeof(*h));
 		hash_result_as_bytes(fhash, h->hash);
-		h->size = hash_input_size(fhash);
+		h->hashed_content_size = hash_input_size(fhash);
 		hashtable_insert(included_files, path, h);
 		path = NULL; // Ownership transferred to included_files.
 
 		if (depend_mode_hash) {
 			hash_delimiter(depend_mode_hash, "include");
-			char *result = format_hash_as_string(h->hash, h->size);
+			char *result = format_hash_as_string(h->hash, h->hashed_content_size);
 			hash_string(depend_mode_hash, result);
 			free(result);
 		}
@@ -1169,7 +1169,7 @@ object_hash_from_depfile(const char *depfile, struct hash *hash)
 
 	struct file_hash *result = x_malloc(sizeof(*result));
 	hash_result_as_bytes(hash, result->hash);
-	result->size = hash_input_size(hash);
+	result->hashed_content_size = hash_input_size(hash);
 	return result;
 }
 
@@ -1366,7 +1366,7 @@ update_manifest_file(void)
 static void
 update_cached_result_globals(struct file_hash *hash)
 {
-	char *object_name = format_hash_as_string(hash->hash, hash->size);
+	char *object_name = format_hash_as_string(hash->hash, hash->hashed_content_size);
 	cached_obj_hash = hash;
 	cached_obj = get_path_in_cache(object_name, ".o");
 	cached_stderr = get_path_in_cache(object_name, ".stderr");
@@ -1728,7 +1728,7 @@ get_object_name_from_cpp(struct args *args, struct hash *hash)
 
 	struct file_hash *result = x_malloc(sizeof(*result));
 	hash_result_as_bytes(hash, result->hash);
-	result->size = hash_input_size(hash);
+	result->hashed_content_size = hash_input_size(hash);
 	return result;
 }
 

--- a/src/hashutil.c
+++ b/src/hashutil.c
@@ -41,7 +41,7 @@ int
 file_hashes_equal(struct file_hash *fh1, struct file_hash *fh2)
 {
 	return memcmp(fh1->hash, fh2->hash, 16) == 0
-	       && fh1->size == fh2->size;
+	       && fh1->hashed_content_size == fh2->hashed_content_size;
 }
 
 // Search for the strings "__DATE__" and "__TIME__" in str.

--- a/src/hashutil.h
+++ b/src/hashutil.h
@@ -24,7 +24,7 @@
 struct file_hash
 {
 	uint8_t hash[16];
-	uint32_t size;
+	uint32_t hashed_content_size;
 };
 
 unsigned hash_from_string(void *str);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -24,22 +24,23 @@
 
 // Sketchy specification of the manifest disk format:
 //
-// <magic>         magic number                        (4 bytes)
-// <version>       file format version                 (1 byte unsigned int)
-// <hash_size>     size of the hash fields (in bytes)  (1 byte unsigned int)
-// <reserved>      reserved for future use             (2 bytes)
+// <magic>                     magic number                        (4 bytes)
+// <version>                   file format version                 (1 byte unsigned int)
+// <hash_size>                 size of the hash fields (in bytes)  (1 byte unsigned int)
+// <reserved>                  reserved for future use             (2 bytes)
 // ----------------------------------------------------------------------------
-// <n>             number of include file paths        (4 bytes unsigned int)
-// <path_0>        path to include file                (NUL-terminated string,
+// <n>                         number of include file paths        (4 bytes unsigned int)
+// <path_0>                    path to include file                (NUL-terminated string,
 // ...                                                  at most 1024 bytes)
 // <path_n-1>
 // ----------------------------------------------------------------------------
-// <n>             number of include file hash entries (4 bytes unsigned int)
-// <index[0]>      index of include file path          (4 bytes unsigned int)
-// <hash[0]>       hash of include file                (<hash_size> bytes)
-// <size[0]>       size of include file                (4 bytes unsigned int)
-// <mtime[0]>      mtime of include file               (8 bytes signed int)
-// <ctime[0]>      ctime of include file               (8 bytes signed int)
+// <n>                         number of include file hash entries (4 bytes unsigned int)
+// <index[0]>                  index of include file path          (4 bytes unsigned int)
+// <hash[0]>                   hash of include file                (<hash_size> bytes)
+// <size[0]>                   size of include file                (8 bytes unsigned int)
+// <hashed_content_size[0]>    bytes passed through hash function  (4 bytes unsigned int)
+// <mtime[0]>                  mtime of include file               (8 bytes signed int)
+// <ctime[0]>                  ctime of include file               (8 bytes signed int)
 // ...
 // <index[n-1]>
 // <hash[n-1]>
@@ -47,16 +48,16 @@
 // <mtime[n-1]>
 // <ctime[n-1]>
 // ----------------------------------------------------------------------------
-// <n>             number of object name entries       (4 bytes unsigned int)
-// <m[0]>          number of include file hash indexes (4 bytes unsigned int)
-// <index[0][0]>   include file hash index             (4 bytes unsigned int)
+// <n>                         number of object name entries       (4 bytes unsigned int)
+// <m[0]>                      number of include file hash indexes (4 bytes unsigned int)
+// <index[0][0]>               include file hash index             (4 bytes unsigned int)
 // ...
 // <index[0][m[0]-1]>
-// <hash[0]>       hash part of object name            (<hash_size> bytes)
-// <size[0]>       size part of object name            (4 bytes unsigned int)
+// <hash[0]>                   hash part of object name            (<hash_size> bytes)
+// <size[0]>                   size part of object name            (4 bytes unsigned int)
 // ...
-// <m[n-1]>        number of include file hash indexes
-// <index[n-1][0]> include file hash index
+// <m[n-1]>                    number of include file hash indexes
+// <index[n-1][0]>             include file hash index
 // ...
 // <index[n-1][m[n-1]]>
 // <hash[n-1]>
@@ -780,8 +781,8 @@ manifest_dump(const char *manifest_path, FILE *stream)
 		hash = format_hash_as_string(mf->file_infos[i].hash, -1);
 		fprintf(stream, "    Hash: %s\n", hash);
 		free(hash);
-		fprintf(stream, "    File size: %lu\n", mf->file_infos[i].size);
-        fprintf(stream, "    Hashed bytes: %u\n", mf->file_infos[i].hashed_content_size);
+		fprintf(stream, "    File size: %"PRIu64"\n", mf->file_infos[i].size);
+		fprintf(stream, "    Hashed bytes: %u\n", mf->file_infos[i].hashed_content_size);
 		fprintf(stream, "    Mtime: %lld\n", (long long)mf->file_infos[i].mtime);
 		fprintf(stream, "    Ctime: %lld\n", (long long)mf->file_infos[i].ctime);
 	}

--- a/src/manifest.h
+++ b/src/manifest.h
@@ -5,7 +5,7 @@
 #include "hashutil.h"
 #include "hashtable.h"
 
-#define MANIFEST_VERSION 1
+#define MANIFEST_VERSION 2
 
 struct file_hash *manifest_get(struct conf *conf, const char *manifest_path);
 bool manifest_put(const char *manifest_path, struct file_hash *object_hash,

--- a/test/suites/depend.bash
+++ b/test/suites/depend.bash
@@ -294,6 +294,29 @@ EOF
     expect_stat 'files in cache' 9
 
     # -------------------------------------------------------------------------
+    TEST "__DATE__ in header file results in direct cache hit as the date remains the same"
 
+    cat <<EOF >test_date2.c
+// test_date2.c
+#include "test_date2.h"
+char date_str[] = MACRO_STRING;
+EOF
+    cat <<EOF >test_date2.h
+#define MACRO_STRING __DATE__
+EOF
+
+    backdate test_date2.c test_date2.h
+
+    CCACHE_DEPEND=1 $CCACHE_COMPILE -MP -MMD -MF test_date2.d -c test_date2.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    CCACHE_DEPEND=1 $CCACHE_COMPILE -MP -MMD -MF test_date2.d -c test_date2.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    # -------------------------------------------------------------------------
     # TODO: Add more test cases (see direct.bash for inspiration)
 }

--- a/test/suites/depend.bash
+++ b/test/suites/depend.bash
@@ -294,29 +294,5 @@ EOF
     expect_stat 'files in cache' 9
 
     # -------------------------------------------------------------------------
-    TEST "__DATE__ in header file results in direct cache hit as the date remains the same"
-
-    cat <<EOF >test_date2.c
-// test_date2.c
-#include "test_date2.h"
-char date_str[] = MACRO_STRING;
-EOF
-    cat <<EOF >test_date2.h
-#define MACRO_STRING __DATE__
-EOF
-
-    backdate test_date2.c test_date2.h
-
-    CCACHE_DEPEND=1 $CCACHE_COMPILE -MP -MMD -MF test_date2.d -c test_date2.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    CCACHE_DEPEND=1 $CCACHE_COMPILE -MP -MMD -MF test_date2.d -c test_date2.c
-    expect_stat 'cache hit (direct)' 1
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    # -------------------------------------------------------------------------
     # TODO: Add more test cases (see direct.bash for inspiration)
 }

--- a/test/suites/direct.bash
+++ b/test/suites/direct.bash
@@ -759,6 +759,30 @@ EOF
     expect_stat 'cache miss' 1
 
     # -------------------------------------------------------------------------
+    TEST "__DATE__ in header file results in direct cache hit as the date remains the same"
+
+    cat <<EOF >test_date2.c
+// test_date2.c
+#include "test_date2.h"
+char date_str[] = MACRO_STRING;
+EOF
+    cat <<EOF >test_date2.h
+#define MACRO_STRING __DATE__
+EOF
+
+    backdate test_date2.c test_date2.h
+
+    $CCACHE_COMPILE -MP -MMD -MF test_date2.d -c test_date2.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    $CCACHE_COMPILE -MP -MMD -MF test_date2.d -c test_date2.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    # -------------------------------------------------------------------------
     TEST "New include file ignored if sloppy"
 
     cat <<EOF >new.c


### PR DESCRIPTION
Changed manifest format to save the actual file size along with hashed content size.
File size field in manifest updated to 64bits.
Manifest version set to 2.

Fixes #382.