### PR TITLE
Implement optional logging to syslog

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,7 @@ AC_HEADER_SYS_WAIT
 AC_CHECK_TYPES(long long)
 
 AC_CHECK_HEADERS(ctype.h pwd.h stdlib.h string.h strings.h sys/time.h sys/mman.h)
+AC_CHECK_HEADERS(syslog.h)
 AC_CHECK_HEADERS(termios.h)
 
 AC_CHECK_FUNCS(gethostname)
@@ -93,6 +94,7 @@ AC_CHECK_FUNCS(realpath)
 AC_CHECK_FUNCS(setenv)
 AC_CHECK_FUNCS(strndup)
 AC_CHECK_FUNCS(strtok_r)
+AC_CHECK_FUNCS(syslog)
 AC_CHECK_FUNCS(unsetenv)
 AC_CHECK_FUNCS(utimes)
 

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -465,6 +465,14 @@ might be incorrect.
     the specified file. This is useful for tracking down problems.
 +
 If set to "syslog", then ccache will log using syslog() instead of a file.
+Then you can use syslogd configuration to filter into a file, example:
++
+-------------------------------------------------------------------------------
+# log ccache to file
+:programname, isequal, "ccache"         /var/log/ccache
+# remove from syslog
+& ~
+-------------------------------------------------------------------------------
 
 *max_files* (*CCACHE_MAXFILES*)::
 

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -463,6 +463,8 @@ might be incorrect.
 
     If set to a file path, ccache will write information on what it is doing to
     the specified file. This is useful for tracking down problems.
++
+If set to "syslog", then ccache will log using syslog() instead of a file.
 
 *max_files* (*CCACHE_MAXFILES*)::
 

--- a/misc/rsyslog.d/00-ccache.conf
+++ b/misc/rsyslog.d/00-ccache.conf
@@ -1,0 +1,2 @@
+:programname, isequal, "ccache"         /var/log/ccache
+& ~


### PR DESCRIPTION
The file logger has some issues with large log lines and many jobs,
so provide the "syslog" alternative when doing the ccache logging.

For #350