### PR TITLE
Add a statsd client, for sending stats over UDP

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -450,6 +450,37 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -------------------------------------------------------------------------------
 
+src/statsd-client.[hc]
+~~~~~~~~~~~~~~~~~~
+
+Trivial statsd client in C, implements the statsd protocol
+Downloaded from <https://github.com/romanbsd/statsd-c-client>.
+
+-------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2012 Roman Shterenzon
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-------------------------------------------------------------------------------
+
 src/snprintf.c and m4/snprintf.m4
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,14 @@ if test x${enable_tracing} = xyes; then
     extra_sources="src/minitrace.c"
 fi
 
+AC_ARG_ENABLE(statsd,
+  [AS_HELP_STRING([--enable-statsd],
+    [enable sending ccache stats to statsd server])])
+if test x${enable_statsd} = xyes; then
+    CPPFLAGS="$CPPFLAGS -DHAVE_STATSD_CLIENT_H=1 -DHAVE_STATSD"
+    extra_sources="$extra_sources src/statsd-client.c"
+fi
+
 dnl Linking on Windows needs ws2_32
 if test x${windows_os} = xyes; then
     LIBS="$LIBS -lws2_32"

--- a/src/statsd-client.c
+++ b/src/statsd-client.c
@@ -1,0 +1,193 @@
+// statsd-c-client
+// Copyright (c) 2012 Roman Shterenzon
+// https://github.com/romanbsd/statsd-c-client
+// Released under the MIT license.
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <netdb.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include "statsd-client.h"
+
+#define MAX_MSG_LEN 100
+
+
+
+statsd_link *statsd_init_with_namespace(const char *host, int port, const char *ns_)
+{
+    if (!host || !port || !ns_)
+        return NULL;
+
+    size_t len = strlen(ns_);
+
+    statsd_link *temp = statsd_init(host, port);
+    if(!temp)
+        return NULL;
+
+    if ( (temp->ns = malloc(len + 2)) == NULL ) {
+        perror("malloc");
+        return NULL;
+    }
+    strcpy(temp->ns, ns_);
+    temp->ns[len++] = '.';
+    temp->ns[len] = 0;
+
+    return temp;
+}
+
+statsd_link *statsd_init(const char *host, int port)
+{
+    if (!host || !port)
+        return NULL;
+    
+    statsd_link *temp = calloc(1, sizeof(statsd_link));
+    if (!temp) {
+        fprintf(stderr, "calloc() failed");
+        goto err;
+    }
+
+    if ((temp->sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
+        perror("socket");
+        goto err;
+    }
+
+    memset(&temp->server, 0, sizeof(temp->server));
+    temp->server.sin_family = AF_INET;
+    temp->server.sin_port = htons(port);
+
+    struct addrinfo *result = NULL, hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_DGRAM;
+
+    int error;
+    if ( (error = getaddrinfo(host, NULL, &hints, &result)) ) {
+        fprintf(stderr, "%s\n", gai_strerror(error));
+        goto err;
+    }
+    memcpy(&(temp->server.sin_addr), &((struct sockaddr_in*)result->ai_addr)->sin_addr, sizeof(struct in_addr));
+    freeaddrinfo(result);
+
+    srandom(time(NULL));
+
+    return temp;
+
+err:
+    if (temp) {
+        free(temp);
+    }
+
+    return NULL;
+}
+
+void statsd_finalize(statsd_link *link)
+{
+    if (!link) return;
+
+    // close socket
+    if (link->sock != -1) {
+        close(link->sock);
+        link->sock = -1;
+    }
+
+    // freeing ns
+    if (link->ns) {
+        free(link->ns);
+        link->ns = NULL;
+    }
+
+    // free whole link
+    free(link);
+}
+
+/* will change the original string */
+static void cleanup(char *stat)
+{
+    char *p;
+    for (p = stat; *p; p++) {
+        if (*p == ':' || *p == '|' || *p == '@') {
+            *p = '_';
+        }
+    }
+}
+
+static int should_send(float sample_rate)
+{
+    if (sample_rate < 1.0) {
+        float p = ((float)random() / RAND_MAX);
+        return sample_rate > p;
+    } else {
+        return 1;
+    }
+}
+
+int statsd_send(statsd_link *link, const char *message)
+{
+    if (!link) return -2;
+    int slen = sizeof(link->server);
+
+    if (sendto(link->sock, message, strlen(message), 0, (struct sockaddr *) &link->server, slen) == -1) {
+        perror("sendto");
+        return -1;
+    }
+    return 0;
+}
+
+static int send_stat(statsd_link *link, char *stat, size_t value, const char *type, float sample_rate)
+{
+    char message[MAX_MSG_LEN];
+    if (!should_send(sample_rate)) {
+        return 0;
+    }
+
+    statsd_prepare(link, stat, value, type, sample_rate, message, MAX_MSG_LEN, 0);
+
+    return statsd_send(link, message);
+}
+
+void statsd_prepare(statsd_link *link, char *stat, size_t value, const char *type, float sample_rate, char *message, size_t buflen, int lf)
+{
+    if (!link) return;
+    
+    cleanup(stat);
+    if (sample_rate == 1.0) {
+        snprintf(message, buflen, "%s%s:%zd|%s%s", link->ns ? link->ns : "", stat, value, type, lf ? "\n" : "");
+    } else {
+        snprintf(message, buflen, "%s%s:%zd|%s|@%.5f%s", link->ns ? link->ns : "", stat, value, type, sample_rate, lf ? "\n" : "");
+    }
+}
+
+/* public interface */
+int statsd_count(statsd_link *link, char *stat, size_t value, float sample_rate)
+{
+    return send_stat(link, stat, value, "c", sample_rate);
+}
+
+int statsd_dec(statsd_link *link, char *stat, float sample_rate)
+{
+    return statsd_count(link, stat, -1, sample_rate);
+}
+
+int statsd_inc(statsd_link *link, char *stat, float sample_rate)
+{
+    return statsd_count(link, stat, 1, sample_rate);
+}
+
+int statsd_gauge(statsd_link *link, char *stat, size_t value)
+{
+    return send_stat(link, stat, value, "g", 1.0);
+}
+
+int statsd_timing(statsd_link *link, char *stat, size_t ms)
+{
+    return statsd_timing_with_sample_rate(link, stat, ms, 1.0);
+}
+
+int statsd_timing_with_sample_rate(statsd_link *link, char *stat, size_t ms, float sample_rate)
+{
+    return send_stat(link, stat, ms, "ms", sample_rate);
+}

--- a/src/statsd-client.h
+++ b/src/statsd-client.h
@@ -1,5 +1,5 @@
-#ifndef _H_STATSD_CLIENT
-#define _H_STATSD_CLIENT
+#ifndef STATSD_CLIENT_H
+#define STATSD_CLIENT_H
 #include <sys/types.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>

--- a/src/statsd-client.h
+++ b/src/statsd-client.h
@@ -1,0 +1,36 @@
+#ifndef _H_STATSD_CLIENT
+#define _H_STATSD_CLIENT
+#include <sys/types.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+
+struct _statsd_link  {
+	struct sockaddr_in server;
+	int sock;
+	char *ns;
+};
+
+typedef struct _statsd_link statsd_link;
+
+
+statsd_link *statsd_init(const char *host, int port);
+statsd_link *statsd_init_with_namespace(const char *host, int port, const char *ns);
+void statsd_finalize(statsd_link *link);
+
+/*
+  write the stat line to the provided buffer,
+  type can be "c", "g" or "ms"
+  lf - whether line feed needs to be added
+ */
+void statsd_prepare(statsd_link *link, char *stat, size_t value, const char *type, float sample_rate, char *buf, size_t buflen, int lf);
+
+/* manually send a message, which might be composed of several lines. Must be null-terminated */
+int statsd_send(statsd_link *link, const char *message);
+
+int statsd_inc(statsd_link *link, char *stat, float sample_rate);
+int statsd_dec(statsd_link *link, char *stat, float sample_rate);
+int statsd_count(statsd_link *link, char *stat, size_t count, float sample_rate);
+int statsd_gauge(statsd_link *link, char *stat, size_t value);
+int statsd_timing(statsd_link *link, char *stat, size_t ms);
+int statsd_timing_with_sample_rate(statsd_link *link, char *stat, size_t ms, float sample_rate);
+#endif


### PR DESCRIPTION
This will send stats to a local "statsd" server

```
{ counters: 
   { 'statsd.bad_lines_seen': 0,
     'statsd.packets_received': 1,
     'statsd.metrics_received': 1,
     'ccache.stats.called_for_preprocessing': 0,
     'ccache.stats.unsupported_compiler_option': 0,
     'ccache.stats.compiler_check_failed': 0,
     'ccache.stats.cache_miss': 1 },
  timers: {},
  gauges: { 'statsd.timestamp_lag': 0 },
  timer_data: {},
  counter_rates: 
   { 'statsd.bad_lines_seen': 0,
     'statsd.packets_received': 0.1,
     'statsd.metrics_received': 0.1,
     'ccache.stats.called_for_preprocessing': 0,
     'ccache.stats.unsupported_compiler_option': 0,
     'ccache.stats.compiler_check_failed': 0,
     'ccache.stats.cache_miss': 0.1 },
  sets: {},
  pctThreshold: [ 90 ] }
```

The local statsd will flush stats to e.g. [graphite](http://graphite.readthedocs.org/)

For details see https://github.com/statsd/statsd

For #262