### PR TITLE
clang's -ftime-trace is too hard

### DIFF
--- a/src/compopt.c
+++ b/src/compopt.c
@@ -69,6 +69,7 @@ static const struct compopt compopts[] = {
 	{"-fno-working-directory", AFFECTS_CPP},
 	{"-fplugin=libcc1plugin", TOO_HARD}, // interaction with GDB
 	{"-frepo",          TOO_HARD},
+	{"-ftime-trace",    TOO_HARD}, // clang
 	{"-fworking-directory", AFFECTS_CPP},
 	{"-gtoggle",        TOO_HARD},
 	{"-idirafter",      AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},


### PR DESCRIPTION
It produces extra .json file with timing information about the compilation.

(https://aras-p.info/blog/2019/01/16/time-trace-timeline-flame-chart-profiler-for-Clang/)
