### PR TITLE
Refactor: save tmp stderr until done storing

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1330,9 +1330,9 @@ copy_file_from_cache(const char *source, const char *dest)
 
 // Send cached stderr, if any, to stderr.
 static void
-send_cached_stderr(void)
+send_cached_stderr(const char *path_stderr)
 {
-	int fd_stderr = open(cached_stderr, O_RDONLY | O_BINARY);
+	int fd_stderr = open(path_stderr, O_RDONLY | O_BINARY);
 	if (fd_stderr != -1) {
 		copy_fd(fd_stderr, 2);
 		close(fd_stderr);
@@ -1574,9 +1574,6 @@ to_cache(struct args *args, struct hash *depend_mode_hash)
 		// If recaching, we need to remove any previous .stderr.
 		x_unlink(cached_stderr);
 	}
-	if (st.st_size == 0 || conf->depend_mode) {
-		tmp_unlink(tmp_stderr);
-	}
 
 	MTR_BEGIN("file", "file_put");
 
@@ -1624,9 +1621,18 @@ to_cache(struct args *args, struct hash *depend_mode_hash)
 	}
 
 	// Everything OK.
-	send_cached_stderr();
+	if (st.st_size > 0) {
+		if (!conf->depend_mode) {
+			send_cached_stderr(cached_stderr);
+		} else {
+			send_cached_stderr(tmp_stderr);
+		}
+	}
 	update_manifest_file();
 
+	if (st.st_size == 0 || conf->depend_mode) {
+		tmp_unlink(tmp_stderr);
+	}
 	free(tmp_stderr);
 	free(tmp_stdout);
 }
@@ -2355,7 +2361,7 @@ from_cache(enum fromcache_call_mode mode, bool put_object_in_manifest)
 		update_mtime(cached_dwo);
 	}
 
-	send_cached_stderr();
+	send_cached_stderr(cached_stderr);
 
 	if (put_object_in_manifest) {
 		update_manifest_file();


### PR DESCRIPTION
We might need it for the alternate codepaths

If not using a standard file store, it might
not be possible to move stderr instead of copy.

For those cases, use the temporary file instead.

---
_Broken out from #408, if not ready for all of it_
_This just restructures the code, for extending..._

_By doing it separately like this, ahead of time,_
_the other changes need to modify less things_