### PR TITLE
Fix possible NULL pointer dereference

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -266,7 +266,7 @@ read_manifest(gzFile f, char **errmsg)
 	return mf;
 
 error:
-	if (!errmsg) {
+	if (!*errmsg) {
 		*errmsg = x_strdup("Corrupt manifest file");
 	}
 	free_manifest(mf);


### PR DESCRIPTION
cppcheck:
  [src/manifest.c:270] -> [src/manifest.c:269]: (warning)
  Either the condition '!errmsg' is redundant or there is possible null pointer
  dereference: errmsg.

### Description ###
PR fixes possible NULL pointer dereference found by cppcheck
