### PR TITLE
Fix dest path with equal char

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     include:
         - os: linux
           compiler: gcc
-          env: CFLAGS="-m32 -g -O2" LDFLAGS="-m32" HOST="--host=i386-linux-gnu"
+          env: CFLAGS="-m32 -g -O2" LDFLAGS="-m32" HOST="--host=i386-linux-gnu" ENABLE_CACHE_CLEANUP_TESTS=1
           addons:
               apt:
                   packages:
@@ -28,7 +28,7 @@ matrix:
                       - lib32z1-dev
         - os: linux
           compiler: i686-w64-mingw32-gcc
-          env: HOST="--host=i686-w64-mingw32" TEST="unittest/run.exe"
+          env: HOST="--host=i686-w64-mingw32" TEST="unittest/run.exe" ENABLE_CACHE_CLEANUP_TESTS=1
           addons:
               apt:
                   packages:
@@ -36,13 +36,13 @@ matrix:
                       - gperf
         - os: linux
           compiler: clang
-          env: CFLAGS="-fsanitize=undefined" LDFLAGS="-fsanitize=undefined" ASAN_OPTIONS="detect_leaks=0"
+          env: CFLAGS="-fsanitize=undefined" LDFLAGS="-fsanitize=undefined" ASAN_OPTIONS="detect_leaks=0" ENABLE_CACHE_CLEANUP_TESTS=1
         - os: linux
           compiler: clang
-          env: CFLAGS="-fsanitize=address -g" LDFLAGS="-fsanitize=address" ASAN_OPTIONS="detect_leaks=0"
+          env: CFLAGS="-fsanitize=address -g" LDFLAGS="-fsanitize=address" ASAN_OPTIONS="detect_leaks=0" ENABLE_CACHE_CLEANUP_TESTS=1
         - os: linux
           compiler: clang
-          env: PATH="/usr/bin:$PATH" TEST=analyze
+          env: PATH="/usr/bin:$PATH" TEST=analyze ENABLE_CACHE_CLEANUP_TESTS=1
           addons:
               apt:
                   packages:
@@ -50,7 +50,7 @@ matrix:
                       - gperf
         - os: linux
           compiler: gcc
-          env: CUDA=8.0.61-1
+          env: CUDA=8.0.61-1 ENABLE_CACHE_CLEANUP_TESTS=1
           sudo: required
           before_install:
               - source ./.travis/install_cuda.sh

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,7 +2,19 @@
 
 set -e
 
-rm -f dev_mode_disabled
+if [ -f dev_mode_disabled ]; then
+    cat <<EOF >&2
+Error: It looks like you are building ccache from a release archive. If so,
+there is no need to run autoconf.sh. See INSTALL.md for further instructions.
+
+If you do want to the enable the development mode, delete the file
+dev_mode_disabled first, but it's probably a better idea to work with the
+proper ccache Git repository directly as described on
+<https://ccache.dev/repo.html>.
+EOF
+    exit 1
+fi
+
 autoheader
 autoconf
 echo "Now run ./configure and make"

--- a/autogen.sh
+++ b/autogen.sh
@@ -5,7 +5,7 @@ set -e
 if [ -f dev_mode_disabled ]; then
     cat <<EOF >&2
 Error: It looks like you are building ccache from a release archive. If so,
-there is no need to run autoconf.sh. See INSTALL.md for further instructions.
+there is no need to run autogen.sh. See INSTALL.md for further instructions.
 
 If you do want to the enable the development mode, delete the file
 dev_mode_disabled first, but it's probably a better idea to work with the

--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,7 @@ fi
 mkdir -p .deps src unittest
 
 dnl Enable developer mode if dev.mk.in exists.
-if test ! -f $srcdir/dev_mode_disabled && test "$RUN_FROM_BUILD_FARM" != yes; then
+if test ! -f $srcdir/dev_mode_disabled; then
     AC_MSG_NOTICE(developer mode enabled)
     AC_CONFIG_FILES([dev.mk])
     include_dev_mk='include dev.mk'

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -22,11 +22,8 @@ version := \
 
 dist_dir = ccache-$(version)
 dist_archives = \
-    ccache-$(version).tar.bz2 \
-    ccache-$(version).tar.gz
-ifneq ($(shell uname), Darwin)
-    dist_archives += ccache-$(version).tar.xz
-endif
+    ccache-$(version).tar.gz \
+    ccache-$(version).tar.xz
 
 generated_docs = \
     LICENSE.html \
@@ -62,7 +59,7 @@ headers = \
 generated_headers = \
     unittest/suites.h
 
-files_to_clean += *.tar.bz2 *.tar.gz *.tar.xz *.xml doc/*.xml .deps/* perfdir.*
+files_to_clean += *.tar.gz *.tar.xz *.xml doc/*.xml .deps/* perfdir.*
 files_to_clean += compile_commands.json
 files_to_clean += src/confitems_lookup.c
 files_to_clean += src/envtoconfitems_lookup.c
@@ -145,7 +142,6 @@ $(dist_archives): $(dist_files)
 	(cd $$tmpdir && \
 	 tarcompression= && \
 	 case $@ in \
-	     *.bz2) tarcompression=-j ;; \
 	     *.gz) tarcompression=-z ;; \
 	     *.xz) tarcompression=-J ;; \
 	 esac && \

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -62,7 +62,7 @@ headers = \
 generated_headers = \
     unittest/suites.h
 
-files_to_clean += *.tar.bz2 *.tar.gz *.tar.xz *.xml .deps/* perfdir.*
+files_to_clean += *.tar.bz2 *.tar.gz *.tar.xz *.xml doc/*.xml .deps/* perfdir.*
 files_to_clean += compile_commands.json
 files_to_clean += src/confitems_lookup.c
 files_to_clean += src/envtoconfitems_lookup.c

--- a/doc/AUTHORS.adoc
+++ b/doc/AUTHORS.adoc
@@ -31,6 +31,7 @@ ccache is a collective work with contributions from many people, including:
 * Havard Graff
 * Hongli Lai
 * Ivan Vaigult
+* Ivan Volnov
 * Jiang Jiang
 * Joel Galenson
 * Joel Rosdahl

--- a/doc/AUTHORS.adoc
+++ b/doc/AUTHORS.adoc
@@ -49,6 +49,7 @@ ccache is a collective work with contributions from many people, including:
 * Leanid Chaika
 * Loïc Yhuel
 * Luboš Luňák
+* luzpaz
 * Maarten Maathuis
 * Mark Starovoytov
 * Martin Ettl

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -8,9 +8,12 @@ To build ccache from a source repository, you need:
 
 - A C compiler (for instance GCC)
 - GNU Bourne Again SHell (bash) for tests.
-- [AsciiDoc](http://www.methods.co.nz/asciidoc/) to build the documentation.
-- [Autoconf](http://www.gnu.org/software/autoconf/)
-- [gperf](http://www.gnu.org/software/gperf/)
+- [AsciiDoc](http://www.methods.co.nz/asciidoc/) to build the HTML
+  documentation.
+- [xsltproc](http://xmlsoft.org/XSLT/xsltproc2.html) to build the man page.
+- [Autoconf](http://www.gnu.org/software/autoconf/) to generate the configure
+  script and related files.
+- [gperf](http://www.gnu.org/software/gperf/) to create lookup tables.
 
 It is also recommended that you have:
 

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -932,8 +932,10 @@ Disadvantages:
   or source code will make the hash different. Compare this with the default
   setup where ccache will fall back to the preprocessor mode, which is tolerant
   to some types of changes of compiler options and source code changes.
-* The manifest entries will include system header files as well, thus slowing
-  down cache hits slightly.
+* (If -MD is used) The manifest entries will include system header files as well,
+  thus slowing down cache hits slightly, just as using -MD slows down make.
+* (If -MMD is used) The manifest entries will not include system header files,
+  which means ccache will ignore changes in them.
 
 The depend mode will be disabled if any of the following holds:
 
@@ -1047,10 +1049,12 @@ things to make it work properly:
 +
 --
 ** use the *-include* compiler option to include the precompiled header
-   (i.e., don't use *#include* in the source code to include the header); or
+   (i.e., don't use *#include* in the source code to include the header),
+   the filename itself must be sufficient to find the header (i.e. -I paths
+   are not searched); or
 ** (for the Clang compiler) use the *-include-pch* compiler option to include
    the PCH file generated from the precompiled header; or
-** add the *-fpch-preprocess* compiler option when compiling.
+** (for the GCC compiler) add the *-fpch-preprocess* compiler option when compiling.
 
 If you don't do this, either the non-precompiled version of the header file
 will be used (if available) or ccache will fall back to running the real

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -932,9 +932,10 @@ Disadvantages:
   or source code will make the hash different. Compare this with the default
   setup where ccache will fall back to the preprocessor mode, which is tolerant
   to some types of changes of compiler options and source code changes.
-* (If -MD is used) The manifest entries will include system header files as well,
-  thus slowing down cache hits slightly, just as using -MD slows down make.
-* (If -MMD is used) The manifest entries will not include system header files,
+* If -MD is used, the manifest entries will include system header files as
+  well, thus slowing down cache hits slightly, just as using -MD slows down
+  make.
+* If -MMD is used, the manifest entries will not include system header files,
   which means ccache will ignore changes in them.
 
 The depend mode will be disabled if any of the following holds:
@@ -1048,13 +1049,14 @@ things to make it work properly:
 * You must either:
 +
 --
-** use the *-include* compiler option to include the precompiled header
-   (i.e., don't use *#include* in the source code to include the header),
-   the filename itself must be sufficient to find the header (i.e. -I paths
-   are not searched); or
+** use the *-include* compiler option to include the precompiled header (i.e.,
+   don't use *#include* in the source code to include the header; the filename
+   itself must be sufficient to find the header, i.e. *-I* paths are not
+   searched); or
 ** (for the Clang compiler) use the *-include-pch* compiler option to include
    the PCH file generated from the precompiled header; or
-** (for the GCC compiler) add the *-fpch-preprocess* compiler option when compiling.
+** (for the GCC compiler) add the *-fpch-preprocess* compiler option when
+   compiling.
 
 If you don't do this, either the non-precompiled version of the header file
 will be used (if available) or ccache will fall back to running the real

--- a/doc/NEWS.adoc
+++ b/doc/NEWS.adoc
@@ -13,8 +13,11 @@ Bug fixes
   e.g. ecryptfs or btrfs/zfs with transparent compression. This also fixes a
   related problem with ccache's own test suite.
 
+- Fixed a regression in 3.7.2 when using the compiler option “-Werror” and then
+  “-Wno-error” later on the command line.
 
-ccache 3.7.2
+
+ccache 4.7.2
 ------------
 Release date: 2019-07-19
 

--- a/doc/NEWS.adoc
+++ b/doc/NEWS.adoc
@@ -1,6 +1,19 @@
 ccache news
 ===========
 
+ccache 3.7.3
+------------
+Unreleased
+
+Bug fixes
+~~~~~~~~~
+
+- The cache size (which is counted in "used disk blocks") is now correct on
+  filesystems that use more or less disk blocks than conventional filesystems,
+  e.g. ecryptfs or btrfs/zfs with transparent compression. This also fixes a
+  related problem with ccache's own test suite.
+
+
 ccache 3.7.2
 ------------
 Release date: 2019-07-19

--- a/doc/NEWS.adoc
+++ b/doc/NEWS.adoc
@@ -3,7 +3,7 @@ ccache news
 
 ccache 3.7.3
 ------------
-Unreleased
+Release date: 2019-08-17
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/NEWS.adoc
+++ b/doc/NEWS.adoc
@@ -17,7 +17,7 @@ Bug fixes
   “-Wno-error” later on the command line.
 
 
-ccache 4.7.2
+ccache 3.7.2
 ------------
 Release date: 2019-07-19
 

--- a/doc/NEWS.adoc
+++ b/doc/NEWS.adoc
@@ -1,6 +1,42 @@
 ccache news
 ===========
 
+ccache 3.7.2
+------------
+Release date: 2019-07-19
+
+Bug fixes
+~~~~~~~~~
+
+- The compiler option `-gdwarf*` no longer forces “run_second_cpp = true”.
+
+- Added verification that the value passed to the `-o/--set-config` option is
+  valid.
+
+- Fixed detection of precompiled headers in the depend mode.
+
+- Bail out on too hard Clang option `-ftime-trace`.
+
+- ccache now updates the correct stats file when adding/updating manifest
+  files. This bug previously made the file and size statistics counters
+  incorrect over time.
+
+- Fixed warnings from Clang about unused arguments during preprocessing.
+
+- Unknown manifest versions are now handled gracefully in `--dump-manifest`.
+
+- Fixed `make check` with “funny” locales.
+
+
+Documentation
+~~~~~~~~~~~~~
+
+- Added a hint about not running `autogen.sh` when building from a release
+  archive.
+
+- Mention that `xsltproc` is needed when building from the source repository.
+
+
 ccache 3.7.1
 ------------
 Release date: 2019-05-01

--- a/doc/NEWS.adoc
+++ b/doc/NEWS.adoc
@@ -8,10 +8,10 @@ Unreleased
 Bug fixes
 ~~~~~~~~~
 
-- The cache size (which is counted in "used disk blocks") is now correct on
+- The cache size (which is counted in “used disk blocks”) is now correct on
   filesystems that use more or less disk blocks than conventional filesystems,
   e.g. ecryptfs or btrfs/zfs with transparent compression. This also fixes a
-  related problem with ccache's own test suite.
+  related problem with ccache's own test suite when run on such file systems.
 
 - Fixed a regression in 3.7.2 when using the compiler option “-Werror” and then
   “-Wno-error” later on the command line.

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -3932,7 +3932,7 @@ ccache(int argc, char *argv[])
 			from_cache(FROMCACHE_DIRECT_MODE, 0);
 
 			// Wasn't able to return from cache at this point. However, the object
-			// was already found in manifest, so don't readd it later.
+			// was already found in manifest, so don't re-add it later.
 			put_object_in_manifest = false;
 
 			object_hash_from_manifest = object_hash;

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -4045,6 +4045,7 @@ ccache_main_options(int argc, char *argv[])
 	       != -1) {
 		switch (c) {
 		case DUMP_MANIFEST:
+			initialize();
 			manifest_dump(optarg, stdout);
 			break;
 

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -695,6 +695,9 @@ remember_include_file(char *path, struct hash *cpp_hash, bool system,
 
 	bool is_pch = is_precompiled_header(path);
 	if (is_pch) {
+		if (!included_pch_file) {
+			cc_log("Detected use of precompiled header: %s", path);
+		}
 		bool using_pch_sum = false;
 		if (conf->pch_external_checksum) {
 			// hash pch.sum instead of pch when it exists
@@ -1161,6 +1164,15 @@ object_hash_from_depfile(const char *depfile, struct hash *hash)
 	}
 
 	fclose(f);
+
+	// Explicitly check the .gch/.pch/.pth file, it may not be mentioned
+	// in the dependencies output.
+	if (included_pch_file) {
+		char *pch_path = x_strdup(included_pch_file);
+		pch_path = make_relative_path(pch_path);
+		hash_string(hash, pch_path);
+		remember_include_file(pch_path, hash, false, NULL);
+	}
 
 	bool debug_included = getenv("CCACHE_DEBUG_INCLUDED");
 	if (debug_included) {

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2497,26 +2497,32 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 	const char *explicit_language = NULL; // As specified with -x.
 	const char *file_language;            // As deduced from file extension.
 	const char *input_charset = NULL;
+
 	// Is the dependency makefile name overridden with -MF?
 	bool dependency_filename_specified = false;
+
 	// Is the dependency makefile target name specified with -MT or -MQ?
 	bool dependency_target_specified = false;
+
 	// Is the dependency target name implicitly specified using
 	// DEPENDENCIES_OUTPUT or SUNPRO_DEPENDENCIES?
 	bool dependency_implicit_target_specified = false;
+
 	// expanded_args is a copy of the original arguments given to the compiler
 	// but with arguments from @file and similar constructs expanded. It's only
 	// used as a temporary data structure to loop over.
 	struct args *expanded_args = args_copy(args);
-	// stripped_args essentially contains all original arguments except those
-	// that only should be passed to the preprocessor (if run_second_cpp is
-	// false) and except dependency options (like -MD and friends).
-	struct args *stripped_args = args_init(0, NULL);
-	// cpp_args contains arguments that were not added to stripped_args, i.e.
-	// those that should only be passed to the preprocessor if run_second_cpp is
-	// false. If run_second_cpp is true, they will be passed to the compiler as
-	// well.
+
+	// common_args essentially contains all original arguments except those that
+	// only should be passed to the preprocessor (if run_second_cpp is false) and
+	// except dependency options (like -MD and friends).
+	struct args *common_args = args_init(0, NULL);
+
+	// cpp_args contains arguments that were not added to common_args, i.e. those
+	// that should only be passed to the preprocessor if run_second_cpp is false.
+	// If run_second_cpp is true, they will be passed to the compiler as well.
 	struct args *cpp_args = args_init(0, NULL);
+
 	// dep_args contains dependency options like -MD. They only passed to the
 	// preprocessor, never to the compiler.
 	struct args *dep_args = args_init(0, NULL);
@@ -2528,7 +2534,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 
 	int argc = expanded_args->argc;
 	char **argv = expanded_args->argv;
-	args_add(stripped_args, argv[0]);
+	args_add(common_args, argv[0]);
 
 	bool result = true;
 	for (int i = 1; i < argc; i++) {
@@ -2540,7 +2546,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 				result = false;
 				goto out;
 			}
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			continue;
 		}
 
@@ -2670,7 +2676,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 
 		// -S changes the default extension.
 		if (str_eq(argv[i], "-S")) {
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			found_S_opt = true;
 			continue;
 		}
@@ -2723,14 +2729,14 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 				(debug_prefix_maps_len + 1) * sizeof(char *));
 			debug_prefix_maps[debug_prefix_maps_len++] =
 				x_strdup(&argv[i][argv[i][2] == 'f' ? 18 : 19]);
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			continue;
 		}
 
 		// Debugging is handled specially, so that we know if we can strip line
 		// number info.
 		if (str_startswith(argv[i], "-g")) {
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 
 			if (str_startswith(argv[i], "-gdwarf")) {
 				// Selection of DWARF format (-gdwarf or -gdwarf-<version>) enables
@@ -2826,29 +2832,29 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		}
 		if (str_eq(argv[i], "-fprofile-arcs")) {
 			profile_arcs = true;
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			continue;
 		}
 		if (str_eq(argv[i], "-ftest-coverage")) {
 			generating_coverage = true;
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			continue;
 		}
 		if (str_eq(argv[i], "-fstack-usage")) {
 			generating_stackusage = true;
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			continue;
 		}
 		if (str_eq(argv[i], "--coverage") // = -fprofile-arcs -ftest-coverage
 		    || str_eq(argv[i], "-coverage")) { // Undocumented but still works.
 			profile_arcs = true;
 			generating_coverage = true;
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			continue;
 		}
 		if (str_startswith(argv[i], "-fprofile-dir=")) {
 			profile_dir = x_strdup(argv[i] + 14);
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			continue;
 		}
 		if (str_startswith(argv[i], "-fsanitize-blacklist=")) {
@@ -2856,13 +2862,13 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 				sanitize_blacklists,
 				(sanitize_blacklists_len + 1) * sizeof(char *));
 			sanitize_blacklists[sanitize_blacklists_len++] = x_strdup(argv[i] + 21);
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			continue;
 		}
 		if (str_startswith(argv[i], "--sysroot=")) {
 			char *relpath = make_relative_path(x_strdup(argv[i] + 10));
 			char *option = format("--sysroot=%s", relpath);
-			args_add(stripped_args, option);
+			args_add(common_args, option);
 			free(relpath);
 			free(option);
 			continue;
@@ -2875,9 +2881,9 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 				result = false;
 				goto out;
 			}
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			char *relpath = make_relative_path(x_strdup(argv[i+1]));
-			args_add(stripped_args, relpath);
+			args_add(common_args, relpath);
 			i++;
 			free(relpath);
 			continue;
@@ -2890,8 +2896,8 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 				result = false;
 				goto out;
 			}
-			args_add(stripped_args, argv[i]);
-			args_add(stripped_args, argv[i+1]);
+			args_add(common_args, argv[i]);
+			args_add(common_args, argv[i+1]);
 			i++;
 			continue;
 		}
@@ -3006,7 +3012,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			}
 
 			if (supported_profile_option) {
-				args_add(stripped_args, arg);
+				args_add(common_args, arg);
 				free(arg);
 
 				// If the profile directory has already been set, give up... Hard to
@@ -3031,17 +3037,17 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		    || str_eq(argv[i], "-fdiagnostics-color=always")
 		    || str_eq(argv[i], "-fno-diagnostics-color")
 		    || str_eq(argv[i], "-fdiagnostics-color=never")) {
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			found_color_diagnostics = true;
 			continue;
 		}
 		if (str_eq(argv[i], "-fdiagnostics-color=auto")) {
 			if (color_output_possible()) {
 				// Output is redirected, so color output must be forced.
-				args_add(stripped_args, "-fdiagnostics-color=always");
+				args_add(common_args, "-fdiagnostics-color=always");
 				cc_log("Automatically forcing colors");
 			} else {
-				args_add(stripped_args, argv[i]);
+				args_add(common_args, argv[i]);
 			}
 			found_color_diagnostics = true;
 			continue;
@@ -3091,8 +3097,8 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 				args_add(cpp_args, argv[i]);
 				args_add(cpp_args, relpath);
 			} else {
-				args_add(stripped_args, argv[i]);
-				args_add(stripped_args, relpath);
+				args_add(common_args, argv[i]);
+				args_add(common_args, relpath);
 			}
 			free(relpath);
 
@@ -3112,7 +3118,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 					if (compopt_affects_cpp(option)) {
 						args_add(cpp_args, new_option);
 					} else {
-						args_add(stripped_args, new_option);
+						args_add(common_args, new_option);
 					}
 					free(new_option);
 					free(relpath);
@@ -3137,8 +3143,8 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 				args_add(cpp_args, argv[i]);
 				args_add(cpp_args, argv[i+1]);
 			} else {
-				args_add(stripped_args, argv[i]);
-				args_add(stripped_args, argv[i+1]);
+				args_add(common_args, argv[i]);
+				args_add(common_args, argv[i+1]);
 			}
 
 			i++;
@@ -3151,7 +3157,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			    || compopt_prefix_affects_cpp(argv[i])) {
 				args_add(cpp_args, argv[i]);
 			} else {
-				args_add(stripped_args, argv[i]);
+				args_add(common_args, argv[i]);
 			}
 			continue;
 		}
@@ -3166,7 +3172,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		    && (stat(argv[i], &st) != 0 || !S_ISREG(st.st_mode))) {
 			cc_log("%s is not a regular file, not considering as input file",
 			       argv[i]);
-			args_add(stripped_args, argv[i]);
+			args_add(common_args, argv[i]);
 			continue;
 		}
 
@@ -3322,7 +3328,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 
 	if (!found_c_opt && !found_S_opt) {
 		if (output_is_precompiled_header) {
-			args_add(stripped_args, "-c");
+			args_add(common_args, "-c");
 		} else {
 			cc_log("No -c option found");
 			// I find that having a separate statistic for autoconf tests is useful,
@@ -3445,7 +3451,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 	if (!found_color_diagnostics && color_output_possible()) {
 		if (guessed_compiler == GUESSED_CLANG) {
 			if (!str_eq(actual_language, "assembler")) {
-				args_add(stripped_args, "-fcolor-diagnostics");
+				args_add(common_args, "-fcolor-diagnostics");
 				cc_log("Automatically enabling colors");
 			}
 		} else if (guessed_compiler == GUESSED_GCC) {
@@ -3454,7 +3460,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			// set (and not empty), so use that for detecting if GCC would use
 			// colors.
 			if (getenv("GCC_COLORS") && getenv("GCC_COLORS")[0] != '\0') {
-				args_add(stripped_args, "-fdiagnostics-color");
+				args_add(common_args, "-fdiagnostics-color");
 				cc_log("Automatically enabling colors");
 			}
 		}
@@ -3491,7 +3497,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		output_su = make_relative_path(default_sufile_name);
 	}
 
-	*compiler_args = args_copy(stripped_args);
+	*compiler_args = args_copy(common_args);
 	if (conf->run_second_cpp) {
 		args_extend(*compiler_args, cpp_args);
 	} else if (found_directives_only || found_rewrite_includes) {
@@ -3531,12 +3537,12 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 	// source.
 	args_extend(cpp_args, dep_args);
 
-	*preprocessor_args = args_copy(stripped_args);
+	*preprocessor_args = args_copy(common_args);
 	args_extend(*preprocessor_args, cpp_args);
 
 out:
 	args_free(expanded_args);
-	args_free(stripped_args);
+	args_free(common_args);
 	args_free(dep_args);
 	args_free(cpp_args);
 	return result;

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2732,6 +2732,13 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		if (str_startswith(argv[i], "-g")) {
 			args_add(stripped_args, argv[i]);
 
+			if (str_startswith(argv[i], "-gdwarf")) {
+				// Selection of DWARF format (-gdwarf or -gdwarf-<version>) enables
+				// debug info on level 2.
+				generating_debuginfo = true;
+				continue;
+			}
+
 			char last_char = argv[i][strlen(argv[i]) - 1];
 			if (last_char == '0') {
 				// "-g0", "-ggdb0" or similar: All debug information disabled.

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2513,9 +2513,11 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 	// used as a temporary data structure to loop over.
 	struct args *expanded_args = args_copy(args);
 
-	// common_args essentially contains all original arguments except those that
-	// only should be passed to the preprocessor (if run_second_cpp is false) and
-	// except dependency options (like -MD and friends).
+	// common_args contains all original arguments except:
+	// * those that never should be passed to the preprocessor,
+	// * those that only should be passed to the preprocessor (if run_second_cpp
+	//   is false), and
+	// * dependency options (like -MD and friends).
 	struct args *common_args = args_init(0, NULL);
 
 	// cpp_args contains arguments that were not added to common_args, i.e. those
@@ -2523,12 +2525,15 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 	// If run_second_cpp is true, they will be passed to the compiler as well.
 	struct args *cpp_args = args_init(0, NULL);
 
-	// dep_args contains dependency options like -MD. They only passed to the
+	// dep_args contains dependency options like -MD. They are only passed to the
 	// preprocessor, never to the compiler.
 	struct args *dep_args = args_init(0, NULL);
 
-	bool found_color_diagnostics = false;
+	// compiler_only_args contains arguments that should only be passed to the
+	// compiler, not the preprocessor.
+	struct args *compiler_only_args = args_init(0, NULL);
 
+	bool found_color_diagnostics = false;
 	bool found_directives_only = false;
 	bool found_rewrite_includes = false;
 
@@ -2659,6 +2664,26 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			if (arch_args_size == 2) {
 				conf->run_second_cpp = true;
 			}
+			continue;
+		}
+
+		// Handle options that should not be passed to the preprocessor.
+		if (compopt_affects_comp(argv[i])) {
+			args_add(compiler_only_args, argv[i]);
+			if (compopt_takes_arg(argv[i])) {
+				if (i == argc - 1) {
+					cc_log("Missing argument to %s", argv[i]);
+					stats_update(STATS_ARGS);
+					result = false;
+					goto out;
+				}
+				args_add(compiler_only_args, argv[i + 1]);
+				++i;
+			}
+			continue;
+		}
+		if (compopt_prefix_affects_comp(argv[i])) {
+			args_add(compiler_only_args, argv[i]);
 			continue;
 		}
 
@@ -3498,6 +3523,8 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 	}
 
 	*compiler_args = args_copy(common_args);
+	args_extend(*compiler_args, compiler_only_args);
+
 	if (conf->run_second_cpp) {
 		args_extend(*compiler_args, cpp_args);
 	} else if (found_directives_only || found_rewrite_includes) {

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1035,7 +1035,7 @@ process_preprocessed_file(struct hash *hash, const char *path, bool pump)
 	free(data);
 	free(cwd);
 
-	// Explicitly check the .gch/.pch/.pth file, Clang does not include any
+	// Explicitly check the .gch/.pch/.pth file as Clang does not include any
 	// mention of it in the preprocessed output.
 	if (included_pch_file) {
 		char *pch_path = x_strdup(included_pch_file);
@@ -1165,8 +1165,8 @@ object_hash_from_depfile(const char *depfile, struct hash *hash)
 
 	fclose(f);
 
-	// Explicitly check the .gch/.pch/.pth file, it may not be mentioned
-	// in the dependencies output.
+	// Explicitly check the .gch/.pch/.pth file as it may not be mentioned in the
+	// dependencies output.
 	if (included_pch_file) {
 		char *pch_path = x_strdup(included_pch_file);
 		pch_path = make_relative_path(pch_path);

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -785,6 +785,10 @@ print_included_files(FILE *fp)
 static char *
 make_relative_path(char *path)
 {
+    if(path[0] == '=') { // Remove first char if string starts with "="
+        path++;
+    }
+
 	if (str_eq(conf->base_dir, "") || !str_startswith(path, conf->base_dir)) {
 		return path;
 	}

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -224,7 +224,7 @@ unsigned stats_get_pending(enum stats stat);
 void stats_zero(void);
 void stats_summary(void);
 void stats_print(void);
-void stats_update_size(int64_t size, int files);
+void stats_update_size(const char *sfile, int64_t size, int files);
 void stats_get_obsolete_limits(const char *dir, unsigned *maxfiles,
                                uint64_t *maxsize);
 void stats_set_sizes(const char *dir, unsigned num_files, uint64_t total_size);

--- a/src/compopt.c
+++ b/src/compopt.c
@@ -17,12 +17,28 @@
 #include "ccache.h"
 #include "compopt.h"
 
+// The option it too hard to handle at all.
 #define TOO_HARD         (1 << 0)
+
+// The option it too hard for the direct mode.
 #define TOO_HARD_DIRECT  (1 << 1)
+
+// The option takes a separate argument, e.g. "-D FOO=1".
 #define TAKES_ARG        (1 << 2)
+
+// The option takes a concatenated argument, e.g. "-DFOO=1".
 #define TAKES_CONCAT_ARG (1 << 3)
+
+// The argument to the option is a path that may be rewritten if base_dir is
+// used.
 #define TAKES_PATH       (1 << 4)
+
+// The option only affects preprocessing; not passed to the compiler if
+// run_second_cpp is false.
 #define AFFECTS_CPP      (1 << 5)
+
+// The option only affects compilation; not passed to the preprocesor.
+#define AFFECTS_COMP (1 << 6)
 
 struct compopt {
 	const char *name;
@@ -56,14 +72,20 @@ static const struct compopt compopts[] = {
 	{"-P",              TOO_HARD},
 	{"-U",              AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG},
 	{"-V",              TAKES_ARG},
-	{"-Xassembler",     TAKES_ARG},
+	{"-Wa,",            TAKES_CONCAT_ARG | AFFECTS_COMP},
+	{"-Werror",         AFFECTS_COMP}, // don't exit with error when preprocessing
+	{"-Wl,",            TAKES_CONCAT_ARG | AFFECTS_COMP},
+	{"-Xassembler",     TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},
 	{"-Xclang",         TAKES_ARG},
-	{"-Xlinker",        TAKES_ARG},
+	{"-Xlinker",        TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},
 	{"-Xpreprocessor",  AFFECTS_CPP | TOO_HARD_DIRECT | TAKES_ARG},
+	{"-all_load",       AFFECTS_COMP},
 	{"-analyze",        TOO_HARD}, // clang
 	{"-arch",           TAKES_ARG},
 	{"-aux-info",       TAKES_ARG},
 	{"-b",              TAKES_ARG},
+	{"-bind_at_load",   AFFECTS_COMP},
+	{"-bundle",         AFFECTS_COMP},
 	{"-ccbin",          AFFECTS_CPP | TAKES_ARG}, // nvcc
 	{"-fmodules",       TOO_HARD},
 	{"-fno-working-directory", AFFECTS_CPP},
@@ -87,9 +109,14 @@ static const struct compopt compopts[] = {
 	{"-iwithprefixbefore",
 	 AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
 	{"-ldir",           AFFECTS_CPP | TAKES_ARG}, // nvcc
+	{"-nolibc",         AFFECTS_COMP},
 	{"-nostdinc",       AFFECTS_CPP},
 	{"-nostdinc++",     AFFECTS_CPP},
 	{"-odir",           AFFECTS_CPP | TAKES_ARG}, // nvcc
+	{"-pie",            AFFECTS_COMP},
+	{"-prebind",        AFFECTS_COMP},
+	{"-preload",        AFFECTS_COMP},
+	{"-rdynamic",       AFFECTS_COMP},
 	{"-remap",          AFFECTS_CPP},
 	{"-save-temps",     TOO_HARD},
 	{"-save-temps=cwd", TOO_HARD},
@@ -173,6 +200,13 @@ compopt_affects_cpp(const char *option)
 }
 
 bool
+compopt_affects_comp(const char *option)
+{
+	const struct compopt *co = find(option);
+	return co && (co->type & AFFECTS_COMP);
+}
+
+bool
 compopt_too_hard(const char *option)
 {
 	const struct compopt *co = find(option);
@@ -215,4 +249,14 @@ compopt_prefix_affects_cpp(const char *option)
 	// Prefix options have to take concatenated args.
 	const struct compopt *co = find_prefix(option);
 	return co && (co->type & TAKES_CONCAT_ARG) && (co->type & AFFECTS_CPP);
+}
+
+// Determines if the prefix of the option matches any option and affects the
+// preprocessor.
+bool
+compopt_prefix_affects_comp(const char *option)
+{
+	// Prefix options have to take concatenated args.
+	const struct compopt *co = find_prefix(option);
+	return co && (co->type & TAKES_CONCAT_ARG) && (co->type & AFFECTS_COMP);
 }

--- a/src/compopt.c
+++ b/src/compopt.c
@@ -75,6 +75,7 @@ static const struct compopt compopts[] = {
 	{"-Wa,",            TAKES_CONCAT_ARG | AFFECTS_COMP},
 	{"-Werror",         AFFECTS_COMP}, // don't exit with error when preprocessing
 	{"-Wl,",            TAKES_CONCAT_ARG | AFFECTS_COMP},
+	{"-Wno-error",      AFFECTS_COMP},
 	{"-Xassembler",     TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},
 	{"-Xclang",         TAKES_ARG},
 	{"-Xlinker",        TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},

--- a/src/compopt.c
+++ b/src/compopt.c
@@ -69,6 +69,7 @@ static const struct compopt compopts[] = {
 	{"-fno-working-directory", AFFECTS_CPP},
 	{"-fplugin=libcc1plugin", TOO_HARD}, // interaction with GDB
 	{"-frepo",          TOO_HARD},
+	{"-ftime-trace",    TOO_HARD}, // clang
 	{"-fworking-directory", AFFECTS_CPP},
 	{"-gtoggle",        TOO_HARD},
 	{"-idirafter",      AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},

--- a/src/compopt.h
+++ b/src/compopt.h
@@ -5,11 +5,13 @@
 
 bool compopt_short(bool (*fn)(const char *option), const char *option);
 bool compopt_affects_cpp(const char *option);
+bool compopt_affects_comp(const char *option);
 bool compopt_too_hard(const char *option);
 bool compopt_too_hard_for_direct_mode(const char *option);
 bool compopt_takes_path(const char *option);
 bool compopt_takes_arg(const char *option);
 bool compopt_takes_concat_arg(const char *option);
 bool compopt_prefix_affects_cpp(const char *option);
+bool compopt_prefix_affects_comp(const char *option);
 
 #endif // CCACHE_COMPOPT_H

--- a/src/conf.c
+++ b/src/conf.c
@@ -300,6 +300,12 @@ conf_set_value_in_file(const char *path, const char *key, const char *value,
 		return false;
 	}
 
+	char dummy[8] = {0}; // The maximum entry size in struct conf.
+	if (!item->parser(value, (void *)dummy, errmsg)
+	    || (item->verifier && !item->verifier(value, errmsg))) {
+		return false;
+	}
+
 	FILE *infile = fopen(path, "r");
 	if (!infile) {
 		*errmsg = format("%s: %s", path, strerror(errno));

--- a/src/confitems.c
+++ b/src/confitems.c
@@ -18,9 +18,9 @@
 #include "ccache.h"
 
 static char *
-format_string(void *value)
+format_string(const void *value)
 {
-	char **str = (char **)value;
+	const char * const *str = (const char * const*)value;
 	return x_strdup(*str);
 }
 
@@ -42,9 +42,9 @@ confitem_parse_bool(const char *str, void *result, char **errmsg)
 }
 
 char *
-confitem_format_bool(void *value)
+confitem_format_bool(const void *value)
 {
-	bool *b = (bool *)value;
+	const bool *b = (const bool *)value;
 	return x_strdup(*b ? "true" : "false");
 }
 
@@ -58,7 +58,7 @@ confitem_parse_env_string(const char *str, void *result, char **errmsg)
 }
 
 char *
-confitem_format_env_string(void *value)
+confitem_format_env_string(const void *value)
 {
 	return format_string(value);
 }
@@ -80,9 +80,9 @@ confitem_parse_double(const char *str, void *result, char **errmsg)
 }
 
 char *
-confitem_format_double(void *value)
+confitem_format_double(const void *value)
 {
-	double *x = (double *)value;
+	const double *x = (const double *)value;
 	return format("%.1f", *x);
 }
 
@@ -101,9 +101,9 @@ confitem_parse_size(const char *str, void *result, char **errmsg)
 }
 
 char *
-confitem_format_size(void *value)
+confitem_format_size(const void *value)
 {
-	uint64_t *size = (uint64_t *)value;
+	const uint64_t *size = (const uint64_t *)value;
 	return format_parsable_size_with_suffix(*size);
 }
 
@@ -153,9 +153,9 @@ confitem_parse_sloppiness(const char *str, void *result, char **errmsg)
 }
 
 char *
-confitem_format_sloppiness(void *value)
+confitem_format_sloppiness(const void *value)
 {
-	unsigned *sloppiness = (unsigned *)value;
+	const unsigned *sloppiness = (const unsigned *)value;
 	char *s = x_strdup("");
 	if (*sloppiness & SLOPPY_FILE_MACRO) {
 		reformat(&s, "%sfile_macro, ", s);
@@ -206,7 +206,7 @@ confitem_parse_string(const char *str, void *result, char **errmsg)
 }
 
 char *
-confitem_format_string(void *value)
+confitem_format_string(const void *value)
 {
 	return format_string(value);
 }
@@ -232,9 +232,9 @@ confitem_parse_umask(const char *str, void *result, char **errmsg)
 }
 
 char *
-confitem_format_umask(void *value)
+confitem_format_umask(const void *value)
 {
-	unsigned *umask = (unsigned *)value;
+	const unsigned *umask = (const unsigned *)value;
 	if (*umask == UINT_MAX) {
 		return x_strdup("");
 	} else {
@@ -259,16 +259,16 @@ confitem_parse_unsigned(const char *str, void *result, char **errmsg)
 }
 
 char *
-confitem_format_unsigned(void *value)
+confitem_format_unsigned(const void *value)
 {
-	unsigned *i = (unsigned *)value;
+	const unsigned *i = (const unsigned *)value;
 	return format("%u", *i);
 }
 
 bool
-confitem_verify_absolute_path(void *value, char **errmsg)
+confitem_verify_absolute_path(const void *value, char **errmsg)
 {
-	char **path = (char **)value;
+	const char * const *path = (const char * const *)value;
 	assert(*path);
 	if (str_eq(*path, "")) {
 		// The empty string means "disable" in this case.
@@ -282,9 +282,9 @@ confitem_verify_absolute_path(void *value, char **errmsg)
 }
 
 bool
-confitem_verify_dir_levels(void *value, char **errmsg)
+confitem_verify_dir_levels(const void *value, char **errmsg)
 {
-	unsigned *levels = (unsigned *)value;
+	const unsigned *levels = (const unsigned *)value;
 	assert(levels);
 	if (*levels >= 1 && *levels <= 8) {
 		return true;

--- a/src/confitems.h
+++ b/src/confitems.h
@@ -4,8 +4,8 @@
 #include "system.h"
 
 typedef bool (*conf_item_parser)(const char *str, void *result, char **errmsg);
-typedef bool (*conf_item_verifier)(void *value, char **errmsg);
-typedef char *(*conf_item_formatter)(void *value);
+typedef bool (*conf_item_verifier)(const void *value, char **errmsg);
+typedef char *(*conf_item_formatter)(const void *value);
 
 struct conf_item {
 	const char *name;
@@ -17,31 +17,31 @@ struct conf_item {
 };
 
 bool confitem_parse_bool(const char *str, void *result, char **errmsg);
-char *confitem_format_bool(void *value);
+char *confitem_format_bool(const void *value);
 
 bool confitem_parse_env_string(const char *str, void *result, char **errmsg);
-char *confitem_format_env_string(void *value);
+char *confitem_format_env_string(const void *value);
 
 bool confitem_parse_double(const char *str, void *result, char **errmsg);
-char *confitem_format_double(void *value);
+char *confitem_format_double(const void *value);
 
 bool confitem_parse_size(const char *str, void *result, char **errmsg);
-char *confitem_format_size(void *value);
+char *confitem_format_size(const void *value);
 
 bool confitem_parse_sloppiness(const char *str, void *result, char **errmsg);
-char *confitem_format_sloppiness(void *value);
+char *confitem_format_sloppiness(const void *value);
 
 bool confitem_parse_string(const char *str, void *result, char **errmsg);
-char *confitem_format_string(void *value);
+char *confitem_format_string(const void *value);
 
 bool confitem_parse_umask(const char *str, void *result, char **errmsg);
-char *confitem_format_umask(void *value);
+char *confitem_format_umask(const void *value);
 
 bool confitem_parse_unsigned(const char *str, void *result, char **errmsg);
-char *confitem_format_unsigned(void *value);
+char *confitem_format_unsigned(const void *value);
 
-bool confitem_verify_absolute_path(void *value, char **errmsg);
-bool confitem_verify_dir_levels(void *value, char **errmsg);
+bool confitem_verify_absolute_path(const void *value, char **errmsg);
+bool confitem_verify_dir_levels(const void *value, char **errmsg);
 
 const struct conf_item *confitems_get(const char *str, size_t len);
 size_t confitems_count(void);

--- a/src/counters.c
+++ b/src/counters.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2016 Joel Rosdahl
+// Copyright (C) 2010-2019 Joel Rosdahl
 //
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the Free
@@ -35,8 +35,10 @@ counters_init(size_t initial_size)
 void
 counters_free(struct counters *c)
 {
-	free(c->data);
-	free(c);
+	if (c) {
+		free(c->data);
+		free(c);
+	}
 }
 
 // Set a new size. New data entries are set to 0.

--- a/src/util.c
+++ b/src/util.c
@@ -984,12 +984,7 @@ file_size(struct stat *st)
 #ifdef _WIN32
 	return (st->st_size + 1023) & ~1023;
 #else
-	size_t size = st->st_blocks * 512;
-	if ((size_t)st->st_size > size) {
-		// Probably a broken stat() call...
-		size = (st->st_size + 1023) & ~1023;
-	}
-	return size;
+	return st->st_blocks * 512;
 #endif
 }
 

--- a/test/run
+++ b/test/run
@@ -273,6 +273,8 @@ EOF
 # =============================================================================
 # main program
 
+export LC_ALL=C
+
 if pwd | grep '[^A-Za-z0-9/.,=_%+-]' >/dev/null 2>&1; then
     cat <<EOF
 Error: The test suite doesn't work in directories with whitespace or other

--- a/test/suites/cleanup.bash
+++ b/test/suites/cleanup.bash
@@ -75,32 +75,34 @@ SUITE_cleanup() {
     done
 
     # -------------------------------------------------------------------------
-    TEST "Forced cache cleanup, size limit"
+    if [ -n "$ENABLE_CACHE_CLEANUP_TESTS" ]; then
+        TEST "Forced cache cleanup, size limit"
 
-    # NOTE: This test is known to fail on filesystems that have unusual block
-    # sizes, including ecryptfs. The workaround is to place the test directory
-    # elsewhere:
-    #
-    #     cd /tmp
-    #     CCACHE=$DIR/ccache $DIR/test.sh
+        # NOTE: This test is known to fail on filesystems that have unusual block
+        # sizes, including ecryptfs. The workaround is to place the test directory
+        # elsewhere:
+        #
+        #     cd /tmp
+        #     CCACHE=$DIR/ccache $DIR/test.sh
 
-    prepare_cleanup_test_dir $CCACHE_DIR/a
+        prepare_cleanup_test_dir $CCACHE_DIR/a
 
-    $CCACHE -F 0 -M 256K >/dev/null
-    $CCACHE -c >/dev/null
-    expect_file_count 3 '*.o' $CCACHE_DIR
-    expect_file_count 4 '*.d' $CCACHE_DIR
-    expect_file_count 4 '*.stderr' $CCACHE_DIR
-    expect_stat 'files in cache' 11
-    expect_stat 'cleanups performed' 1
-    for i in 0 1 2 3 4 5 6; do
-        file=$CCACHE_DIR/a/result$i-4017.o
-        expect_file_missing $file
-    done
-    for i in 7 8 9; do
-        file=$CCACHE_DIR/a/result$i-4017.o
-        expect_file_exists $file
-    done
+        $CCACHE -F 0 -M 256K >/dev/null
+        $CCACHE -c >/dev/null
+        expect_file_count 3 '*.o' $CCACHE_DIR
+        expect_file_count 4 '*.d' $CCACHE_DIR
+        expect_file_count 4 '*.stderr' $CCACHE_DIR
+        expect_stat 'files in cache' 11
+        expect_stat 'cleanups performed' 1
+        for i in 0 1 2 3 4 5 6; do
+            file=$CCACHE_DIR/a/result$i-4017.o
+            expect_file_missing $file
+        done
+        for i in 7 8 9; do
+            file=$CCACHE_DIR/a/result$i-4017.o
+            expect_file_exists $file
+        done
+    fi
 
     # -------------------------------------------------------------------------
     TEST "Automatic cache cleanup, limit_multiple 0.9"

--- a/test/suites/pch.bash
+++ b/test/suites/pch.bash
@@ -31,15 +31,20 @@ EOF
 }
 
 SUITE_pch() {
-    # Clang and GCC handle precompiled headers similarly, but GCC is much more
-    # forgiving with precompiled headers. Both GCC and Clang keep an absolute
-    # path reference to the original file except that Clang uses that reference
-    # to validate the pch and GCC ignores the reference. Also, Clang has an
-    # additional feature: pre-tokenized headers. For these reasons, Clang
-    # should be tested differently from GCC. Clang can only use pch or pth
-    # headers on the command line and not as an #include statement inside a
-    # source file.
+    # Clang should generally be compatible with GCC and so most of the tests
+    # can be shared. There are some differences though:
+    # - Both GCC and Clang keep an absolute path reference to the original
+    # file except that Clang uses that reference to validate the pch and GCC
+    # ignores the reference (i.e. the original file can be removed).
+    # - Clang can only use pch headers on the command line and not as an #include
+    # statement inside a source file, because it silently ignores -fpch-preprocess
+    # and does not output pragma GCC pch_preprocess.
+    # - Clang has -include-pch to directly include a PCH file without any magic
+    # of searching for a .gch file.
+    #
+    # Therefore have common tests and do dedicated tests only for differences.
 
+    pch_suite_common
     if $COMPILER_TYPE_CLANG; then
         pch_suite_clang
     else
@@ -47,7 +52,7 @@ SUITE_pch() {
     fi
 }
 
-pch_suite_gcc() {
+pch_suite_common() {
     # -------------------------------------------------------------------------
     TEST "Create .gch, -c, no -o, without opt-in"
 
@@ -81,41 +86,49 @@ pch_suite_gcc() {
     expect_stat 'cache miss' 1
     expect_file_exists pch.h.gch
 
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    rm pch.h.gch
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT -c pch.h
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+    expect_file_exists pch.h.gch
+
     # -------------------------------------------------------------------------
     TEST "Create .gch, no -c, -o, with opt-in"
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT pch.h -o pch.gch
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT pch.h -o pch.gch
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT pch.h -o pch.gch
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT pch.h -o pch.gch
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     expect_file_exists pch.gch
 
     # -------------------------------------------------------------------------
-    TEST "Use .gch, no -fpch-preprocess, #include"
+    TEST "Use .gch, #include, remove pch.h"
 
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
     rm pch.h
 
-    $CCACHE_COMPILE $SYSROOT -c pch.c
+    $CCACHE_COMPILE $SYSROOT -c pch.c 2>/dev/null
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 0
     # Preprocessor error because GCC can't find the real include file when
-    # trying to preprocess:
+    # trying to preprocess (gcc -E will be called by ccache):
     expect_stat 'preprocessor error' 1
 
     # -------------------------------------------------------------------------
-    TEST "Use .gch, no -fpch-preprocess, -include, no sloppiness"
+    TEST "Use .gch, -include, no sloppiness"
 
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
-    rm pch.h
 
     $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
     expect_stat 'cache hit (direct)' 0
@@ -125,7 +138,264 @@ pch_suite_gcc() {
     expect_stat "can't use precompiled header" 1
 
     # -------------------------------------------------------------------------
-    TEST "Use .gch, no -fpch-preprocess, -include, sloppiness"
+    TEST "Use .gch, -include"
+
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    expect_stat 'cache hit (direct)' 2
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+
+    # -------------------------------------------------------------------------
+    TEST "Use .gch, preprocessor mode, -include"
+
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 1
+
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 2
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 2
+    expect_stat 'cache miss' 2
+
+    # -------------------------------------------------------------------------
+    TEST "Create .gch, -c, -o"
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT -c pch.h -o pch.h.gch
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+    rm -f pch.h.gch
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT -c pch.h -o pch.h.gch
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+    expect_file_exists pch.h.gch
+
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    rm pch.h.gch
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT -c pch.h -o pch.h.gch
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+    expect_file_exists pch.h.gch
+
+    # -------------------------------------------------------------------------
+    TEST "Use .gch, -include, PCH_EXTSUM=1"
+
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    echo "original checksum" > pch.h.gch.sum
+
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    echo "other checksum" > pch.h.gch.sum
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+
+    echo "original checksum" > pch.h.gch.sum
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    expect_stat 'cache hit (direct)' 2
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+
+    # With GCC, a newly generated PCH is always different, even if the contents should be exactly the same.
+    # And Clang stores file timestamps, so in this case the PCH is different too.
+    # So without .sum a "changed" PCH would mean a miss, but if the .sum doesn't change, it should be a hit.
+
+    sleep 1
+    touch pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    expect_stat 'cache hit (direct)' 3
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+
+    # -------------------------------------------------------------------------
+    TEST "Use .gch, -include, no PCH_EXTSUM"
+
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    echo "original checksum" > pch.h.gch.sum
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    # external checksum not used, so no cache miss when changed
+    echo "other checksum" > pch.h.gch.sum
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
+    expect_stat 'cache hit (direct)' 2
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    # -------------------------------------------------------------------------
+    TEST "Use .gch, -include, other dir for .gch"
+
+    mkdir -p dir
+    $REAL_COMPILER $SYSROOT -c pch.h -o dir/pch.h.gch
+    backdate dir/pch.h.gch
+    rm -f pch.h.gch
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include dir/pch.h pch2.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include dir/pch.h pch2.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h -o dir/pch.h.gch
+    backdate dir/pch.h.gch
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include dir/pch.h pch2.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include dir/pch.h pch2.c
+    expect_stat 'cache hit (direct)' 2
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+    rm -rf dir
+
+    # -------------------------------------------------------------------------
+    TEST "Use .gch, preprocessor mode, -include, other dir for .gch"
+
+    mkdir -p dir
+    $REAL_COMPILER $SYSROOT -c pch.h -o dir/pch.h.gch
+    backdate dir/pch.h.gch
+    rm -f pch.h.gch
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include dir/pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include dir/pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 1
+
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h -o dir/pch.h.gch
+    backdate dir/pch.h.gch
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include dir/pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 2
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include dir/pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 2
+    expect_stat 'cache miss' 2
+    rm -rf dir
+
+    # -------------------------------------------------------------------------
+    TEST "Use .gch, depend mode, -include"
+
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    CCACHE_DEPEND=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c -MD -MF pch.d
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    CCACHE_DEPEND=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c -MD -MF pch.d
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    CCACHE_DEPEND=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c -MD -MF pch.d
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+
+    CCACHE_DEPEND=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c -MD -MF pch.d
+    expect_stat 'cache hit (direct)' 2
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+}
+
+pch_suite_gcc() {
+    # -------------------------------------------------------------------------
+    TEST "Use .gch, -include, remove pch.h"
 
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
@@ -142,7 +412,7 @@ pch_suite_gcc() {
     expect_stat 'cache miss' 1
 
     # -------------------------------------------------------------------------
-    TEST "Use .gch, -fpch-preprocess, #include, no sloppiness"
+    TEST "Use .gch, #include, no sloppiness"
 
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
@@ -155,92 +425,67 @@ pch_suite_gcc() {
     expect_stat "can't use precompiled header" 1
 
     # -------------------------------------------------------------------------
-    TEST "Use .gch, -fpch-preprocess, #include, sloppiness"
+    TEST "Use .gch, #include"
 
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
     rm pch.h
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    # -------------------------------------------------------------------------
-    TEST "Use .gch, -fpch-preprocess, #include, file changed"
-
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
-    rm pch.h
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 1
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    echo "updated" >>pch.h.gch # GCC seems to cope with this...
-    backdate pch.h.gch
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 2
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
     # -------------------------------------------------------------------------
-    TEST "Use .gch, preprocessor mode"
+    TEST "Use .gch, preprocessor mode, #include"
 
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
     rm pch.h
 
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 1
     expect_stat 'cache miss' 1
 
-    # -------------------------------------------------------------------------
-    TEST "Use .gch, preprocessor mode, file changed"
-
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
-    rm pch.h
 
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    echo "updated" >>pch.h.gch # GCC seems to cope with this...
-    backdate pch.h.gch
-
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache hit (preprocessed)' 1
     expect_stat 'cache miss' 2
 
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache hit (preprocessed)' 2
     expect_stat 'cache miss' 2
 
     # -------------------------------------------------------------------------
@@ -248,13 +493,13 @@ pch_suite_gcc() {
 
     mkdir pch.h.gch
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -x c-header -c pch.h -o pch.h.gch/foo
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT -x c-header -c pch.h -o pch.h.gch/foo
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
     rm pch.h.gch/foo
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -x c-header -c pch.h -o pch.h.gch/foo
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT -x c-header -c pch.h -o pch.h.gch/foo
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
@@ -262,12 +507,12 @@ pch_suite_gcc() {
 
     backdate pch.h.gch/foo
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
     expect_stat 'cache hit (direct)' 2
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
@@ -275,120 +520,87 @@ pch_suite_gcc() {
     echo "updated" >>pch.h.gch/foo # GCC seems to cope with this...
     backdate pch.h.gch/foo
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
     expect_stat 'cache hit (direct)' 2
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 3
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
     expect_stat 'cache hit (direct)' 3
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 3
 
     # -------------------------------------------------------------------------
-    TEST "Use .gch, -fpch-preprocess, PCH_EXTSUM=1"
+    TEST "Use .gch, #include, PCH_EXTSUM=1"
 
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
 
     echo "original checksum" > pch.h.gch.sum
 
-    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
     echo "other checksum" > pch.h.gch.sum
-    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
     echo "original checksum" > pch.h.gch.sum
-    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 2
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
+    # With GCC, a newly generated PCH is always different, even if the contents should be exactly the same.
+    # And Clang stores file timestamps, so in this case the PCH is different too.
+    # So without .sum a "changed" PCH would mean a miss, but if the .sum doesn't change, it should be a hit.
+
+    sleep 1
+    touch pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h
+    backdate pch.h.gch
+
+    CCACHE_PCH_EXTSUM=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    expect_stat 'cache hit (direct)' 3
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 2
+
     # -------------------------------------------------------------------------
-    TEST "Use .gch, -fpch-preprocess, no PCH_EXTSUM"
+    TEST "Use .gch, #include, no PCH_EXTSUM"
 
     $REAL_COMPILER $SYSROOT -c pch.h
     backdate pch.h.gch
 
     echo "original checksum" > pch.h.gch.sum
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
     # external checksum not used, so no cache miss when changed
     echo "other checksum" > pch.h.gch.sum
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
     expect_stat 'cache hit (direct)' 2
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 }
 
 pch_suite_clang() {
-    # -------------------------------------------------------------------------
-    TEST "Create .gch, -c, no -o, without opt-in"
-
-    $CCACHE_COMPILE $SYSROOT -c pch.h
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 0
-    expect_stat "can't use precompiled header" 1
-
-    # -------------------------------------------------------------------------
-    TEST "Create .gch, no -c, -o, without opt-in"
-
-    $CCACHE_COMPILE pch.h -o pch.gch
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 0
-    expect_stat "can't use precompiled header" 1
-
-    # -------------------------------------------------------------------------
-    TEST "Create .gch, -c, no -o, with opt-in"
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c pch.h
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-    rm pch.h.gch
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c pch.h
-    expect_stat 'cache hit (direct)' 1
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-    expect_file_exists pch.h.gch
-
-    # -------------------------------------------------------------------------
-    TEST "Create .gch, no -c, -o, with opt-in"
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT pch.h -o pch.gch
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT pch.h -o pch.gch
-    expect_stat 'cache hit (direct)' 1
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-    expect_file_exists pch.gch
-
     # -------------------------------------------------------------------------
     TEST "Create .gch, include file mtime changed"
 
@@ -402,7 +614,7 @@ EOF
     # of the test.h include, otherwise we might not cache its ctime/mtime.
     sleep 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c pch2.h
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT -c pch2.h
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
@@ -410,7 +622,7 @@ EOF
     touch test.h
     sleep 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c pch2.h
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT -c pch2.h
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
@@ -418,124 +630,16 @@ EOF
     $REAL_COMPILER $SYSROOT -c -include pch2.h pch2.c
     expect_file_exists pch2.o
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c pch2.h
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines" $CCACHE_COMPILE $SYSROOT -c pch2.h
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
     # -------------------------------------------------------------------------
-    TEST "Use .gch, no -fpch-preprocess, -include, no sloppiness"
+    TEST "Use .pch, -include, no sloppiness"
 
-    $REAL_COMPILER $SYSROOT -c pch.h
-    backdate pch.h.gch
-
-    $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c 2>/dev/null
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 0
-    # Must enable sloppy time macros:
-    expect_stat "can't use precompiled header" 1
-
-    # -------------------------------------------------------------------------
-    TEST "Use .gch, no -fpch-preprocess, -include, sloppiness"
-
-    $REAL_COMPILER $SYSROOT -c pch.h
-    backdate pch.h.gch
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
-    expect_stat 'cache hit (direct)' 1
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    # -------------------------------------------------------------------------
-    TEST "Use .gch, -fpch-preprocess, -include, file changed"
-
-    $REAL_COMPILER $SYSROOT -c pch.h
-    backdate pch.h.gch
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    echo "updated" >>pch.h.gch # clang seems to cope with this...
-    backdate pch.h.gch
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 2
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 1
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 2
-
-    # -------------------------------------------------------------------------
-    TEST "Use .gch, preprocessor mode"
-
-    $REAL_COMPILER $SYSROOT -c pch.h
-    backdate pch.h.gch
-
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 1
-    expect_stat 'cache miss' 1
-
-    # -------------------------------------------------------------------------
-    TEST "Use .gch, preprocessor mode, file changed"
-
-    $REAL_COMPILER $SYSROOT -c pch.h
-    backdate pch.h.gch
-
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    echo "updated" >>pch.h.gch # clang seems to cope with this...
-    backdate pch.h.gch
-
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 2
-
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 1
-    expect_stat 'cache miss' 2
-
-    # -------------------------------------------------------------------------
-    TEST "Create .pth, -c, -o"
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c pch.h -o pch.h.pth
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-    rm -f pch.h.pth
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c pch.h -o pch.h.pth
-    expect_stat 'cache hit (direct)' 1
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-    expect_file_exists pch.h.pth
-
-    # -------------------------------------------------------------------------
-    TEST "Use .pth, no -fpch-preprocess, -include, no sloppiness"
-
-    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pth
-    backdate pch.h.pth
+    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pch
+    backdate pch.h.pch
 
     $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
     expect_stat 'cache hit (direct)' 0
@@ -545,82 +649,116 @@ EOF
     expect_stat "can't use precompiled header" 1
 
     # -------------------------------------------------------------------------
-    TEST "Use .pth, no -fpch-preprocess, -include, sloppiness"
+    TEST "Use .pch, -include"
 
-    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pth
-    backdate pch.h.pth
+    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pch
+    backdate pch.h.pch
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    # -------------------------------------------------------------------------
-    TEST "Use .pth, -fpch-preprocess, -include, file changed"
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pch
+    backdate pch.h.pch
 
-    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pth
-    backdate pch.h.pth
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    echo "updated" >>pch.h.pth # clang seems to cope with this...
-    backdate pch.h.pth
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 2
-
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch2.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
     # -------------------------------------------------------------------------
-    TEST "Use .pth, preprocessor mode"
+    TEST "Use .pch, preprocessor mode, -include"
 
-    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pth
-    backdate pch.h.pth
+    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pch
+    backdate pch.h.pch
 
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 1
     expect_stat 'cache miss' 1
 
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pch
+    backdate pch.h.pch
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 2
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 2
+    expect_stat 'cache miss' 2
+
     # -------------------------------------------------------------------------
-    TEST "Use .pth, preprocessor mode, file changed"
+    TEST "Use .pch, -include-pch"
 
-    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pth
-    backdate pch.h.pth
+    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pch
+    backdate pch.h.pch
 
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include-pch pch.h.pch pch2.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 1
 
-    echo "updated" >>pch.h.pth # clang seems to cope with this...
-    backdate pch.h.pth
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include-pch pch.h.pch pch2.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
 
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
-    expect_stat 'cache hit (direct)' 0
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pch
+    backdate pch.h.pch
+
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include-pch pch.h.pch pch2.c
+    expect_stat 'cache hit (direct)' 1
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS pch_defines time_macros" $CCACHE_COMPILE $SYSROOT -c -include pch.h -fpch-preprocess pch.c
+    # -------------------------------------------------------------------------
+    TEST "Use .pch, preprocessor mode, -include-pch"
+
+    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pch
+    backdate pch.h.pch
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include-pch pch.h.pch pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include-pch pch.h.pch pch.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 1
+
+    echo '#include <string.h> /*change pch*/' >>pch.h
+    backdate pch.h
+    $REAL_COMPILER $SYSROOT -c pch.h -o pch.h.pch
+    backdate pch.h.pch
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include-pch pch.h.pch pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 2
+
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS time_macros" $CCACHE_COMPILE $SYSROOT -c -include-pch pch.h.pch pch.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache hit (preprocessed)' 2
     expect_stat 'cache miss' 2
 }

--- a/test/suites/pch.bash
+++ b/test/suites/pch.bash
@@ -33,16 +33,18 @@ EOF
 SUITE_pch() {
     # Clang should generally be compatible with GCC and so most of the tests
     # can be shared. There are some differences though:
-    # - Both GCC and Clang keep an absolute path reference to the original
-    # file except that Clang uses that reference to validate the pch and GCC
-    # ignores the reference (i.e. the original file can be removed).
-    # - Clang can only use pch headers on the command line and not as an #include
-    # statement inside a source file, because it silently ignores -fpch-preprocess
-    # and does not output pragma GCC pch_preprocess.
-    # - Clang has -include-pch to directly include a PCH file without any magic
-    # of searching for a .gch file.
     #
-    # Therefore have common tests and do dedicated tests only for differences.
+    # - Both GCC and Clang keep an absolute path reference to the original file
+    #   except that Clang uses that reference to validate the pch and GCC
+    #   ignores the reference (i.e. the original file can be removed).
+    # - Clang can only use pch headers on the command line and not as an
+    #   #include statement inside a source file, because it silently ignores
+    #   -fpch-preprocess and does not output pragma GCC pch_preprocess.
+    # - Clang has -include-pch to directly include a PCH file without any magic
+    #   of searching for a .gch file.
+    #
+    # Put tests that work with both compilers in pch_suite_common and put
+    # compiler-specific tests in pch_suite_clang/pch_suite_gcc.
 
     pch_suite_common
     if $COMPILER_TYPE_CLANG; then
@@ -254,9 +256,10 @@ pch_suite_common() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
-    # With GCC, a newly generated PCH is always different, even if the contents should be exactly the same.
-    # And Clang stores file timestamps, so in this case the PCH is different too.
-    # So without .sum a "changed" PCH would mean a miss, but if the .sum doesn't change, it should be a hit.
+    # With GCC, a newly generated PCH is always different, even if the contents
+    # should be exactly the same. And Clang stores file timestamps, so in this
+    # case the PCH is different too. So without .sum a "changed" PCH would mean
+    # a miss, but if the .sum doesn't change, it should be a hit.
 
     sleep 1
     touch pch.h
@@ -560,9 +563,10 @@ pch_suite_gcc() {
     expect_stat 'cache hit (preprocessed)' 0
     expect_stat 'cache miss' 2
 
-    # With GCC, a newly generated PCH is always different, even if the contents should be exactly the same.
-    # And Clang stores file timestamps, so in this case the PCH is different too.
-    # So without .sum a "changed" PCH would mean a miss, but if the .sum doesn't change, it should be a hit.
+    # With GCC, a newly generated PCH is always different, even if the contents
+    # should be exactly the same. And Clang stores file timestamps, so in this
+    # case the PCH is different too. So without .sum a "changed" PCH would mean
+    # a miss, but if the .sum doesn't change, it should be a hit.
 
     sleep 1
     touch pch.h

--- a/unittest/main.c
+++ b/unittest/main.c
@@ -74,10 +74,6 @@ main(int argc, char **argv)
 		}
 	}
 
-	if (getenv("TRAVIS")) {
-		verbose = 1;
-	}
-
 	testdir = format("testdir.%d", (int)getpid());
 	cct_create_fresh_dir(testdir);
 	dir_before = gnu_getcwd();

--- a/unittest/main.c
+++ b/unittest/main.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2018 Joel Rosdahl
+// Copyright (C) 2010-2019 Joel Rosdahl
 //
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the Free
@@ -74,7 +74,7 @@ main(int argc, char **argv)
 		}
 	}
 
-	if (getenv("RUN_FROM_BUILD_FARM")) {
+	if (getenv("TRAVIS")) {
 		verbose = 1;
 	}
 

--- a/unittest/test_argument_processing.c
+++ b/unittest/test_argument_processing.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2018 Joel Rosdahl
+// Copyright (C) 2010-2019 Joel Rosdahl
 //
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the Free
@@ -483,6 +483,24 @@ TEST(debug_flag_order_with_known_option_last)
 	struct args *orig = args_init_from_string("cc -gsplit-dwarf -g1 foo.c -c");
 	struct args *exp_cpp = args_init_from_string("cc -gsplit-dwarf -g1");
 	struct args *exp_cc = args_init_from_string("cc -gsplit-dwarf -g1 -c");
+	struct args *act_cpp = NULL;
+	struct args *act_cc = NULL;
+
+	create_file("foo.c", "");
+	CHECK(cc_process_args(orig, &act_cpp, &act_cc));
+	CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
+	CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
+
+	args_free(orig);
+}
+
+TEST(options_not_to_be_passed_to_the_preprocesor)
+{
+	struct args *orig = args_init_from_string(
+		"cc -Wa,foo foo.c -g -Xlinker fie -Xlinker,fum -c -Werror");
+	struct args *exp_cpp = args_init_from_string("cc -g");
+	struct args *exp_cc = args_init_from_string(
+		"cc -g -Wa,foo -Xlinker fie -Xlinker,fum -Werror -c");
 	struct args *act_cpp = NULL;
 	struct args *act_cc = NULL;
 

--- a/unittest/test_argument_processing.c
+++ b/unittest/test_argument_processing.c
@@ -497,10 +497,10 @@ TEST(debug_flag_order_with_known_option_last)
 TEST(options_not_to_be_passed_to_the_preprocesor)
 {
 	struct args *orig = args_init_from_string(
-		"cc -Wa,foo foo.c -g -Xlinker fie -Xlinker,fum -c -Werror");
-	struct args *exp_cpp = args_init_from_string("cc -g");
+		"cc -Wa,foo foo.c -g -c -DX -Werror -Xlinker fie -Xlinker,fum -Wno-error");
+	struct args *exp_cpp = args_init_from_string("cc -g -DX");
 	struct args *exp_cc = args_init_from_string(
-		"cc -g -Wa,foo -Xlinker fie -Xlinker,fum -Werror -c");
+		"cc -g -Wa,foo -Werror -Xlinker fie -Xlinker,fum -Wno-error -DX -c");
 	struct args *act_cpp = NULL;
 	struct args *act_cc = NULL;
 

--- a/unittest/test_conf.c
+++ b/unittest/test_conf.c
@@ -369,11 +369,11 @@ TEST(conf_set_new_value)
 	char *data;
 
 	create_file("ccache.conf", "path = vanilla\n");
-	CHECKM(conf_set_value_in_file("ccache.conf", "stats", "chocolate", &errmsg),
+	CHECKM(conf_set_value_in_file("ccache.conf", "compiler", "chocolate", &errmsg),
 	       errmsg);
 	data = read_text_file("ccache.conf", 0);
 	CHECK(data);
-	CHECK_STR_EQ_FREE2("path = vanilla\nstats = chocolate\n", data);
+	CHECK_STR_EQ_FREE2("path = vanilla\ncompiler = chocolate\n", data);
 }
 
 TEST(conf_set_existing_value)


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.
-->
### Description ###
<!--
  Bugfix: If a compiler option contains "=" char, remove is from string.
  Example: cxrh850.exe -MD -MF=<path_to_file>
    Destination before fix: "=<path_to_file>"
    After fix: <path_to_file>
-->

