### PR TITLE
Handle -MF=file.d as understood by the Green Hills compilers

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -24,11 +24,9 @@ args_init(int init_argc, char **init_args)
 	args->argc = 0;
 	args->argv = (char **)x_malloc(sizeof(char *));
 	args->argv[0] = NULL;
-
-    for (int i = 0; i < init_argc; i++) {
-        args_add(args, init_args[i]);
-    }
-
+	for (int i = 0; i < init_argc; i++) {
+		args_add(args, init_args[i]);
+	}
 	return args;
 }
 

--- a/src/args.c
+++ b/src/args.c
@@ -24,9 +24,20 @@ args_init(int init_argc, char **init_args)
 	args->argc = 0;
 	args->argv = (char **)x_malloc(sizeof(char *));
 	args->argv[0] = NULL;
-	for (int i = 0; i < init_argc; i++) {
-		args_add(args, init_args[i]);
-	}
+
+    for (int i = 0; i < init_argc; i++) {
+        if(strstr(init_args[i], "-MF") == NULL) {
+            args_add(args, init_args[i]);
+        } else {
+            char *token;
+            token = strtok(init_args[i], "=");
+            while( token != NULL ) {
+                args_add(args, token);
+                token = strtok(NULL, "=");
+            }
+        }
+    }
+
 	return args;
 }
 

--- a/src/args.c
+++ b/src/args.c
@@ -26,16 +26,7 @@ args_init(int init_argc, char **init_args)
 	args->argv[0] = NULL;
 
     for (int i = 0; i < init_argc; i++) {
-        if(strstr(init_args[i], "-MF") == NULL) {
-            args_add(args, init_args[i]);
-        } else {
-            char *token;
-            token = strtok(init_args[i], "=");
-            while( token != NULL ) {
-                args_add(args, token);
-                token = strtok(NULL, "=");
-            }
-        }
+        args_add(args, init_args[i]);
     }
 
 	return args;

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -785,9 +785,9 @@ print_included_files(FILE *fp)
 static char *
 make_relative_path(char *path)
 {
-    if(path[0] == '=') { // Remove first char if string starts with "="
-        path++;
-    }
+    // if(path[0] == '=') { // Remove first char if string starts with "="
+    //     path++;
+    // }
 
 	if (str_eq(conf->base_dir, "") || !str_startswith(path, conf->base_dir)) {
 		return path;
@@ -795,7 +795,15 @@ make_relative_path(char *path)
 
 #ifdef _WIN32
 	if (path[0] == '/') {
-		path++;  // Skip leading slash.
+		char *p = NULL;
+		if (isalpha(path[1]) && path[2] == '/') {
+			// Transform /c/path... to c:/path...
+			p = format("%c:/%s", path[1], &path[3]);
+		} else {
+			p = x_strdup(path+1); // Skip leading slash.
+		}
+		free(path);
+		path = p;
 	}
 #endif
 

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -549,6 +549,7 @@ static enum guessed_compiler
 guess_compiler(const char *path)
 {
 	char *name = basename(path);
+    name = remove_extension(name);
 	enum guessed_compiler result = GUESSED_UNKNOWN;
 	if (strstr(name, "clang")) {
 		result = GUESSED_CLANG;
@@ -558,6 +559,8 @@ guess_compiler(const char *path)
 		result = GUESSED_NVCC;
 	} else if (str_eq(name, "pump") || str_eq(name, "distcc-pump")) {
 		result = GUESSED_PUMP;
+	} else if (str_eq(name, "cxrh850") || str_eq(name, "ccrh850") || str_eq(name, "cctri") || str_eq(name, "cxtri")) {
+		result = GUESSED_GHS;
 	}
 	free(name);
 	return result;
@@ -786,8 +789,9 @@ static char *
 make_relative_path(char *path)
 {
     // if(path[0] == '=') { // Remove first char if string starts with "="
-    //     path++;
-    // }
+    if(path[0] == '=') { // Remove first char if string starts with "="
+        path++;
+    }
 
 	if (str_eq(conf->base_dir, "") || !str_startswith(path, conf->base_dir)) {
 		return path;
@@ -1679,7 +1683,11 @@ get_object_name_from_cpp(struct args *args, struct hash *hash)
 		add_pending_tmp_file(path_stderr);
 
 		int args_added = 2;
-		args_add(args, "-E");
+        if (guessed_compiler == GUESSED_GHS)
+		    args_add(args, "-c"); // Temporary fix for GHS
+        else
+            args_add(args, "-E"); 
+        
 		if (conf->keep_comments_cpp) {
 			args_add(args, "-C");
 			args_added = 3;
@@ -2002,7 +2010,7 @@ calculate_object_hash(struct args *args, struct hash *hash, int direct_mode)
 	// clang will emit warnings for unused linker flags, so we shouldn't skip
 	// those arguments.
 	int is_clang =
-		guessed_compiler == GUESSED_CLANG || guessed_compiler == GUESSED_UNKNOWN;
+		guessed_compiler == GUESSED_CLANG || guessed_compiler == GUESSED_UNKNOWN || guessed_compiler == GUESSED_GHS;
 
 	// First the arguments.
 	for (int i = 1; i < args->argc; i++) {
@@ -2292,7 +2300,7 @@ from_cache(enum fromcache_call_mode mode, bool put_object_in_manifest)
 	//
 	//     file 'foo.h' has been modified since the precompiled header 'foo.pch'
 	//     was built
-	if ((guessed_compiler == GUESSED_CLANG || guessed_compiler == GUESSED_UNKNOWN)
+	if ((guessed_compiler == GUESSED_CLANG || guessed_compiler == GUESSED_UNKNOWN || guessed_compiler == GUESSED_GHS)
 	    && output_is_precompiled_header
 	    && mode == FROMCACHE_CPP_MODE) {
 		cc_log("Not considering cached precompiled header in preprocessor mode");
@@ -3517,7 +3525,10 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		if (!dependency_target_specified
 		    && !dependency_implicit_target_specified
 		    && !str_eq(get_extension(output_dep), ".o")) {
-			args_add(dep_args, "-MQ");
+			if (guessed_compiler == GUESSED_GHS)
+                args_add(dep_args, "-o"); // Temporary fix for GHS
+            else
+                args_add(dep_args, "-MQ");
 			args_add(dep_args, output_obj);
 		}
 	}

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -785,6 +785,10 @@ print_included_files(FILE *fp)
 static char *
 make_relative_path(char *path)
 {
+    if(path[0] == '=') { // Remove first char if string starts with "="
+        path++;
+    }
+
 	if (str_eq(conf->base_dir, "") || !str_startswith(path, conf->base_dir)) {
 		return path;
 	}

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -788,7 +788,6 @@ print_included_files(FILE *fp)
 static char *
 make_relative_path(char *path)
 {
-    // if(path[0] == '=') { // Remove first char if string starts with "="
     if(path[0] == '=') { // Remove first char if string starts with "="
         path++;
     }
@@ -799,15 +798,7 @@ make_relative_path(char *path)
 
 #ifdef _WIN32
 	if (path[0] == '/') {
-		char *p = NULL;
-		if (isalpha(path[1]) && path[2] == '/') {
-			// Transform /c/path... to c:/path...
-			p = format("%c:/%s", path[1], &path[3]);
-		} else {
-			p = x_strdup(path+1); // Skip leading slash.
-		}
-		free(path);
-		path = p;
+		path++;  // Skip leading slash.
 	}
 #endif
 
@@ -3499,7 +3490,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 	// Since output is redirected, compilers will not color their output by
 	// default, so force it explicitly if it would be otherwise done.
 	if (!found_color_diagnostics && color_output_possible()) {
-		if (guessed_compiler == GUESSED_CLANG) {
+		if (guessed_compiler == GUESSED_CLANG || guessed_compiler == GUESSED_GHS) {
 			if (!str_eq(actual_language, "assembler")) {
 				args_add(common_args, "-fcolor-diagnostics");
 				cc_log("Automatically enabling colors");

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -549,7 +549,7 @@ static enum guessed_compiler
 guess_compiler(const char *path)
 {
 	char *name = basename(path);
-    name = remove_extension(name);
+	name = remove_extension(name);
 	enum guessed_compiler result = GUESSED_UNKNOWN;
 	if (strstr(name, "clang")) {
 		result = GUESSED_CLANG;
@@ -788,9 +788,9 @@ print_included_files(FILE *fp)
 static char *
 make_relative_path(char *path)
 {
-    if(path[0] == '=') { // Remove first char if string starts with "="
-        path++;
-    }
+	if(path[0] == '=') { // Remove first char if string starts with "="
+		path++;
+	}
 
 	if (str_eq(conf->base_dir, "") || !str_startswith(path, conf->base_dir)) {
 		return path;
@@ -1674,11 +1674,11 @@ get_object_name_from_cpp(struct args *args, struct hash *hash)
 		add_pending_tmp_file(path_stderr);
 
 		int args_added = 2;
-        if (guessed_compiler == GUESSED_GHS)
-		    args_add(args, "-c"); // Temporary fix for GHS
-        else
-            args_add(args, "-E"); 
-        
+		if (guessed_compiler == GUESSED_GHS)
+			args_add(args, "-c"); // Temporary fix for GHS
+		else
+			args_add(args, "-E"); 
+		
 		if (conf->keep_comments_cpp) {
 			args_add(args, "-C");
 			args_added = 3;
@@ -3522,9 +3522,9 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		    && !dependency_implicit_target_specified
 		    && !str_eq(get_extension(output_dep), ".o")) {
 			if (guessed_compiler == GUESSED_GHS)
-                args_add(dep_args, "-o"); // Temporary fix for GHS
-            else
-                args_add(dep_args, "-MQ");
+				args_add(dep_args, "-o"); // Temporary fix for GHS
+			else
+				args_add(dep_args, "-MQ");
 			args_add(dep_args, output_obj);
 		}
 	}

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -80,6 +80,7 @@ enum guessed_compiler {
 	GUESSED_GCC,
 	GUESSED_NVCC,
 	GUESSED_PUMP,
+    GUESSED_GHS,
 	GUESSED_UNKNOWN
 };
 

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -80,7 +80,7 @@ enum guessed_compiler {
 	GUESSED_GCC,
 	GUESSED_NVCC,
 	GUESSED_PUMP,
-    GUESSED_GHS,
+	GUESSED_GHS,
 	GUESSED_UNKNOWN
 };
 

--- a/src/util.c
+++ b/src/util.c
@@ -466,7 +466,6 @@ error:
 int
 move_file(const char *src, const char *dest, int compress_level)
 {
-    cc_log("move_file() -> copy_file()");
 	int ret = copy_file(src, dest, compress_level);
 	if (ret != -1) {
 		x_unlink(src);
@@ -480,7 +479,6 @@ int
 move_uncompressed_file(const char *src, const char *dest, int compress_level)
 {
 	if (compress_level > 0) {
-        cc_log("move_uncompressed_file() -> move_file()");
 		return move_file(src, dest, compress_level);
 	} else {
 		return x_rename(src, dest);
@@ -1163,15 +1161,7 @@ x_realpath(const char *path)
 	p = realpath(path, ret);
 #elif defined(_WIN32)
 	if (path[0] == '/') {
-		char *p = NULL;
-		if (isalpha(path[1]) && path[2] == '/') {
-			// Transform /c/path... to c:/path...
-			p = format("%c:/%s", path[1], &path[3]);
-		} else {
-			p = x_strdup(path+1); // Skip leading slash.
-		}
-		free(path);
-		path = p;
+		path++;  // Skip leading slash.
 	}
 	HANDLE path_handle = CreateFile(
 		path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,

--- a/src/util.c
+++ b/src/util.c
@@ -322,9 +322,9 @@ copy_file(const char *src, const char *dest, int compress_level)
 	gzFile gz_in = NULL;
 	gzFile gz_out = NULL;
 	int saved_errno = 0;
-    if(src[0] == '=') { // Remove first char if string starts with "="
-        src++;
-    }
+	if(src[0] == '=') { // Remove first char if string starts with "="
+		src++;
+	}
 
 	// Open destination file.
 	char *tmp_name = x_strdup(dest);

--- a/src/util.c
+++ b/src/util.c
@@ -340,7 +340,6 @@ copy_file(const char *src, const char *dest, int compress_level)
 	gz_in = gzdopen(fd_in, "rb");
 	if (!gz_in) {
 		saved_errno = errno;
-		cc_log("gzdopen(src) error: %s", strerror(saved_errno));
 		close(fd_in);
 		goto error;
 	}
@@ -464,6 +463,7 @@ error:
 int
 move_file(const char *src, const char *dest, int compress_level)
 {
+    cc_log("move_file() -> copy_file()");
 	int ret = copy_file(src, dest, compress_level);
 	if (ret != -1) {
 		x_unlink(src);
@@ -477,6 +477,7 @@ int
 move_uncompressed_file(const char *src, const char *dest, int compress_level)
 {
 	if (compress_level > 0) {
+        cc_log("move_uncompressed_file() -> move_file()");
 		return move_file(src, dest, compress_level);
 	} else {
 		return x_rename(src, dest);
@@ -1159,7 +1160,15 @@ x_realpath(const char *path)
 	p = realpath(path, ret);
 #elif defined(_WIN32)
 	if (path[0] == '/') {
-		path++;  // Skip leading slash.
+		char *p = NULL;
+		if (isalpha(path[1]) && path[2] == '/') {
+			// Transform /c/path... to c:/path...
+			p = format("%c:/%s", path[1], &path[3]);
+		} else {
+			p = x_strdup(path+1); // Skip leading slash.
+		}
+		free(path);
+		path = p;
 	}
 	HANDLE path_handle = CreateFile(
 		path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,

--- a/src/util.c
+++ b/src/util.c
@@ -322,6 +322,9 @@ copy_file(const char *src, const char *dest, int compress_level)
 	gzFile gz_in = NULL;
 	gzFile gz_out = NULL;
 	int saved_errno = 0;
+    if(src[0] == '=') { // Remove first char if string starts with "="
+        src++;
+    }
 
 	// Open destination file.
 	char *tmp_name = x_strdup(dest);


### PR DESCRIPTION

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.
-->
### Description ###

Remove '=' from destination path.
In case compiler option contains an '=' char, remove it from the dest path.

Fix: Removes "=" char from destination path if compiler option contains "="
Example: cxrh850.exe -MD -MF=<path_to_file>
Before fix: dest path: **=**<path_to_file>
After fix: dest path: <path_to_file>

