### PR TITLE
configure: Update libzstd to 1.4.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ dnl Check if -lm is needed.
 AC_SEARCH_LIBS(cos, m)
 
 dnl Check for libzstd
-zstd_version=1.4.2
+zstd_version=1.4.3
 zstd_url=https://github.com/facebook/zstd/releases/download/v${zstd_version}/zstd-${zstd_version}.tar.gz
 
 AC_ARG_WITH(libzstd-from-internet,


### PR DESCRIPTION
### Description ###

Updates libzstd to [v1.4.3](https://github.com/facebook/zstd/releases/tag/v1.4.3)

Confirmed that `make check` passes on Linux x86_64