### PR TITLE
Limit suffix size in ResultFileMap to 15

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1440,25 +1440,25 @@ to_cache(struct args* args, struct hash* depend_mode_hash)
   }
   ResultFileMap result_file_map;
   if (st.st_size > 0) {
-    result_file_map.emplace(k_result_stderr_name, tmp_stderr);
+    result_file_map.register_suffix(k_result_stderr_name, tmp_stderr);
   }
-  result_file_map.emplace(".o", output_obj);
+  result_file_map.register_suffix(".o", output_obj);
   if (generating_dependencies) {
-    result_file_map.emplace(".d", output_dep);
+    result_file_map.register_suffix(".d", output_dep);
   }
   if (generating_coverage) {
-    result_file_map.emplace(".gcno", output_cov);
+    result_file_map.register_suffix(".gcno", output_cov);
   }
   if (generating_stackusage) {
-    result_file_map.emplace(".su", output_su);
+    result_file_map.register_suffix(".su", output_su);
   }
   if (generating_diagnostics) {
-    result_file_map.emplace(".dia", output_dia);
+    result_file_map.register_suffix(".dia", output_dia);
   }
   if (seen_split_dwarf && stat(output_dwo, &st) == 0) {
     // Only copy .dwo file if it was created by the compiler (GCC and Clang
     // behave differently e.g. for "-gsplit-dwarf -g1").
-    result_file_map.emplace(".dwo", output_dwo);
+    result_file_map.register_suffix(".dwo", output_dwo);
   }
   struct stat orig_dest_st;
   bool orig_dest_existed = stat(cached_result_path, &orig_dest_st) == 0;
@@ -2179,23 +2179,23 @@ from_cache(enum fromcache_call_mode mode, bool put_result_in_manifest)
 
   ResultFileMap result_file_map;
   if (!str_eq(output_obj, "/dev/null")) {
-    result_file_map.emplace(".o", output_obj);
+    result_file_map.register_suffix(".o", output_obj);
     if (seen_split_dwarf) {
-      result_file_map.emplace(".dwo", output_dwo);
+      result_file_map.register_suffix(".dwo", output_dwo);
     }
   }
-  result_file_map.emplace(k_result_stderr_name, tmp_stderr);
+  result_file_map.register_suffix(k_result_stderr_name, tmp_stderr);
   if (produce_dep_file) {
-    result_file_map.emplace(".d", output_dep);
+    result_file_map.register_suffix(".d", output_dep);
   }
   if (generating_coverage) {
-    result_file_map.emplace(".gcno", output_cov);
+    result_file_map.register_suffix(".gcno", output_cov);
   }
   if (generating_stackusage) {
-    result_file_map.emplace(".su", output_su);
+    result_file_map.register_suffix(".su", output_su);
   }
   if (generating_diagnostics) {
-    result_file_map.emplace(".dia", output_dia);
+    result_file_map.register_suffix(".dia", output_dia);
   }
   bool ok = result_get(cached_result_path, result_file_map);
   if (!ok) {

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -121,6 +121,8 @@ extern enum guessed_compiler guessed_compiler;
 // Buffer size for I/O operations. Should be a multiple of 4 KiB.
 #define READ_BUFFER_SIZE 65536
 
+#define MAX_SUFFIX_SIZE 15
+
 class Config;
 
 // ----------------------------------------------------------------------------

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -97,6 +97,14 @@ const uint8_t k_embedded_file_marker = 0;
 // File stored as-is in the file system.
 const uint8_t k_raw_file_marker = 1;
 
+void ResultFileMap::register_suffix(std::string suffix, const char* path)
+{
+  if (suffix.size() >= MAX_SUFFIX_SIZE) {
+    throw Error("internal error: suffix too large");
+  }
+  this->emplace(suffix, path);
+}
+
 using ReadEntryFunction = void (*)(CacheEntryReader& reader,
                                    const std::string& result_path_in_cache,
                                    uint32_t entry_number,
@@ -119,8 +127,9 @@ read_embedded_file_entry(CacheEntryReader& reader,
   uint8_t suffix_len;
   reader.read(suffix_len);
 
-  char suffix[256];
+  char suffix[MAX_SUFFIX_SIZE + 1];
   reader.read(suffix, suffix_len);
+  suffix[suffix_len] = '\0';
 
   uint64_t file_len;
   reader.read(file_len);
@@ -220,8 +229,9 @@ read_raw_file_entry(CacheEntryReader& reader,
   uint8_t suffix_len;
   reader.read(suffix_len);
 
-  char suffix[256];
+  char suffix[MAX_SUFFIX_SIZE + 1];
   reader.read(suffix, suffix_len);
+  suffix[suffix_len] = '\0';
 
   uint64_t file_len;
   reader.read(file_len);

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -27,7 +27,16 @@ extern const uint8_t k_result_magic[4];
 extern const uint8_t k_result_version;
 extern const std::string k_result_stderr_name;
 
-typedef std::map<std::string /*suffix*/, std::string /*path*/> ResultFileMap;
+struct ResultFileMap : private std::map<std::string, std::string> {
+  using map = std::map<std::string /*suffix*/, std::string /*path*/>;
+  using map::at;
+  using map::begin;
+  using map::end;
+  using map::find;
+  using map::size;
+  using map::value_type;
+  void register_suffix(std::string suffix, const char* path);
+};
 
 bool result_get(const std::string& path, const ResultFileMap& result_file_map);
 bool result_put(const std::string& path, const ResultFileMap& result_file_map);


### PR DESCRIPTION
Implicit but unenforced limit was 256 before.
Reduces stack usage and ensures SSO for the
std::string (which is used as the map key) is
always possible.

Also fix an out-of-bounds read when logging.

-------
Additional motivation: Make sure this limit is set now before plugins use overly long keys.

And now that I think about it: The key uniqueness needs to be ensured as well.