### PR TITLE
Convert result type string to an enum

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1440,25 +1440,25 @@ to_cache(struct args* args, struct hash* depend_mode_hash)
   }
   ResultFileMap result_file_map;
   if (st.st_size > 0) {
-    result_file_map.emplace(k_result_stderr_name, tmp_stderr);
+    result_file_map.emplace(FileType::stderr_output, tmp_stderr);
   }
-  result_file_map.emplace(".o", output_obj);
+  result_file_map.emplace(FileType::object, output_obj);
   if (generating_dependencies) {
-    result_file_map.emplace(".d", output_dep);
+    result_file_map.emplace(FileType::dependency, output_dep);
   }
   if (generating_coverage) {
-    result_file_map.emplace(".gcno", output_cov);
+    result_file_map.emplace(FileType::coverage, output_cov);
   }
   if (generating_stackusage) {
-    result_file_map.emplace(".su", output_su);
+    result_file_map.emplace(FileType::stackusage, output_su);
   }
   if (generating_diagnostics) {
-    result_file_map.emplace(".dia", output_dia);
+    result_file_map.emplace(FileType::diagnostic, output_dia);
   }
   if (seen_split_dwarf && stat(output_dwo, &st) == 0) {
     // Only copy .dwo file if it was created by the compiler (GCC and Clang
     // behave differently e.g. for "-gsplit-dwarf -g1").
-    result_file_map.emplace(".dwo", output_dwo);
+    result_file_map.emplace(FileType::dwarf_object, output_dwo);
   }
   struct stat orig_dest_st;
   bool orig_dest_existed = stat(cached_result_path, &orig_dest_st) == 0;
@@ -2179,23 +2179,23 @@ from_cache(enum fromcache_call_mode mode, bool put_result_in_manifest)
 
   ResultFileMap result_file_map;
   if (!str_eq(output_obj, "/dev/null")) {
-    result_file_map.emplace(".o", output_obj);
+    result_file_map.emplace(FileType::object, output_obj);
     if (seen_split_dwarf) {
-      result_file_map.emplace(".dwo", output_dwo);
+      result_file_map.emplace(FileType::dwarf_object, output_dwo);
     }
   }
-  result_file_map.emplace(k_result_stderr_name, tmp_stderr);
+  result_file_map.emplace(FileType::stderr_output, tmp_stderr);
   if (produce_dep_file) {
-    result_file_map.emplace(".d", output_dep);
+    result_file_map.emplace(FileType::dependency, output_dep);
   }
   if (generating_coverage) {
-    result_file_map.emplace(".gcno", output_cov);
+    result_file_map.emplace(FileType::coverage, output_cov);
   }
   if (generating_stackusage) {
-    result_file_map.emplace(".su", output_su);
+    result_file_map.emplace(FileType::stackusage, output_su);
   }
   if (generating_diagnostics) {
-    result_file_map.emplace(".dia", output_dia);
+    result_file_map.emplace(FileType::diagnostic, output_dia);
   }
   bool ok = result_get(cached_result_path, result_file_map);
   if (!ok) {

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -25,9 +25,24 @@
 
 extern const uint8_t k_result_magic[4];
 extern const uint8_t k_result_version;
-extern const std::string k_result_stderr_name;
 
-typedef std::map<std::string /*suffix*/, std::string /*path*/> ResultFileMap;
+using UnderlyingFileTypeInt = uint8_t;
+enum class FileType : UnderlyingFileTypeInt {
+  // These values are written into the cache result file.
+  // This means they must never be changed or removed unless the
+  // result file version is incremented. Adding new values is Ok.
+  object = 0,
+  dependency = 1,
+  stderr_output = 2,
+  coverage = 3,
+  stackusage = 4,
+  diagnostic = 5,
+  dwarf_object = 6,
+
+  Max = 255,
+};
+
+using ResultFileMap = std::map<FileType, std::string /*path*/>;
 
 bool result_get(const std::string& path, const ResultFileMap& result_file_map);
 bool result_put(const std::string& path, const ResultFileMap& result_file_map);


### PR DESCRIPTION
As discussed in #473, feel free to adapt the enum name or the enum entries to your liking. E.g. to me it was very important that stderr_output had the id 2!