### PR TITLE
Fix warning during configure in out of tree build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ if test ! -f $srcdir/dev_mode_disabled; then
     AC_CONFIG_FILES([dev.mk])
     include_dev_mk='include dev.mk'
     version=`(git --git-dir=$srcdir/.git describe --dirty 2>/dev/null || echo vunknown) | sed -e 's/v//' -e 's/-/+/' -e 's/-/_/g'`
+    mkdir -p src
     echo "extern const char CCACHE_VERSION@<:@@:>@; const char CCACHE_VERSION@<:@@:>@ = \"$version\";" >src/version.cpp
 else
     dev_mode=no


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.
-->
### Description ###
<!--
  Please describe below what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
Fixes the warning `../configure: line 2250: src/version.cpp: No such file or directory` when doing out of source build.
