### PR TITLE
Correct "-MJ" bail out, identify both "-MJ file" and "-MJfile"

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2649,7 +2649,9 @@ cc_process_args(struct args *args,
 		}
 
 		// These are always too hard.
-		if (compopt_too_hard(argv[i]) || str_startswith(argv[i], "-fdump-")) {
+		if (compopt_too_hard(argv[i])
+		    || str_startswith(argv[i], "-fdump-")
+		    || str_startswith(argv[i], "-MJ")) {
 			cc_log("Compiler option %s is unsupported", argv[i]);
 			stats_update(STATS_UNSUPPORTED_OPTION);
 			result = false;

--- a/src/compopt.c
+++ b/src/compopt.c
@@ -65,7 +65,6 @@ static const struct compopt compopts[] = {
 	{"-L",              TAKES_ARG},
 	{"-M",              TOO_HARD},
 	{"-MF",             TAKES_ARG},
-	{"-MJ",             TAKES_ARG | TOO_HARD},
 	{"-MM",             TOO_HARD},
 	{"-MQ",             TAKES_ARG},
 	{"-MT",             TAKES_ARG},
@@ -175,16 +174,27 @@ compopt_short(bool (*fn)(const char *), const char *option)
 }
 
 // Used by unittest/test_compopt.c.
-bool compopt_verify_sortedness(void);
+bool compopt_verify_sortedness_and_flags(void);
 
 // For test purposes.
 bool
-compopt_verify_sortedness(void)
+compopt_verify_sortedness_and_flags(void)
 {
-	for (size_t i = 1; i < ARRAY_SIZE(compopts); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(compopts); i++) {
+		if (compopts[i].type & TOO_HARD && compopts[i].type & TAKES_CONCAT_ARG) {
+			fprintf(stderr,
+			        "type (TOO_HARD | TAKES_CONCAT_ARG) not allowed, used by %s\n",
+			        compopts[i].name);
+			return false;
+		}
+
+		if (i == 0) {
+			continue;
+		}
+
 		if (strcmp(compopts[i-1].name, compopts[i].name) >= 0) {
 			fprintf(stderr,
-			        "compopt_verify_sortedness: %s >= %s\n",
+			        "compopt_verify_sortedness_and_flags: %s >= %s\n",
 			        compopts[i-1].name,
 			        compopts[i].name);
 			return false;

--- a/unittest/test_compopt.c
+++ b/unittest/test_compopt.c
@@ -24,8 +24,8 @@ TEST_SUITE(compopt)
 
 TEST(option_table_should_be_sorted)
 {
-	bool compopt_verify_sortedness(void);
-	CHECK(compopt_verify_sortedness());
+	bool compopt_verify_sortedness_and_flags(void);
+	CHECK(compopt_verify_sortedness_and_flags());
 }
 
 TEST(dash_I_affects_cpp)


### PR DESCRIPTION
Added test to detect the invalid case TOO_HARD | TAKES_CONCAT_ARG