### PR TITLE
Add handling of __TIMESTAMP__ macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,7 @@ AC_CHECK_HEADERS(sys/ioctl.h)
 AC_CHECK_HEADERS(linux/fs.h)
 AC_CHECK_HEADERS(sys/clonefile.h)
 
+AC_CHECK_FUNCS(asctime_r)
 AC_CHECK_FUNCS(gethostname)
 AC_CHECK_FUNCS(getopt_long)
 AC_CHECK_FUNCS(getpwuid)

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -678,7 +678,8 @@ still has to do _some_ preprocessing (like macros).
     With this option set, ccache will only include system headers in the hash
     but not add the system header files to the list of include files.
 *time_macros*::
-    Ignore `__DATE__` and `__TIME__` being present in the source code.
+    Ignore `__DATE__`, `__TIME__` and `__TIMESTAMP__` being present in the
+    source code.
 --
 +
 See the discussion under <<_troubleshooting,TROUBLESHOOTING>> for more
@@ -1171,10 +1172,10 @@ ccache has support for GCC's precompiled headers. However, you have to do some
 things to make it work properly:
 
 * You must set <<config_sloppiness,*sloppiness*>> to *pch_defines,time_macros*.
-  The reason is that ccache can't tell whether `__TIME__` or `__DATE__` is used
-  when using a precompiled header. Further, it can't detect changes in
-  **#define**s in the source code because of how preprocessing works in
-  combination with precompiled headers.
+  The reason is that ccache can't tell whether `__TIME__`, `__DATE__` or
+  `__TIMESTAMP__` is used when using a precompiled header. Further, it can't
+  detect changes in **#define**s in the source code because of how
+  preprocessing works in combination with precompiled headers.
 * You must either:
 +
 --
@@ -1361,6 +1362,15 @@ problems and what may be done to increase the hit rate:
    output. If you know that `__DATE__` isn't used in practise, or don't care if
    ccache produces objects where `__DATE__` is expanded to something in the
    past, you can set <<config_sloppiness,*sloppiness*>> to *time_macros*.
+** The `__TIMESTAMP__` preprocessor macro is (potentially) being used and the
+   source file's modification time has changed. This is similar to how
+   `__TIME__` is handled. If `__TIMESTAMP__` is present in the source code,
+   ccache hashes the string representation of the source file's modification
+   time in order to be able to produce the correct object file if the
+   `__TIMESTAMP__` macro affects the output. If you know that `__TIMESTAMP__`
+   isn't used in practise, or don't care if ccache produces objects where
+   `__TIMESTAMP__` is expanded to something in the past, you can set
+   <<config_sloppiness,*sloppiness*>> to *time_macros*.
 ** The input file path has changed. ccache normally includes the input file
    path in the hash in order to be able to produce the correct object file if
    the source code includes a `__FILE__` macro. If you know that `__FILE__`
@@ -1372,9 +1382,9 @@ problems and what may be done to increase the hit rate:
   compiled and cached before, ccache has either detected that something has
   changed anyway or a cleanup has been performed (either explicitly or
   implicitly when a cache limit has been reached). Some perhaps unobvious
-  things that may result in a cache miss are usage of `__TIME__` or
-  `__DATE__` macros, or use of automatically generated code that contains a
-  timestamp, build counter or other volatile information.
+  things that may result in a cache miss are usage of `__TIME__`, `__DATE__` or
+  `__TIMESTAMP__` macros, or use of automatically generated code that contains
+  a timestamp, build counter or other volatile information.
 * If ``multiple source files'' has been incremented, it's an indication that
   the compiler has been invoked on several source code files at once. ccache
   doesn't support that. Compile the source code files separately if possible.

--- a/src/hashutil.hpp
+++ b/src/hashutil.hpp
@@ -31,6 +31,7 @@ unsigned hash_from_int(int i);
 #define HASH_SOURCE_CODE_ERROR 1
 #define HASH_SOURCE_CODE_FOUND_DATE 2
 #define HASH_SOURCE_CODE_FOUND_TIME 4
+#define HASH_SOURCE_CODE_FOUND_TIMESTAMP 8
 
 int check_for_temporal_macros(const char* str, size_t len);
 int hash_source_code_string(const Config& config,

--- a/src/macroskip.hpp
+++ b/src/macroskip.hpp
@@ -23,9 +23,9 @@
 #include <cstdint>
 
 // A Boyer-Moore-Horspool skip table used for searching for the strings
-// "__TIME__" and "__DATE__".
+// "__TIME__", "__DATE__" and "__TIMESTAMP__".
 //
-// macro_skip[c] = 8 for all c not in "__TIME__" and "__DATE__".
+// macro_skip[c] = 8 for all c not in "__TIME__", "__DATE__" and "__TIMEST".
 //
 // The other characters map as follows:
 //
@@ -36,6 +36,7 @@
 //   I -> 4
 //   M -> 3
 //   T -> 3
+//   S -> 1
 //
 //
 // This was generated with the following Python script:
@@ -46,6 +47,7 @@
 //      'E': 2,
 //      'I': 4,
 //      'M': 3,
+//      'S': 1,
 //      'T': 3}
 //
 // for i in range(0, 256):
@@ -62,7 +64,7 @@ static const uint32_t macro_skip[] = {
   8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
   8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
   8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 4, 8, 8, 5, 2, 8, 8, 8, 4, 8, 8, 8, 3,
-  8, 8, 8, 8, 8, 8, 3, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 8, 8, 8, 8, 8, 8, 8, 8,
+  8, 8, 8, 8, 8, 1, 3, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 8, 8, 8, 8, 8, 8, 8, 8,
   8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
   8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
   8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,

--- a/unittest/test_hashutil.cpp
+++ b/unittest/test_hashutil.cpp
@@ -178,6 +178,14 @@ TEST(check_for_temporal_macros)
     "int ab;\n";
   const char date_end[] = "#define ab __DATE__";
 
+  const char timestamp_start[] =
+    "__TIMESTAMP__\n"
+    "int c;\n";
+  const char timestamp_middle[] =
+    "#define c __TIMESTAMP__\n"
+    "int c;\n";
+  const char timestamp_end[] = "#define c __TIMESTAMP__";
+
   const char no_temporal[] =
     "#define ab a__DATE__\n"
     "#define ab  __DATE__a\n"
@@ -236,6 +244,35 @@ TEST(check_for_temporal_macros)
   CHECK(check_for_temporal_macros(date_end + 0, sizeof(date_end) - 0));
   CHECK(check_for_temporal_macros(date_end + sizeof(date_end) - 9, 9));
   CHECK(!check_for_temporal_macros(date_end + sizeof(date_end) - 8, 8));
+
+  CHECK(check_for_temporal_macros(timestamp_start + 0,
+                                  sizeof(timestamp_start) - 0));
+  CHECK(!check_for_temporal_macros(timestamp_start + 1,
+                                   sizeof(timestamp_start) - 1));
+
+  CHECK(check_for_temporal_macros(timestamp_middle + 0,
+                                  sizeof(timestamp_middle) - 0));
+  CHECK(check_for_temporal_macros(timestamp_middle + 1,
+                                  sizeof(timestamp_middle) - 1));
+  CHECK(check_for_temporal_macros(timestamp_middle + 2,
+                                  sizeof(timestamp_middle) - 2));
+  CHECK(check_for_temporal_macros(timestamp_middle + 3,
+                                  sizeof(timestamp_middle) - 3));
+  CHECK(check_for_temporal_macros(timestamp_middle + 4,
+                                  sizeof(timestamp_middle) - 4));
+  CHECK(check_for_temporal_macros(timestamp_middle + 5,
+                                  sizeof(timestamp_middle) - 5));
+  CHECK(check_for_temporal_macros(timestamp_middle + 6,
+                                  sizeof(timestamp_middle) - 6));
+  CHECK(check_for_temporal_macros(timestamp_middle + 7,
+                                  sizeof(timestamp_middle) - 7));
+
+  CHECK(
+    check_for_temporal_macros(timestamp_end + 0, sizeof(timestamp_end) - 0));
+  CHECK(
+    check_for_temporal_macros(timestamp_end + sizeof(timestamp_end) - 14, 14));
+  CHECK(
+    !check_for_temporal_macros(timestamp_end + sizeof(timestamp_end) - 13, 13));
 
   CHECK(!check_for_temporal_macros(no_temporal + 0, sizeof(no_temporal) - 0));
   CHECK(!check_for_temporal_macros(no_temporal + 1, sizeof(no_temporal) - 1));


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.
-->
### Description ###
<!--
  Please describe below what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
`__TIMESTAMP__` is [expanded by the pre-processor](https://github.com/gcc-mirror/gcc/blob/master/libcpp/macro.c#L397) to `asctime()` of the source file's modification time. Handle `__TIMESTAMP__` similar to `__DATE__` and include asctime(modification time) in the hash when `__TIMESTAMP__` is detected in the source code.


