### PR TITLE
do not resolve symlinks for CCACHE_BASEDIR

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -833,7 +833,7 @@ make_relative_path(char* path)
     free(p);
   }
 
-  char* canon_path = x_realpath(path);
+  char* canon_path = x_strdup(path);
   if (canon_path) {
     free(path);
     char* relpath = get_relative_path(get_current_working_dir(), canon_path);

--- a/test/suites/basedir.bash
+++ b/test/suites/basedir.bash
@@ -45,28 +45,6 @@ SUITE_basedir() {
     expect_stat 'cache miss' 2
 
     # -------------------------------------------------------------------------
- if ! $HOST_OS_WINDOWS && ! $HOST_OS_CYGWIN; then
-    TEST "Path normalization"
-
-    cd dir1
-    CCACHE_BASEDIR="`pwd`" $CCACHE_COMPILE -I`pwd`/include -c src/test.c
-    expect_stat 'cache hit (direct)' 0
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
-    mkdir subdir
-    ln -s `pwd`/include subdir/symlink
-
-    # Rewriting triggered by CCACHE_BASEDIR should handle paths with multiple
-    # slashes, redundant "/." parts and "foo/.." parts correctly. Note that the
-    # ".." part of the path is resolved after the symlink has been resolved.
-    CCACHE_BASEDIR=`pwd` $CCACHE_COMPILE -I`pwd`//./subdir/symlink/../include -c `pwd`/src/test.c
-    expect_stat 'cache hit (direct)' 1
-    expect_stat 'cache hit (preprocessed)' 0
-    expect_stat 'cache miss' 1
-
- fi
-    # -------------------------------------------------------------------------
     TEST "Rewriting in stderr"
 
     cat <<EOF >stderr.h


### PR DESCRIPTION
When building with builddir != srcdir, it is practically necessary
to have either builddir contain srcdir or the other way around,
otherwise relative paths from one to another will not be the same
for different builds, which will lead to misses with CCACHE_BASEDIR.
In case one wants builddir and srcdir to be elsewhere (for a number
of reasons, different filesystems, build files inside srcdir being
a mess, ...), this setup can be achieved using a symlink. But then
symlink resolving changes the relative path to exactly the broken
setup mentioned above.

The resolving was introduced in 2df269a3121889ebcdfa5d98dfb4d675f690e039
with questionable reasoning (how can CWD possibly contain "/./"?).
The only test that breaks by removing this change is an artifical
test designed to test exactly this (mis)feature, all the rest work fine.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.
-->
### Description ###
<!--
  Please describe below what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->

