### PR TITLE
Windows define and include restructuring

### DIFF
--- a/src/CacheEntryWriter.hpp
+++ b/src/CacheEntryWriter.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include "Checksum.hpp"
 #include "Compressor.hpp"
 #include "Util.hpp"

--- a/src/CacheFile.hpp
+++ b/src/CacheFile.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include "Error.hpp"
 #include "Stat.hpp"
 

--- a/src/Compressor.hpp
+++ b/src/Compressor.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include "Compression.hpp"
 
 #include <memory>

--- a/src/File.hpp
+++ b/src/File.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include "NonCopyable.hpp"
 
 #include <cstdio>

--- a/src/FormatNonstdStringView.hpp
+++ b/src/FormatNonstdStringView.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include "third_party/fmt/core.h"
 #include "third_party/nonstd/string_view.hpp"
 

--- a/src/NullCompressor.hpp
+++ b/src/NullCompressor.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include "Compressor.hpp"
 #include "NonCopyable.hpp"
 

--- a/src/NullDecompressor.hpp
+++ b/src/NullDecompressor.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include "Decompressor.hpp"
 #include "NonCopyable.hpp"
 

--- a/src/ProgressBar.cpp
+++ b/src/ProgressBar.cpp
@@ -23,9 +23,7 @@
 #include <cstdio>
 #include <unistd.h>
 
-#ifdef _WIN32
-#  include <windows.h>
-#else
+#ifndef _WIN32
 #  include <sys/ioctl.h>
 #endif
 

--- a/src/ProgressBar.hpp
+++ b/src/ProgressBar.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include <string>
 
 class ProgressBar

--- a/src/cleanup.hpp
+++ b/src/cleanup.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include "Util.hpp"
 
 #include <string>

--- a/src/compress.hpp
+++ b/src/compress.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "system.hpp"
+
 #include "Config.hpp"
 #include "Util.hpp"
 

--- a/src/legacy_util.cpp
+++ b/src/legacy_util.cpp
@@ -60,7 +60,6 @@
 #  include <psapi.h>
 #  include <sys/locking.h>
 #  include <tchar.h>
-#  include <windows.h>
 #endif
 
 // Destination for g_config.log_file.

--- a/src/system.hpp
+++ b/src/system.hpp
@@ -71,7 +71,8 @@ extern char** environ;
 
 #ifdef _WIN32
 #  ifndef _WIN32_WINNT
-#    define _WIN32_WINNT 0x0501
+// _WIN32_WINNT is set in the generated header config.h
+#    error _WIN32_WINNT is undefined
 #  endif
 #  include <windows.h>
 #  define mkdir(a, b) mkdir(a)


### PR DESCRIPTION
Set the _WIN32_WINNT macro only once in the generated config.h.

Include <windows.h> only once in system.hpp, unless these includes
are in third party libs - however third party includes themselves
should always be behind internal includes.
