### PR TITLE
Visual C/C++ compiler support

### DIFF
--- a/misc/codespell-allowlist.txt
+++ b/misc/codespell-allowlist.txt
@@ -1,3 +1,4 @@
+fo
 copyable
 creat
 files'

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -50,7 +50,7 @@ Args::from_string(const std::string& command)
 }
 
 optional<Args>
-Args::from_gcc_atfile(const std::string& filename)
+Args::from_atfile(const std::string& filename, bool ignore_backslash)
 {
   std::string argtext;
   try {
@@ -72,6 +72,9 @@ Args::from_gcc_atfile(const std::string& filename)
   while (true) {
     switch (*pos) {
     case '\\':
+      if (ignore_backslash) {
+        break;
+      }
       pos++;
       if (*pos == '\0') {
         continue;

--- a/src/Args.hpp
+++ b/src/Args.hpp
@@ -36,7 +36,8 @@ public:
 
   static Args from_argv(int argc, const char* const* argv);
   static Args from_string(const std::string& command);
-  static nonstd::optional<Args> from_gcc_atfile(const std::string& filename);
+  static nonstd::optional<Args> from_atfile(const std::string& filename,
+                                            bool ignore_backslash = false);
 
   Args& operator=(const Args& other) = default;
   Args& operator=(Args&& other) noexcept;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -452,6 +452,7 @@ compiler_type_to_string(CompilerType compiler_type)
     CASE(nvcc);
     CASE(other);
     CASE(pump);
+    CASE(cl);
   }
 #undef CASE
 

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -31,7 +31,7 @@
 #include <string>
 #include <unordered_map>
 
-enum class CompilerType { auto_guess, clang, gcc, nvcc, other, pump };
+enum class CompilerType { auto_guess, clang, gcc, nvcc, other, pump, cl };
 
 std::string compiler_type_to_string(CompilerType compiler_type);
 

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -140,6 +140,20 @@ const CompOpt compopts[] = {
   {"-stdlib=", AFFECTS_CPP | TAKES_CONCAT_ARG},
   {"-trigraphs", AFFECTS_CPP},
   {"-u", TAKES_ARG | TAKES_CONCAT_ARG},
+  {"/AI", TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},               // msvc
+  {"/D", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG},               // msvc
+  {"/E", TOO_HARD},                                                 // msvc
+  {"/EP", TOO_HARD},                                                // msvc
+  {"/FI", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
+  {"/FU", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
+  {"/I", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},  // msvc
+  {"/L", TAKES_ARG},                                                // msvc
+  {"/P", TOO_HARD},                                                 // msvc
+  {"/U", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG},               // msvc
+  {"/Yc", TAKES_ARG | TOO_HARD},                                    // msvc
+  {"/ZI", TOO_HARD},                                                // msvc
+  {"/Zi", TOO_HARD},                                                // msvc
+  {"/u", AFFECTS_CPP},                                              // msvc
 };
 
 static int

--- a/unittest/test_Args.cpp
+++ b/unittest/test_Args.cpp
@@ -76,7 +76,7 @@ TEST_CASE("Args::from_string")
   CHECK(args[3] == "f");
 }
 
-TEST_CASE("Args::from_gcc_atfile")
+TEST_CASE("Args::from_atfile")
 {
   TestContext test_context;
 
@@ -84,20 +84,20 @@ TEST_CASE("Args::from_gcc_atfile")
 
   SUBCASE("Nonexistent file")
   {
-    CHECK(Args::from_gcc_atfile("at_file") == nonstd::nullopt);
+    CHECK(Args::from_atfile("at_file") == nonstd::nullopt);
   }
 
   SUBCASE("Empty")
   {
     Util::write_file("at_file", "");
-    args = *Args::from_gcc_atfile("at_file");
+    args = *Args::from_atfile("at_file");
     CHECK(args.size() == 0);
   }
 
   SUBCASE("One argument without newline")
   {
     Util::write_file("at_file", "foo");
-    args = *Args::from_gcc_atfile("at_file");
+    args = *Args::from_atfile("at_file");
     CHECK(args.size() == 1);
     CHECK(args[0] == "foo");
   }
@@ -105,7 +105,7 @@ TEST_CASE("Args::from_gcc_atfile")
   SUBCASE("One argument with newline")
   {
     Util::write_file("at_file", "foo\n");
-    args = *Args::from_gcc_atfile("at_file");
+    args = *Args::from_atfile("at_file");
     CHECK(args.size() == 1);
     CHECK(args[0] == "foo");
   }
@@ -113,7 +113,7 @@ TEST_CASE("Args::from_gcc_atfile")
   SUBCASE("Multiple simple arguments")
   {
     Util::write_file("at_file", "x y z\n");
-    args = *Args::from_gcc_atfile("at_file");
+    args = *Args::from_atfile("at_file");
     CHECK(args.size() == 3);
     CHECK(args[0] == "x");
     CHECK(args[1] == "y");
@@ -126,7 +126,7 @@ TEST_CASE("Args::from_gcc_atfile")
       "at_file",
       "first\rsec\\\tond\tthi\\\\rd\nfourth  \tfif\\ th \"si'x\\\" th\""
       " 'seve\nth'\\");
-    args = *Args::from_gcc_atfile("at_file");
+    args = *Args::from_atfile("at_file");
     CHECK(args.size() == 7);
     CHECK(args[0] == "first");
     CHECK(args[1] == "sec\tond");


### PR DESCRIPTION
I picked only the compiler commits from: https://github.com/ccache/ccache/pull/162

The following commits I've adapted to the latest ccache C++ code:

375fe24: Add compiler_is_msvc() and MSVC specific option table.
7e01763: Add handling of /Fo option (replaces -o, but shall have no
space)
0c5cd25: Manage /E, /c equivalence. -g is gcc only. -O or /O is msvc
only.
4f61b59: MSVC send part of the error/warning messages to STDOUT, so
concat wit…
64449d6: use common code for gcc an cl response files.

I have tested this with CMake using the Ninja generator in Release mode. It seems to work good enough for having it in GitHub actions for [Qt Creator](https://github.com/qt-creator/qt-creator/actions).

- [x] Release build with Ninja
- [x] Debug / RelWithDebInfo build with Ninja (requires `/Z7` flag)
- [x] NMake Makefiles (requires usage of response files)
- [x] Precompile headers support (correct build without storage of pch files)
- [ ] Precompile headers support (detection and storage of pch files)
- [ ] Unittests

Fixes: https://github.com/ccache/ccache/issues/431