### PR TITLE
Simplify parse_int slightly

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -249,12 +249,11 @@ parse_int(const std::string& value)
   long result;
   bool failed = false;
   try {
-    result = std::stol(value, &end, 10);
+    result = std::stoi(value, &end, 10);
   } catch (std::exception&) {
     failed = true;
   }
-  if (failed || end != value.size() || result < std::numeric_limits<int>::min()
-      || result > std::numeric_limits<int>::max()) {
+  if (failed || end != value.size()) {
     throw Error(fmt::format("invalid integer: \"{}\"", value));
   }
   return result;

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -329,6 +329,24 @@ TEST_CASE("Util::parse_int")
   CHECK_THROWS_WITH(Util::parse_int("0x"), Equals("invalid integer: \"0x\""));
   CHECK_THROWS_WITH(Util::parse_int("0x4"), Equals("invalid integer: \"0x4\""));
   CHECK_THROWS_WITH(Util::parse_int("0 "), Equals("invalid integer: \"0 \""));
+
+  // check boundary values
+  if (sizeof(int) == 2) {
+    CHECK(Util::parse_int("-32768") == -32768);
+    CHECK(Util::parse_int("32767") == 32767);
+    CHECK_THROWS_WITH(Util::parse_int("-32768"),
+                      Equals("invalid integer: \"-32768\""));
+    CHECK_THROWS_WITH(Util::parse_int("32768"),
+                      Equals("invalid integer: \"32768\""));
+  }
+  if (sizeof(int) == 4) {
+    CHECK(Util::parse_int("-2147483648") == -2147483648);
+    CHECK(Util::parse_int("2147483647") == 2147483647);
+    CHECK_THROWS_WITH(Util::parse_int("-2147483649"),
+                      Equals("invalid integer: \"-2147483649\""));
+    CHECK_THROWS_WITH(Util::parse_int("2147483648"),
+                      Equals("invalid integer: \"2147483648\""));
+  }
 }
 
 TEST_CASE("Util::read_file and Util::write_file")


### PR DESCRIPTION
Remove manual int boundary checks as std::stoi already does that (throws out_of_bounds in that case)