### PR TITLE
Make cc_process_args() only use local variables

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -31,6 +31,7 @@ quiet := $(v_at_$(V))
 Q=$(if $(quiet),@)
 
 non_third_party_sources = \
+    src/ArgsInfo.cpp \
     src/AtomicFile.cpp \
     src/CacheEntryReader.cpp \
     src/CacheEntryWriter.cpp \
@@ -57,6 +58,7 @@ non_third_party_sources = \
     src/hash.cpp \
     src/hashutil.cpp \
     src/language.cpp \
+    src/legacy_globals.cpp \
     src/legacy_util.cpp \
     src/lockfile.cpp \
     src/manifest.cpp \

--- a/Makefile.in
+++ b/Makefile.in
@@ -83,6 +83,7 @@ test_suites += unittest/test_Compression.cpp
 test_suites += unittest/test_Config.cpp
 test_suites += unittest/test_FormatNonstdStringView.cpp
 test_suites += unittest/test_NullCompression.cpp
+test_suites += unittest/test_ScopeGuard.cpp
 test_suites += unittest/test_Stat.cpp
 test_suites += unittest/test_Util.cpp
 test_suites += unittest/test_ZstdCompression.cpp

--- a/dev.mk.in
+++ b/dev.mk.in
@@ -43,6 +43,7 @@ non_third_party_headers_without_cpp = \
     src/NullCompressor.hpp \
     src/NullDecompressor.hpp \
     src/ProgressBar.hpp \
+    src/ScopeGuard.hpp \
     src/Stat.hpp \
     src/StdMakeUnique.hpp \
     src/ThreadPool.hpp \

--- a/src/ArgsInfo.cpp
+++ b/src/ArgsInfo.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "ArgsInfo.hpp"
+
+#include "args.hpp"
+
+ArgsInfo::~ArgsInfo()
+{
+  for (size_t i = 0; i < debug_prefix_maps_len; i++) {
+    free(debug_prefix_maps[i]);
+  }
+  free(debug_prefix_maps);
+
+  args_free(depend_extra_args);
+}

--- a/src/ArgsInfo.hpp
+++ b/src/ArgsInfo.hpp
@@ -1,0 +1,114 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#pragma once
+
+#include "system.hpp"
+
+#include <string>
+
+struct ArgsInfo
+{
+  // The source file.
+  std::string input_file;
+
+  // The output file being compiled to.
+  std::string output_obj;
+
+  // The path to the dependency file (implicit or specified with -MF).
+  std::string output_dep;
+
+  // The path to the coverage file (implicit when using -ftest-coverage).
+  std::string output_cov;
+
+  // The path to the stack usage (implicit when using -fstack-usage).
+  std::string output_su;
+
+  // Diagnostic generation information (clang). Contains pathname if not empty.
+  std::string output_dia;
+
+  // Split dwarf information (GCC 4.8 and up). Contains pathname if not empty.
+  std::string output_dwo;
+
+  // Language to use for the compilation target (see language.c).
+  std::string actual_language;
+
+  // Is the compiler being asked to output debug info?
+  bool generating_debuginfo = false;
+
+  // Is the compiler being asked to output dependencies?
+  bool generating_dependencies = false;
+
+  // Is the compiler being asked to output coverage?
+  bool generating_coverage = false;
+
+  // Is the compiler being asked to output stack usage?
+  bool generating_stackusage = false;
+
+  // Us the compiler being asked to generate diagnostics
+  // (--serialize-diagnostics)?
+  bool generating_diagnostics = false;
+
+  // Have we seen -gsplit-dwarf?
+  bool seen_split_dwarf = false;
+
+  // Are we compiling a .i or .ii file directly?
+  bool direct_i_file = false;
+
+  // Whether the output is a precompiled header.
+  bool output_is_precompiled_header = false;
+
+  // Is the compiler being asked to output coverage data (.gcda) at runtime?
+  bool profile_arcs = false;
+
+  // Name of the custom profile directory (default: object dirname).
+  std::string profile_dir;
+
+  // Profile generation / usage information.
+  bool profile_use = false;
+  bool profile_generate = false;
+
+  // Whether we are using a precompiled header (either via -include, #include or
+  // clang's -include-pch or -include-pth).
+  bool using_precompiled_header = false;
+
+  // Sanitize blacklist
+  char** sanitize_blacklists = nullptr;
+  size_t sanitize_blacklists_len = 0;
+
+  // Array for storing -arch options.
+  static constexpr int max_arch_args = 10;
+  size_t arch_args_size = 0;
+  char* arch_args[max_arch_args] = {NULL};
+
+  // Relocating debuginfo in the format old=new.
+  char** debug_prefix_maps = nullptr;
+  size_t debug_prefix_maps_len = 0;
+
+  // Argument list to add to compiler invocation in depend mode.
+  struct args* depend_extra_args = nullptr;
+
+  ArgsInfo() = default;
+  ~ArgsInfo();
+
+  ArgsInfo(const ArgsInfo&) = delete;
+  ArgsInfo& operator=(const ArgsInfo&) = delete;
+
+  ArgsInfo(ArgsInfo&&) = delete;
+  ArgsInfo& operator=(ArgsInfo&&) = delete;
+};

--- a/src/ScopeGuard.hpp
+++ b/src/ScopeGuard.hpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#pragma once
+
+#include "NonCopyable.hpp"
+
+template<typename OnExit, typename T> struct ScopeGuard : NonCopyable
+{
+  explicit ScopeGuard(T& guarded) : m_guarded{guarded}
+  {
+  }
+
+  ~ScopeGuard()
+  {
+    OnExit onexit;
+    onexit(m_guarded);
+  }
+
+private:
+  T& m_guarded;
+};

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -312,3 +312,10 @@ args_equal(const struct args* args1, const struct args* args2)
   }
   return true;
 }
+
+void
+args_deleter::operator()(struct args*& arg)
+{
+  args_free(arg);
+  arg = nullptr;
+}

--- a/src/args.hpp
+++ b/src/args.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "src/ScopeGuard.hpp"
+
 struct args
 {
   char** argv;
@@ -39,3 +41,9 @@ void args_strip(struct args* args, const char* prefix);
 void args_remove_first(struct args* args);
 char* args_to_string(const struct args* args);
 bool args_equal(const struct args* args1, const struct args* args2);
+
+struct args_deleter
+{
+  void operator()(struct args*& arg);
+};
+using ArgsScopeGuard = ScopeGuard<args_deleter, struct args*>;

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -23,6 +23,9 @@
 
 #include "counters.hpp"
 
+struct ArgsInfo;
+class Config;
+
 #ifndef MYNAME
 #  define MYNAME "ccache"
 #endif
@@ -36,8 +39,6 @@ enum guessed_compiler {
   GUESSED_PUMP,
   GUESSED_UNKNOWN
 };
-
-extern enum guessed_compiler guessed_compiler;
 
 #define SLOPPY_INCLUDE_FILE_MTIME (1U << 0)
 #define SLOPPY_INCLUDE_FILE_CTIME (1U << 1)
@@ -63,7 +64,9 @@ extern time_t time_of_compilation;
 extern bool output_is_precompiled_header;
 void block_signals();
 void unblock_signals();
-bool cc_process_args(struct args* args,
+bool cc_process_args(ArgsInfo& args_info,
+                     Config& config,
+                     struct args* args,
                      struct args** preprocessor_args,
                      struct args** extra_args_to_hash,
                      struct args** compiler_args);

--- a/src/legacy_globals.cpp
+++ b/src/legacy_globals.cpp
@@ -1,0 +1,142 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "legacy_globals.hpp"
+
+// Current working directory taken from $PWD, or getcwd() if $PWD is bad.
+char* current_working_dir = nullptr;
+
+// The original argument list.
+extern struct args* orig_args;
+struct args* orig_args = nullptr;
+
+// The source file.
+char* input_file;
+
+// The output file being compiled to.
+char* output_obj;
+
+// The path to the dependency file (implicit or specified with -MF).
+char* output_dep;
+
+// The path to the coverage file (implicit when using -ftest-coverage).
+char* output_cov;
+
+// The path to the stack usage (implicit when using -fstack-usage).
+char* output_su;
+
+// Diagnostic generation information (clang). Contains pathname if not nullptr.
+char* output_dia;
+
+// Split dwarf information (GCC 4.8 and up). Contains pathname if not nullptr.
+char* output_dwo;
+
+// Language to use for the compilation target (see language.c).
+const char* actual_language;
+
+// Array for storing -arch options.
+size_t arch_args_size = 0;
+char* arch_args[MAX_ARCH_ARGS] = {nullptr};
+
+// Name (represented as a struct digest) of the file containing the cached
+// result.
+struct digest* cached_result_name;
+
+// Full path to the file containing the result
+// (cachedir/a/b/cdef[...]-size.result).
+char* cached_result_path;
+
+// Full path to the file containing the manifest
+// (cachedir/a/b/cdef[...]-size.manifest).
+char* manifest_path;
+
+// Time of compilation. Used to see if include files have changed after
+// compilation.
+time_t time_of_compilation;
+
+// Files included by the preprocessor and their hashes. Key: file path. Value:
+// struct digest.
+std::unordered_map<std::string, digest> g_included_files;
+
+// Uses absolute path for some include files.
+bool has_absolute_include_headers = false;
+
+// List of headers to ignore.
+char** ignore_headers;
+
+// Size of headers to ignore list.
+size_t ignore_headers_len;
+
+// Is the compiler being asked to output dependencies?
+bool generating_dependencies;
+
+// Is the compiler being asked to output coverage?
+bool generating_coverage;
+
+// Is the compiler being asked to output stack usage?
+bool generating_stackusage;
+
+// Us the compiler being asked to generate diagnostics
+// (--serialize-diagnostics)?
+bool generating_diagnostics;
+
+// Have we seen -gsplit-dwarf?
+bool seen_split_dwarf;
+
+// Is the compiler being asked to output coverage data (.gcda) at runtime?
+bool profile_arcs;
+
+// Name of the custom profile directory (default: object dirname).
+char* profile_dir;
+
+// The name of the temporary preprocessed file.
+char* i_tmpfile;
+
+// Are we compiling a .i or .ii file directly?
+bool direct_i_file;
+
+// The name of the cpp stderr file.
+char* cpp_stderr;
+
+// Full path to the statistics file in the subdirectory where the cached result
+// belongs (<cache_dir>/<x>/stats).
+char* stats_file = nullptr;
+
+// The stats file to use for the manifest.
+char* manifest_stats_file;
+
+// Whether the output is a precompiled header.
+bool output_is_precompiled_header = false;
+
+// Compiler guessing is currently only based on the compiler name, so nothing
+// should hard-depend on it if possible.
+enum guessed_compiler guessed_compiler = GUESSED_UNKNOWN;
+
+// Profile generation / usage information.
+bool profile_use = false;
+bool profile_generate = false;
+
+// Whether we are using a precompiled header (either via -include, #include or
+// clang's -include-pch or -include-pth).
+bool using_precompiled_header = false;
+
+// The .gch/.pch/.pth file used for compilation.
+char* included_pch_file = nullptr;
+
+// How long (in microseconds) to wait before breaking a stale lock.
+unsigned lock_staleness_limit = 2000000;

--- a/src/legacy_globals.hpp
+++ b/src/legacy_globals.hpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#pragma once
+
+#include "system.hpp"
+
+#include "ccache.hpp"
+#include "hash.hpp"
+
+#include <string>
+#include <unordered_map>
+
+// variable descriptions are in the .cpp file
+
+extern char* current_working_dir;
+extern char* stats_file;
+extern unsigned lock_staleness_limit;
+
+extern struct args* orig_args;
+
+extern char* input_file;
+
+extern char* output_obj;
+
+extern char* output_dep;
+
+extern char* output_cov;
+
+extern char* output_su;
+
+extern char* output_dia;
+
+extern char* output_dwo;
+
+extern const char* actual_language;
+
+#define MAX_ARCH_ARGS 10
+extern size_t arch_args_size;
+extern char* arch_args[MAX_ARCH_ARGS];
+
+extern struct digest* cached_result_name;
+
+extern char* cached_result_path;
+
+extern char* manifest_path;
+
+extern time_t time_of_compilation;
+
+extern std::unordered_map<std::string, digest> g_included_files;
+
+extern bool has_absolute_include_headers;
+
+extern char** ignore_headers;
+
+extern size_t ignore_headers_len;
+
+extern bool generating_dependencies;
+
+extern bool generating_coverage;
+
+extern bool generating_stackusage;
+
+extern bool generating_diagnostics;
+
+extern bool seen_split_dwarf;
+
+extern bool profile_arcs;
+
+extern char* profile_dir;
+
+extern char* i_tmpfile;
+
+extern bool direct_i_file;
+
+extern char* cpp_stderr;
+
+extern char* manifest_stats_file;
+
+extern bool output_is_precompiled_header;
+
+extern enum guessed_compiler guessed_compiler;
+
+extern bool profile_use;
+extern bool profile_generate;
+
+extern bool using_precompiled_header;
+
+extern char* included_pch_file;

--- a/src/legacy_util.cpp
+++ b/src/legacy_util.cpp
@@ -1543,3 +1543,20 @@ time_seconds(void)
   return (double)time(NULL);
 #endif
 }
+
+std::string
+from_owned_cstr(char* str)
+{
+  std::string result;
+  if (str) {
+    result = str;
+    free(str);
+  }
+  return result;
+}
+
+std::string
+from_cstr(const char* str)
+{
+  return str ? str : std::string{};
+}

--- a/src/legacy_util.hpp
+++ b/src/legacy_util.hpp
@@ -20,6 +20,8 @@
 
 #include "system.hpp"
 
+#include <string>
+
 void cc_log(const char* format, ...) ATTR_FORMAT(printf, 1, 2);
 void cc_bulklog(const char* format, ...) ATTR_FORMAT(printf, 1, 2);
 void cc_log_argv(const char* prefix, char** argv);
@@ -78,3 +80,9 @@ char* read_text_file(const char* path, size_t size_hint);
 char* subst_env_in_string(const char* str, char** errmsg);
 void set_cloexec_flag(int fd);
 double time_seconds();
+
+// Convert an owned char* string `str` to an std::string and free `str`.
+std::string from_owned_cstr(char* str);
+
+// Convert a char* string `str` to an std::string, if `str` is NULL return "".
+std::string from_cstr(const char* str);

--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -28,6 +28,7 @@
 #include "ccache.hpp"
 #include "hash.hpp"
 #include "hashutil.hpp"
+#include "legacy_globals.hpp"
 
 // Manifest data format
 // ====================

--- a/unittest/test_ScopeGuard.cpp
+++ b/unittest/test_ScopeGuard.cpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "NonCopyable.hpp"
+#include "ScopeGuard.hpp"
+
+#include "third_party/catch.hpp"
+
+struct ptr_deleter
+{
+  void
+  operator()(int*& ptr)
+  {
+    delete ptr;
+    ptr = nullptr;
+  }
+};
+
+TEST_CASE("delete pointer")
+{
+  using ScopeGuardInt = ScopeGuard<ptr_deleter, int*>;
+  int* i = new int(3);
+
+  {
+    ScopeGuardInt guard(i);
+    CHECK(*i == 3);
+  }
+
+  CHECK(i == nullptr);
+}
+
+struct Value : NonCopyable
+{
+  int i = 3;
+};
+
+struct reset_value
+{
+  void
+  operator()(Value& v)
+  {
+    v.i = 0;
+  }
+};
+
+TEST_CASE("reset a value type")
+{
+  using ScopeGuardValue = ScopeGuard<reset_value, Value>;
+
+  Value v;
+
+  CHECK(v.i == 3);
+
+  {
+    ScopeGuardValue guard(v);
+    CHECK(v.i == 3);
+  }
+
+  CHECK(v.i == 0);
+}

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -73,6 +73,7 @@ TEST_CASE("Util::change_extension")
   CHECK(Util::change_extension(".", "") == "");
   CHECK(Util::change_extension("...", "x") == "..x");
   CHECK(Util::change_extension("abc", "def") == "abcdef");
+  CHECK(Util::change_extension("dot.", ".dot") == "dot.dot");
   CHECK(Util::change_extension("foo.ext", "e2") == "fooe2");
   CHECK(Util::change_extension("bar.txt", ".o") == "bar.o");
   CHECK(Util::change_extension("foo.bar.txt", ".o") == "foo.bar.o");

--- a/unittest/test_argument_processing.cpp
+++ b/unittest/test_argument_processing.cpp
@@ -18,9 +18,11 @@
 
 // This file contains tests for the processing of compiler arguments.
 
+#include "../src/ArgsInfo.hpp"
 #include "../src/Config.hpp"
 #include "../src/args.hpp"
 #include "../src/ccache.hpp"
+#include "../src/legacy_globals.hpp"
 #include "../src/stats.hpp"
 #include "framework.hpp"
 #include "util.hpp"
@@ -60,6 +62,54 @@ get_posix_path(char* path)
   }
   return posix;
 #endif
+}
+
+bool cc_process_args(struct args* args,
+                     struct args** preprocessor_args,
+                     struct args** extra_args_to_hash,
+                     struct args** compiler_args);
+
+bool
+cc_process_args(struct args* args,
+                struct args** preprocessor_args,
+                struct args** extra_args_to_hash,
+                struct args** compiler_args)
+{
+  ArgsInfo argsinfo;
+
+  bool success = cc_process_args(argsinfo,
+                                 g_config,
+                                 args,
+                                 preprocessor_args,
+                                 extra_args_to_hash,
+                                 compiler_args);
+
+  input_file = x_strdup(argsinfo.input_file.c_str());
+
+  output_obj = x_strdup(argsinfo.output_obj.c_str());
+  output_dep = x_strdup(argsinfo.output_dep.c_str());
+  output_cov = x_strdup(argsinfo.output_cov.c_str());
+  output_su = x_strdup(argsinfo.output_su.c_str());
+  output_dia = x_strdup(argsinfo.output_dia.c_str());
+  output_dwo = x_strdup(argsinfo.output_dwo.c_str());
+
+  actual_language = x_strdup(argsinfo.actual_language.c_str());
+
+  generating_dependencies = argsinfo.generating_dependencies;
+  generating_coverage = argsinfo.generating_coverage;
+  generating_stackusage = argsinfo.generating_stackusage;
+  generating_diagnostics = argsinfo.generating_diagnostics;
+  seen_split_dwarf = argsinfo.seen_split_dwarf;
+  profile_arcs = argsinfo.profile_arcs;
+  profile_dir = x_strdup(argsinfo.profile_dir.c_str());
+
+  direct_i_file = argsinfo.direct_i_file;
+  output_is_precompiled_header = argsinfo.output_is_precompiled_header;
+  profile_use = argsinfo.profile_use;
+  profile_generate = argsinfo.profile_generate;
+  using_precompiled_header = argsinfo.using_precompiled_header;
+
+  return success;
 }
 
 TEST_SUITE(argument_processing)

--- a/unittest/test_legacy_util.cpp
+++ b/unittest/test_legacy_util.cpp
@@ -194,4 +194,42 @@ TEST(format_hex)
   CHECK_STR_EQ("00010203", result);
 }
 
+TEST(from_cstr)
+{
+  char* cstr1 = x_strdup("foo");
+  const char* cstr2 = "bar";
+  const char* cstr3 = nullptr;
+  const char* cstr4 = "";
+
+  std::string str1 = from_cstr(cstr1);
+  std::string str2 = from_cstr(cstr2);
+  std::string str3 = from_cstr(cstr3);
+  std::string str4 = from_cstr(cstr4);
+
+  CHECK(str1 == "foo");
+  CHECK(str2 == "bar");
+  CHECK(str3 == "");
+  CHECK(str4 == "");
+
+  free(cstr1);
+}
+
+TEST(from_owned_cstr)
+{
+  char* cstr1 = x_strdup("foo");
+  char* cstr2 = x_strdup("bar");
+  char* cstr3 = nullptr;
+  char* cstr4 = x_strdup("");
+
+  std::string str1 = from_owned_cstr(cstr1);
+  std::string str2 = from_owned_cstr(cstr2);
+  std::string str3 = from_owned_cstr(cstr3);
+  std::string str4 = from_owned_cstr(cstr4);
+
+  CHECK(str1 == "foo");
+  CHECK(str2 == "bar");
+  CHECK(str3 == "");
+  CHECK(str4 == "");
+}
+
 TEST_SUITE_END


### PR DESCRIPTION
plus

Simplify make_relative_path() argument and result ownership

because all the make_relative_path(x_strdup(..)) + free() calls were getting out of hand.