### PR TITLE
Make failure to write a stats file a soft error

### DIFF
--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -229,7 +229,13 @@ stats_write(const char* path, struct counters* counters)
   for (size_t i = 0; i < counters->size; ++i) {
     file.write(fmt::format("{}\n", counters->data[i]));
   }
-  file.commit();
+  try {
+    file.commit();
+  } catch (const Error& e) {
+    // Make failure to write a stats file a soft error since it's not important
+    // enough to fail whole the process.
+    cc_log("Error: %s", e.what());
+  }
 }
 
 static void


### PR DESCRIPTION
If a stats file update for some reason fails, the exception will bubble up to ccache_main which just prints the error and exits with an error. Let’s consider such failures non-fatal and just log them.