### PR TITLE
Refactoring: make struct args a value semantic object

### DIFF
--- a/src/args.hpp
+++ b/src/args.hpp
@@ -18,24 +18,36 @@
 
 #pragma once
 
-struct args
+#include "third_party/nonstd/optional.hpp"
+
+class Args
 {
-  char** argv;
-  int argc;
+public:
+  Args() = default;
+  Args(const Args& other);
+
+  // operators for backwards compatibility
+  Args& operator*() { return *this; }
+  Args* operator->() { return this; }
+  const Args* operator->() const { return this; }
+
+  char** argv = nullptr;
+  int argc = 0;
 };
 
-struct args* args_init(int, const char* const*);
-struct args* args_init_from_string(const char*);
-struct args* args_init_from_gcc_atfile(const char* filename);
-struct args* args_copy(struct args* args);
-void args_free(struct args* args);
-void args_add(struct args* args, const char* s);
-void args_add_prefix(struct args* args, const char* s);
-void args_extend(struct args* args, struct args* to_append);
-void args_insert(struct args* dest, int index, struct args* src, bool replace);
-void args_pop(struct args* args, int n);
-void args_set(struct args* args, int index, const char* value);
-void args_strip(struct args* args, const char* prefix);
-void args_remove_first(struct args* args);
-char* args_to_string(const struct args* args);
-bool args_equal(const struct args* args1, const struct args* args2);
+Args args_init(int, const char* const*);
+Args args_init_from_string(const char*);
+nonstd::optional<Args> args_init_from_gcc_atfile(const char* filename);
+Args args_copy(const Args& args);
+
+void args_free(Args& args);
+void args_add(Args& args, const char* s);
+void args_add_prefix(Args& args, const char* s);
+void args_extend(Args& args, const Args& to_append);
+void args_insert(Args& dest, int index, Args& src, bool replace);
+void args_pop(Args& args, int n);
+void args_set(Args& args, int index, const char* value);
+void args_strip(Args& args, const char* prefix);
+void args_remove_first(Args& args);
+char* args_to_string(const Args& args);
+bool args_equal(const Args& args1, const Args& args2);

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "system.hpp"
-
+#include "Args.hpp"
 #include "counters.hpp"
 
 #ifndef MYNAME
@@ -63,9 +63,9 @@ extern time_t time_of_compilation;
 extern bool output_is_precompiled_header;
 void block_signals();
 void unblock_signals();
-bool cc_process_args(struct args* args,
-                     struct args** preprocessor_args,
-                     struct args** extra_args_to_hash,
-                     struct args** compiler_args);
+bool cc_process_args(const Args& args,
+                     Args& preprocessor_args,
+                     Args& extra_args_to_hash,
+                     Args& compiler_args);
 void cc_reset();
 bool is_precompiled_header(const char* path);

--- a/src/hashutil.cpp
+++ b/src/hashutil.cpp
@@ -307,7 +307,7 @@ hash_command_output(struct hash* hash,
   }
 #endif
 
-  struct args* args = args_init_from_string(command);
+  Args args = args_init_from_string(command);
   for (int i = 0; i < args->argc; i++) {
     if (str_eq(args->argv[i], "%compiler%")) {
       args_set(args, i, compiler);

--- a/unittest/framework.cpp
+++ b/unittest/framework.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2020 Joel Rosdahl and other contributors
+// Copyright (C) 2010-2019 Joel Rosdahl and other contributors
 //
 // See doc/AUTHORS.adoc for a complete list of contributors.
 //
@@ -289,19 +289,19 @@ bool
 cct_check_args_eq(const char* file,
                   int line,
                   const char* expression,
-                  const struct args* expected,
-                  const struct args* actual,
+                  const Args& expected,
+                  const Args& actual,
                   bool free1,
                   bool free2)
 {
   bool result;
 
-  if (expected && actual && args_equal(actual, expected)) {
+  if (args_equal(actual, expected)) {
     cct_check_passed(file, line, expression);
     result = true;
   } else {
-    char* exp_str = expected ? args_to_string(expected) : x_strdup("(null)");
-    char* act_str = actual ? args_to_string(actual) : x_strdup("(null)");
+    char* exp_str = args_to_string(expected);
+    char* act_str = args_to_string(actual);
     cct_check_failed(file, line, expression, exp_str, act_str);
     free(exp_str);
     free(act_str);
@@ -309,10 +309,10 @@ cct_check_args_eq(const char* file,
   }
 
   if (free1) {
-    args_free(const_cast<struct args*>(expected));
+    args_free(const_cast<Args&>(expected));
   }
   if (free2) {
-    args_free(const_cast<struct args*>(actual));
+    args_free(const_cast<Args&>(actual));
   }
   return result;
 }

--- a/unittest/framework.hpp
+++ b/unittest/framework.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "../src/system.hpp"
+class Args;
 
 // ============================================================================
 
@@ -179,8 +180,8 @@ bool cct_check_str_eq(const char* file,
 bool cct_check_args_eq(const char* file,
                        int line,
                        const char* expression,
-                       const struct args* expected,
-                       const struct args* actual,
+                       const Args& expected,
+                       const Args& actual,
                        bool free1,
                        bool free2);
 void cct_chdir(const char* path);

--- a/unittest/test_argument_processing.cpp
+++ b/unittest/test_argument_processing.cpp
@@ -66,11 +66,11 @@ TEST_SUITE(argument_processing)
 
 TEST(dash_E_should_result_in_called_for_preprocessing)
 {
-  struct args* orig = args_init_from_string("cc -c foo.c -E");
-  struct args *preprocessed, *compiler;
+  Args orig = args_init_from_string("cc -c foo.c -E");
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
-  CHECK(!cc_process_args(orig, &preprocessed, NULL, &compiler));
+  CHECK(!cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_INT_EQ(1, stats_get_pending(STATS_PREPROCESSING));
 
   args_free(orig);
@@ -78,11 +78,11 @@ TEST(dash_E_should_result_in_called_for_preprocessing)
 
 TEST(dash_M_should_be_unsupported)
 {
-  struct args* orig = args_init_from_string("cc -c foo.c -M");
-  struct args *preprocessed, *compiler;
+  Args orig = args_init_from_string("cc -c foo.c -M");
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
-  CHECK(!cc_process_args(orig, &preprocessed, NULL, &compiler));
+  CHECK(!cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_INT_EQ(1, stats_get_pending(STATS_UNSUPPORTED_OPTION));
 
   args_free(orig);
@@ -93,19 +93,17 @@ TEST(dependency_args_to_preprocessor_if_run_second_cpp_is_false)
 #define DEP_ARGS                                                               \
   "-MD -MMD -MP -MF foo.d -MT mt1 -MT mt2 -MQ mq1 -MQ mq2 -Wp,-MD,wpmd"        \
   " -Wp,-MMD,wpmmd -Wp,-MP -Wp,-MT,wpmt -Wp,-MQ,wpmq -Wp,-MF,wpf"
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc " DEP_ARGS " -c foo.c -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc " DEP_ARGS);
-  struct args* exp_extra = args_init(0, NULL);
-  struct args* exp_cc = args_init_from_string("cc -c");
+  Args exp_cpp = args_init_from_string("cc " DEP_ARGS);
+  Args exp_extra;
+  Args exp_cc = args_init_from_string("cc -c");
 #undef DEP_ARGS
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args act_cpp, act_cc, act_extra;
   create_file("foo.c", "");
 
   g_config.set_run_second_cpp(false);
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -118,18 +116,16 @@ TEST(dependency_args_to_compiler_if_run_second_cpp_is_true)
 #define DEP_ARGS                                                               \
   "-MD -MMD -MP -MF foo.d -MT mt1 -MT mt2 -MQ mq1 -MQ mq2 -Wp,-MD,wpmd"        \
   " -Wp,-MMD,wpmmd -Wp,-MP -Wp,-MT,wpmt -Wp,-MQ,wpmq -Wp,-MF,wpf"
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc " DEP_ARGS " -c foo.c -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc");
-  struct args* exp_extra = args_init_from_string(DEP_ARGS);
-  struct args* exp_cc = args_init_from_string("cc -c " DEP_ARGS);
+  Args exp_cpp = args_init_from_string("cc");
+  Args exp_extra = args_init_from_string(DEP_ARGS);
+  Args exp_cc = args_init_from_string("cc -c " DEP_ARGS);
 #undef DEP_ARGS
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args act_cpp, act_cc, act_extra;
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -147,20 +143,18 @@ TEST(cpp_only_args_to_preprocessor_if_run_second_cpp_is_false)
 #define DEP_ARGS                                                               \
   "-MD -MMD -MP -MF foo.d -MT mt1 -MT mt2 -MQ mq1 -MQ mq2 -Wp,-MD,wpmd"        \
   " -Wp,-MMD,wpmmd -Wp,-MP -Wp,-MT,wpmt -Wp,-MQ,wpmq -Wp,-MF,wpf"
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc " CPP_ARGS " " DEP_ARGS " -c foo.c -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc " CPP_ARGS " " DEP_ARGS);
-  struct args* exp_extra = args_init(0, NULL);
-  struct args* exp_cc = args_init_from_string("cc -c");
+  Args exp_cpp = args_init_from_string("cc " CPP_ARGS " " DEP_ARGS);
+  Args exp_extra;
+  Args exp_cc = args_init_from_string("cc -c");
 #undef DEP_ARGS
 #undef CPP_ARGS
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args act_cpp, act_cc, act_extra;
   create_file("foo.c", "");
 
   g_config.set_run_second_cpp(false);
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -178,19 +172,20 @@ TEST(cpp_only_args_to_preprocessor_and_compiler_if_run_second_cpp_is_true)
 #define DEP_ARGS                                                               \
   " -MD -MMD -MP -MF foo.d -MT mt1 -MT mt2 -MQ mq1 -MQ mq2 -Wp,-MD,wpmd"       \
   " -Wp,-MMD,wpmmd"
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc " CPP_ARGS " " DEP_ARGS " -c foo.c -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc " CPP_ARGS);
-  struct args* exp_extra = args_init_from_string(DEP_ARGS);
-  struct args* exp_cc = args_init_from_string("cc " CPP_ARGS " -c " DEP_ARGS);
+
+  Args exp_cpp = args_init_from_string("cc " CPP_ARGS);
+  Args exp_extra = args_init_from_string(DEP_ARGS);
+  Args exp_cc = args_init_from_string("cc " CPP_ARGS " -c " DEP_ARGS);
 #undef DEP_ARGS
 #undef CPP_ARGS
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+
+  Args act_cpp, act_cc, act_extra;
+
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -201,18 +196,18 @@ TEST(cpp_only_args_to_preprocessor_and_compiler_if_run_second_cpp_is_true)
 TEST(dependency_args_that_take_an_argument_should_not_require_space_delimiter)
 {
 #define DEP_ARGS "-MMD -MFfoo.d -MT mt -MTmt -MQmq"
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc -c " DEP_ARGS " foo.c -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc");
-  struct args* exp_extra = args_init_from_string(DEP_ARGS);
-  struct args* exp_cc = args_init_from_string("cc -c " DEP_ARGS);
+  Args exp_cpp = args_init_from_string("cc");
+  Args exp_extra = args_init_from_string(DEP_ARGS);
+  Args exp_cc = args_init_from_string("cc -c " DEP_ARGS);
 #undef DEP_ARGS
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+
+  Args act_cpp, act_cc, act_extra;
+
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -222,17 +217,18 @@ TEST(dependency_args_that_take_an_argument_should_not_require_space_delimiter)
 
 TEST(MQ_flag_should_not_be_added_if_run_second_cpp_is_true)
 {
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc -c -MD foo.c -MF foo.d -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc");
-  struct args* exp_extra = args_init_from_string("-MD -MF foo.d");
-  struct args* exp_cc = args_init_from_string("cc -c -MD -MF foo.d");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+
+  Args exp_cpp = args_init_from_string("cc");
+  Args exp_extra = args_init_from_string("-MD -MF foo.d");
+  Args exp_cc = args_init_from_string("cc -c -MD -MF foo.d");
+
+  Args act_cpp, act_cc, act_extra;
+
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -242,18 +238,19 @@ TEST(MQ_flag_should_not_be_added_if_run_second_cpp_is_true)
 
 TEST(MQ_flag_should_be_added_if_run_second_cpp_is_false)
 {
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc -c -MD foo.c -MF foo.d -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc -MD -MF foo.d -MQ foo.o");
-  struct args* exp_extra = args_init(0, NULL);
-  struct args* exp_cc = args_init_from_string("cc -c");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+
+  Args exp_cpp = args_init_from_string("cc -MD -MF foo.d -MQ foo.o");
+  Args exp_extra;
+  Args exp_cc = args_init_from_string("cc -c");
+
+  Args act_cpp, act_cc, act_extra;
+
   create_file("foo.c", "");
 
   g_config.set_run_second_cpp(false);
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -263,18 +260,18 @@ TEST(MQ_flag_should_be_added_if_run_second_cpp_is_false)
 
 TEST(MF_should_be_added_if_run_second_cpp_is_false)
 {
-  struct args* orig = args_init_from_string("cc -c -MD foo.c -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc -MD -MF foo.d -MQ foo.o");
-  struct args* exp_extra = args_init(0, NULL);
-  struct args* exp_cc = args_init_from_string("cc -c");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("cc -c -MD foo.c -o foo.o");
+
+  Args exp_cpp = args_init_from_string("cc -MD -MF foo.d -MQ foo.o");
+  Args exp_extra;
+  Args exp_cc = args_init_from_string("cc -c");
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
   g_config.set_run_second_cpp(false);
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -284,17 +281,17 @@ TEST(MF_should_be_added_if_run_second_cpp_is_false)
 
 TEST(MF_should_not_be_added_if_run_second_cpp_is_true)
 {
-  struct args* orig = args_init_from_string("cc -c -MD foo.c -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc");
-  struct args* exp_extra = args_init_from_string("-MD");
-  struct args* exp_cc = args_init_from_string("cc -c -MD");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("cc -c -MD foo.c -o foo.o");
+
+  Args exp_cpp = args_init_from_string("cc");
+  Args exp_extra = args_init_from_string("-MD");
+  Args exp_cc = args_init_from_string("cc -c -MD");
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -304,17 +301,17 @@ TEST(MF_should_not_be_added_if_run_second_cpp_is_true)
 
 TEST(equal_sign_after_MF_should_be_removed)
 {
-  struct args* orig = args_init_from_string("cc -c -MF=path foo.c -o foo.o");
-  struct args* exp_cpp = args_init_from_string("cc");
-  struct args* exp_extra = args_init_from_string("-MFpath");
-  struct args* exp_cc = args_init_from_string("cc -c -MFpath");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("cc -c -MF=path foo.c -o foo.o");
+
+  Args exp_cpp = args_init_from_string("cc");
+  Args exp_extra = args_init_from_string("-MFpath");
+  Args exp_cc = args_init_from_string("cc -c -MFpath");
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -326,20 +323,17 @@ TEST(sysroot_should_be_rewritten_if_basedir_is_used)
 {
   extern char* current_working_dir;
   char* arg_string;
-  struct args* orig;
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
   g_config.set_base_dir(get_root());
   current_working_dir = get_cwd();
   arg_string = format("cc --sysroot=%s/foo/bar -c foo.c", current_working_dir);
-  orig = args_init_from_string(arg_string);
+  Args orig = args_init_from_string(arg_string);
   free(arg_string);
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
-  CHECK_STR_EQ(act_cpp->argv[1], "--sysroot=./foo/bar");
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
+  CHECK_STR_EQ(act_cpp.argv[1], "--sysroot=./foo/bar");
 
   args_free(orig);
   args_free(act_cpp);
@@ -350,21 +344,18 @@ TEST(sysroot_with_separate_argument_should_be_rewritten_if_basedir_is_used)
 {
   extern char* current_working_dir;
   char* arg_string;
-  struct args* orig;
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
   g_config.set_base_dir(get_root());
   current_working_dir = get_cwd();
   arg_string = format("cc --sysroot %s/foo -c foo.c", current_working_dir);
-  orig = args_init_from_string(arg_string);
+  Args orig = args_init_from_string(arg_string);
   free(arg_string);
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
-  CHECK_STR_EQ(act_cpp->argv[1], "--sysroot");
-  CHECK_STR_EQ(act_cpp->argv[2], "./foo");
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
+  CHECK_STR_EQ(act_cpp.argv[1], "--sysroot");
+  CHECK_STR_EQ(act_cpp.argv[2], "./foo");
 
   args_free(orig);
   args_free(act_cpp);
@@ -373,18 +364,18 @@ TEST(sysroot_with_separate_argument_should_be_rewritten_if_basedir_is_used)
 
 TEST(MF_flag_with_immediate_argument_should_work_as_last_argument)
 {
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc -c foo.c -o foo.o -MMD -MT bar -MFfoo.d");
-  struct args* exp_cpp = args_init_from_string("cc");
-  struct args* exp_extra = args_init_from_string("-MMD -MT bar -MFfoo.d");
-  struct args* exp_cc = args_init_from_string("cc -c -MMD -MT bar -MFfoo.d");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+
+  Args exp_cpp = args_init_from_string("cc");
+  Args exp_extra = args_init_from_string("-MMD -MT bar -MFfoo.d");
+  Args exp_cc = args_init_from_string("cc -c -MMD -MT bar -MFfoo.d");
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -394,20 +385,20 @@ TEST(MF_flag_with_immediate_argument_should_work_as_last_argument)
 
 TEST(MT_flag_with_immediate_argument_should_work_as_last_argument)
 {
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc -c foo.c -o foo.o -MMD -MFfoo.d -MT foo -MTbar");
-  struct args* exp_cpp = args_init_from_string("cc");
-  struct args* exp_extra =
+
+  Args exp_cpp = args_init_from_string("cc");
+  Args exp_extra =
     args_init_from_string("-MMD -MFfoo.d -MT foo -MTbar");
-  struct args* exp_cc =
+  Args exp_cc =
     args_init_from_string("cc -c -MMD -MFfoo.d -MT foo -MTbar");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -417,20 +408,19 @@ TEST(MT_flag_with_immediate_argument_should_work_as_last_argument)
 
 TEST(MQ_flag_with_immediate_argument_should_work_as_last_argument)
 {
-  struct args* orig =
+  Args orig =
     args_init_from_string("cc -c foo.c -o foo.o -MMD -MFfoo.d -MQ foo -MQbar");
-  struct args* exp_cpp = args_init_from_string("cc");
-  struct args* exp_extra =
-    args_init_from_string("-MMD -MFfoo.d -MQ foo -MQbar");
-  struct args* exp_cc =
+
+  Args exp_cpp = args_init_from_string("cc");
+  Args exp_extra = args_init_from_string("-MMD -MFfoo.d -MQ foo -MQbar");
+  Args exp_cc =
     args_init_from_string("cc -c -MMD -MFfoo.d -MQ foo -MQbar");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -440,19 +430,18 @@ TEST(MQ_flag_with_immediate_argument_should_work_as_last_argument)
 
 TEST(MQ_flag_without_immediate_argument_should_not_add_MQobj)
 {
-  struct args* orig =
-    args_init_from_string("gcc -c -MD -MP -MFfoo.d -MQ foo.d foo.c");
-  struct args* exp_cpp = args_init_from_string("gcc");
-  struct args* exp_extra = args_init_from_string("-MD -MP -MFfoo.d -MQ foo.d");
-  struct args* exp_cc =
+  Args orig = args_init_from_string("gcc -c -MD -MP -MFfoo.d -MQ foo.d foo.c");
+
+  Args exp_cpp = args_init_from_string("gcc");
+  Args exp_extra = args_init_from_string("-MD -MP -MFfoo.d -MQ foo.d");
+  Args exp_cc =
     args_init_from_string("gcc -c -MD -MP -MFfoo.d -MQ foo.d");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -462,19 +451,17 @@ TEST(MQ_flag_without_immediate_argument_should_not_add_MQobj)
 
 TEST(MT_flag_without_immediate_argument_should_not_add_MTobj)
 {
-  struct args* orig =
-    args_init_from_string("gcc -c -MD -MP -MFfoo.d -MT foo.d foo.c");
-  struct args* exp_cpp = args_init_from_string("gcc");
-  struct args* exp_extra = args_init_from_string("-MD -MP -MFfoo.d -MT foo.d");
-  struct args* exp_cc =
-    args_init_from_string("gcc -c -MD -MP -MFfoo.d -MT foo.d");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("gcc -c -MD -MP -MFfoo.d -MT foo.d foo.c");
+
+  Args exp_cpp = args_init_from_string("gcc");
+  Args exp_extra = args_init_from_string("-MD -MP -MFfoo.d -MT foo.d");
+  Args exp_cc = args_init_from_string("gcc -c -MD -MP -MFfoo.d -MT foo.d");
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -484,19 +471,17 @@ TEST(MT_flag_without_immediate_argument_should_not_add_MTobj)
 
 TEST(MQ_flag_with_immediate_argument_should_not_add_MQobj)
 {
-  struct args* orig =
-    args_init_from_string("gcc -c -MD -MP -MFfoo.d -MQfoo.d foo.c");
-  struct args* exp_cpp = args_init_from_string("gcc");
-  struct args* exp_extra = args_init_from_string("-MD -MP -MFfoo.d -MQfoo.d");
-  struct args* exp_cc =
-    args_init_from_string("gcc -c -MD -MP -MFfoo.d -MQfoo.d");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("gcc -c -MD -MP -MFfoo.d -MQfoo.d foo.c");
+
+  Args exp_cpp = args_init_from_string("gcc");
+  Args exp_extra = args_init_from_string("-MD -MP -MFfoo.d -MQfoo.d");
+  Args exp_cc = args_init_from_string("gcc -c -MD -MP -MFfoo.d -MQfoo.d");
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -506,19 +491,17 @@ TEST(MQ_flag_with_immediate_argument_should_not_add_MQobj)
 
 TEST(MT_flag_with_immediate_argument_should_not_add_MQobj)
 {
-  struct args* orig =
-    args_init_from_string("gcc -c -MD -MP -MFfoo.d -MTfoo.d foo.c");
-  struct args* exp_cpp = args_init_from_string("gcc");
-  struct args* exp_extra = args_init_from_string("-MD -MP -MFfoo.d -MTfoo.d");
-  struct args* exp_cc =
-    args_init_from_string("gcc -c -MD -MP -MFfoo.d -MTfoo.d");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("gcc -c -MD -MP -MFfoo.d -MTfoo.d foo.c");
+  
+  Args exp_cpp = args_init_from_string("gcc");
+  Args exp_extra = args_init_from_string("-MD -MP -MFfoo.d -MTfoo.d");
+  Args exp_cc = args_init_from_string("gcc -c -MD -MP -MFfoo.d -MTfoo.d");
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -528,14 +511,13 @@ TEST(MT_flag_with_immediate_argument_should_not_add_MQobj)
 
 TEST(fprofile_flag_with_existing_dir_should_be_rewritten_to_real_path)
 {
-  struct args* orig =
-    args_init_from_string("gcc -c -fprofile-generate=some/dir foo.c");
-  struct args* exp_cpp = args_init_from_string("gcc");
-  struct args* exp_extra = args_init(0, NULL);
-  struct args* exp_cc = args_init_from_string("gcc");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("gcc -c -fprofile-generate=some/dir foo.c");
+
+  Args exp_cpp = args_init_from_string("gcc");
+  Args exp_cc = args_init_from_string("gcc");
+  Args exp_extra;
+
+  Args act_cpp, act_cc, act_extra;
 
   char *s, *path;
 
@@ -550,7 +532,7 @@ TEST(fprofile_flag_with_existing_dir_should_be_rewritten_to_real_path)
   args_add(exp_cc, "-c");
   free(s);
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -560,20 +542,17 @@ TEST(fprofile_flag_with_existing_dir_should_be_rewritten_to_real_path)
 
 TEST(fprofile_flag_with_nonexistent_dir_should_not_be_rewritten)
 {
-  struct args* orig =
-    args_init_from_string("gcc -c -fprofile-generate=some/dir foo.c");
-  struct args* exp_cpp =
-    args_init_from_string("gcc -fprofile-generate=some/dir");
-  struct args* exp_extra = args_init(0, NULL);
-  struct args* exp_cc =
-    args_init_from_string("gcc -fprofile-generate=some/dir -c");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("gcc -c -fprofile-generate=some/dir foo.c");
+
+  Args exp_cpp = args_init_from_string("gcc -fprofile-generate=some/dir");
+  Args exp_cc = args_init_from_string("gcc -fprofile-generate=some/dir -c");
+  Args exp_extra;
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -585,20 +564,17 @@ TEST(isystem_flag_with_separate_arg_should_be_rewritten_if_basedir_is_used)
 {
   extern char* current_working_dir;
   char* arg_string;
-  struct args* orig;
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
   g_config.set_base_dir(get_root());
   current_working_dir = get_cwd();
   arg_string = format("cc -isystem %s/foo -c foo.c", current_working_dir);
-  orig = args_init_from_string(arg_string);
+  Args orig = args_init_from_string(arg_string);
   free(arg_string);
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
-  CHECK_STR_EQ("./foo", act_cpp->argv[2]);
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
+  CHECK_STR_EQ("./foo", act_cpp.argv[2]);
 
   args_free(orig);
   args_free(act_cpp);
@@ -610,10 +586,7 @@ TEST(isystem_flag_with_concat_arg_should_be_rewritten_if_basedir_is_used)
   extern char* current_working_dir;
   char* cwd;
   char* arg_string;
-  struct args* orig;
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
   g_config.set_base_dir("/"); // posix
@@ -621,11 +594,12 @@ TEST(isystem_flag_with_concat_arg_should_be_rewritten_if_basedir_is_used)
   // Windows path doesn't work concatenated.
   cwd = get_posix_path(current_working_dir);
   arg_string = format("cc -isystem%s/foo -c foo.c", cwd);
-  orig = args_init_from_string(arg_string);
+  Args orig = args_init_from_string(arg_string);
   free(arg_string);
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
-  CHECK_STR_EQ("-isystem./foo", act_cpp->argv[1]);
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
+
+  CHECK_STR_EQ("-isystem./foo", act_cpp.argv[1]);
 
   free(cwd);
   args_free(orig);
@@ -638,10 +612,7 @@ TEST(I_flag_with_concat_arg_should_be_rewritten_if_basedir_is_used)
   extern char* current_working_dir;
   char* cwd;
   char* arg_string;
-  struct args* orig;
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
   g_config.set_base_dir(x_strdup("/")); // posix
@@ -649,11 +620,11 @@ TEST(I_flag_with_concat_arg_should_be_rewritten_if_basedir_is_used)
   // Windows path doesn't work concatenated.
   cwd = get_posix_path(current_working_dir);
   arg_string = format("cc -I%s/foo -c foo.c", cwd);
-  orig = args_init_from_string(arg_string);
+  Args orig = args_init_from_string(arg_string);
   free(arg_string);
 
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
-  CHECK_STR_EQ("-I./foo", act_cpp->argv[1]);
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
+  CHECK_STR_EQ("-I./foo", act_cpp.argv[1]);
 
   free(cwd);
   args_free(orig);
@@ -663,16 +634,16 @@ TEST(I_flag_with_concat_arg_should_be_rewritten_if_basedir_is_used)
 
 TEST(debug_flag_order_with_known_option_first)
 {
-  struct args* orig = args_init_from_string("cc -g1 -gsplit-dwarf foo.c -c");
-  struct args* exp_cpp = args_init_from_string("cc -g1 -gsplit-dwarf");
-  struct args* exp_extra = args_init(0, NULL);
-  struct args* exp_cc = args_init_from_string("cc -g1 -gsplit-dwarf -c");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("cc -g1 -gsplit-dwarf foo.c -c");
+
+  Args exp_cpp = args_init_from_string("cc -g1 -gsplit-dwarf");
+  Args exp_extra;
+  Args exp_cc = args_init_from_string("cc -g1 -gsplit-dwarf -c");
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -682,16 +653,16 @@ TEST(debug_flag_order_with_known_option_first)
 
 TEST(debug_flag_order_with_known_option_last)
 {
-  struct args* orig = args_init_from_string("cc -gsplit-dwarf -g1 foo.c -c");
-  struct args* exp_cpp = args_init_from_string("cc -gsplit-dwarf -g1");
-  struct args* exp_extra = args_init(0, NULL);
-  struct args* exp_cc = args_init_from_string("cc -gsplit-dwarf -g1 -c");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+  Args orig = args_init_from_string("cc -gsplit-dwarf -g1 foo.c -c");
+
+  Args exp_cpp = args_init_from_string("cc -gsplit-dwarf -g1");
+  Args exp_extra;
+  Args exp_cc = args_init_from_string("cc -gsplit-dwarf -g1 -c");
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);
@@ -701,19 +672,19 @@ TEST(debug_flag_order_with_known_option_last)
 
 TEST(options_not_to_be_passed_to_the_preprocesor)
 {
-  struct args* orig = args_init_from_string(
+  Args orig = args_init_from_string(
     "cc -Wa,foo foo.c -g -c -DX -Werror -Xlinker fie -Xlinker,fum -Wno-error");
-  struct args* exp_cpp = args_init_from_string("cc -g -DX");
-  struct args* exp_extra = args_init_from_string(
+
+  Args exp_cpp = args_init_from_string("cc -g -DX");
+  Args exp_extra = args_init_from_string(
     " -Wa,foo -Werror -Xlinker fie -Xlinker,fum -Wno-error");
-  struct args* exp_cc = args_init_from_string(
+  Args exp_cc = args_init_from_string(
     "cc -g -Wa,foo -Werror -Xlinker fie -Xlinker,fum -Wno-error -DX -c");
-  struct args* act_cpp = NULL;
-  struct args* act_extra = NULL;
-  struct args* act_cc = NULL;
+
+  Args act_cpp, act_cc, act_extra;
 
   create_file("foo.c", "");
-  CHECK(cc_process_args(orig, &act_cpp, &act_extra, &act_cc));
+  CHECK(cc_process_args(orig, act_cpp, act_extra, act_cc));
   CHECK_ARGS_EQ_FREE12(exp_cpp, act_cpp);
   CHECK_ARGS_EQ_FREE12(exp_extra, act_extra);
   CHECK_ARGS_EQ_FREE12(exp_cc, act_cc);


### PR DESCRIPTION
By converting args to a value semantic object, sometimes it becomes Args, sometimes Args& and sometimes Args*.

- Option 1) Change all code where args is on the stack to use &args to call the Args* functions.
This would need to be undone once those functions accept Args&.
Hunderts of lines changed to one direction and then back.
- Option 2) Change all code where args is a pointer to use *args to call the Args& functions.
This would need to be undone once those args become Args&.
Hunderts of lines changed to one direction and then back.
- Option 3) Allow mixed mode for the moment. Implicit cast to pointer is introduced within struct Args.