### PR TITLE
Add support for building with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,212 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(ccache)
+set(CMAKE_CXX_STANDARD 11)
+
+#
+# 3rd party
+#
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+option(USE_LIBZSTD_FROM_INTERNET "Download and use libzstd from the Internet" ON)
+find_package(zstd 1.4.4 REQUIRED)
+
+option(USE_LIBB2_FROM_INTERNET "Download and use libb2 from the Internet" ON)
+find_package(libb2 0.98.1 REQUIRED)
+
+#
+# ccache
+#
+
+set(ccache_sources
+  src/args.cpp src/args.hpp
+  src/ArgsInfo.cpp src/ArgsInfo.hpp
+  src/AtomicFile.cpp src/AtomicFile.hpp
+  src/CacheEntryReader.cpp src/CacheEntryReader.hpp
+  src/CacheEntryWriter.cpp src/CacheEntryWriter.hpp
+  src/CacheFile.cpp src/CacheFile.hpp
+  src/ccache.cpp src/ccache.hpp
+  src/Checksum.hpp
+  src/cleanup.cpp src/cleanup.hpp
+  src/compopt.cpp src/compopt.hpp
+  src/compress.cpp src/compress.hpp
+  src/Compression.cpp src/Compression.hpp
+  src/Compressor.cpp src/Compressor.hpp
+  src/Config.cpp src/Config.hpp
+  src/counters.cpp src/counters.hpp
+  src/Decompressor.cpp src/Decompressor.hpp
+  src/Error.hpp
+  src/execute.cpp src/execute.hpp
+  src/exitfn.cpp src/exitfn.hpp
+  src/File.hpp
+  src/FormatNonstdStringView.hpp
+  src/hash.cpp src/hash.hpp
+  src/hashutil.cpp src/hashutil.hpp
+  src/language.cpp src/language.hpp
+  src/legacy_globals.cpp src/legacy_globals.hpp
+  src/legacy_util.cpp src/legacy_util.hpp
+  src/lockfile.cpp src/lockfile.hpp
+  src/macroskip.hpp
+  src/manifest.cpp src/manifest.hpp
+  src/NonCopyable.hpp
+  src/NullCompressor.cpp src/NullCompressor.hpp
+  src/NullDecompressor.cpp src/NullDecompressor.hpp
+  src/ProgressBar.cpp src/ProgressBar.hpp
+  src/result.cpp src/result.hpp
+  src/Stat.cpp src/Stat.hpp
+  src/stats.cpp src/stats.hpp
+  src/StdMakeUnique.hpp
+  src/system.hpp
+  src/ThreadPool.hpp
+  src/Util.cpp src/Util.hpp
+  src/ZstdCompressor.cpp src/ZstdCompressor.hpp
+  src/ZstdDecompressor.cpp src/ZstdDecompressor.hpp
+
+  src/third_party/fmt/core.h
+  src/third_party/fmt/format-inl.h
+  src/third_party/fmt/format.h
+  src/third_party/getopt_long.h
+  src/third_party/minitrace.h
+  src/third_party/nonstd/optional.hpp
+  src/third_party/nonstd/string_view.hpp
+  src/third_party/xxhash.h
+
+  src/third_party/format.cpp
+  src/third_party/getopt_long.c
+  src/third_party/minitrace.c
+  src/third_party/xxhash.c
+)
+
+find_package(Git)
+execute_process(COMMAND ${GIT_EXECUTABLE} describe
+  OUTPUT_VARIABLE git_output
+  ERROR_VARIABLE git_error
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+if (NOT git_error)
+  string(REGEX MATCH "[0-9.]+" CCACHE_VERSION ${git_output})
+else()
+  set(CCACHE_VERSION 3.7.7)
+endif()
+
+file(WRITE ${CMAKE_BINARY_DIR}/version.cpp.in [=[
+  extern const char CCACHE_VERSION[];
+  const char CCACHE_VERSION[] = "@CCACHE_VERSION@";
+]=])
+configure_file(
+  ${CMAKE_BINARY_DIR}/version.cpp.in
+  ${CMAKE_BINARY_DIR}/version.cpp @ONLY
+)
+
+list(APPEND ccache_sources ${CMAKE_BINARY_DIR}/version.cpp)
+
+add_library(ccache_lib STATIC ${ccache_sources})
+target_include_directories(ccache_lib
+  PUBLIC ${CMAKE_BINARY_DIR} . src src/third_party)
+target_link_libraries(ccache_lib
+  PUBLIC ZSTD::ZSTD libb2::libb2)
+
+add_executable(ccache src/main.cpp)
+target_link_libraries(ccache PRIVATE ccache_lib)
+
+install(TARGETS ccache DESTINATION .)
+
+#
+# unittest
+#
+
+enable_testing()
+set(unittest_files
+  unittest/catch2_tests.cpp unittest/catch2_tests.hpp
+  unittest/framework.cpp unittest/framework.hpp
+  unittest/main.cpp
+  unittest/test_args.cpp
+  unittest/test_argument_processing.cpp
+  unittest/test_AtomicFile.cpp
+  unittest/test_Checksum.cpp
+  unittest/test_compopt.cpp
+  unittest/test_Compression.cpp
+  unittest/test_Config.cpp
+  unittest/test_counters.cpp
+  unittest/test_FormatNonstdStringView.cpp
+  unittest/test_hash.cpp
+  unittest/test_hashutil.cpp
+  unittest/test_legacy_util.cpp
+  unittest/test_lockfile.cpp
+  unittest/test_NullCompression.cpp
+  unittest/test_Stat.cpp
+  unittest/test_stats.cpp
+  unittest/test_Util.cpp
+  unittest/test_ZstdCompression.cpp
+  unittest/util.cpp unittest/util.hpp
+)
+
+add_executable(unittest ${unittest_files})
+target_link_libraries(unittest PRIVATE ccache_lib)
+
+add_test(NAME unittest COMMAND unittest)
+
+#
+# Configuration
+#
+
+include(CheckIncludeFile)
+foreach(include_file IN ITEMS
+    pwd.h
+    sys/mman.h
+    sys/time.h
+    sys/wait.h
+    termios.h
+  )
+  string(TOUPPER ${include_file} include_var)
+  string(REGEX REPLACE "[/.]" "_" include_var ${include_var})
+  set(include_var HAVE_${include_var})
+  check_include_file(${include_file} ${include_var})
+endforeach()
+
+include(CheckFunctionExists)
+foreach(func IN ITEMS
+    GetFinalPathNameByHandleW
+    getopt_long
+    getpwuid
+    gettimeofday
+    localtime_r
+    mkstemp
+    realpath
+    strndup
+    strtok_r
+    unsetenv
+    utimes
+  )
+  string(TOUPPER ${func} func_var)
+  set(func_var HAVE_${func_var})
+  check_function_exists(${func} ${func_var})
+endforeach()
+
+include(CheckSymbolExists)
+list(APPEND CMAKE_REQUIRED_LIBRARIES ws2_32)
+check_symbol_exists(gethostname winsock2.h HAVE_GETHOSTNAME)
+list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES ws2_32)
+
+include(CheckTypeSize)
+check_type_size("long long" HAVE_LONG_LONG)
+
+if(WIN32)
+  set(_WIN32_WINNT 0x0600)
+  target_link_libraries(ccache PRIVATE ws2_32)
+  target_link_libraries(unittest PRIVATE ws2_32)
+
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    target_link_libraries (ccache PRIVATE -static gcc stdc++ winpthread -dynamic)
+  else()
+    target_link_libraries (ccache PRIVATE -static c++ -dynamic)
+  endif()
+endif()
+
+set(_GNU_SOURCE 1)
+set(_POSIX_C_SOURCE 1)
+
+if (CMAKE_SYSTEM MATCHES "Darwin")
+  set(_DARWIN_C_SOURCE 1)
+endif()
+
+configure_file(config.h.cmake.in ${CMAKE_BINARY_DIR}/config.h)

--- a/cmake/Findlibb2.cmake
+++ b/cmake/Findlibb2.cmake
@@ -1,0 +1,98 @@
+if (libb2_FOUND)
+  return()
+endif()
+
+if (USE_LIBB2_FROM_INTERNET)
+  set(libb2_version ${libb2_FIND_VERSION})
+  set(libb2_url https://github.com/BLAKE2/libb2/releases/download/v${libb2_version}/libb2-${libb2_version}.tar.gz)
+
+  set(libb2_dir ${CMAKE_BINARY_DIR}/libb2-${libb2_version})
+  set(libb2_build ${CMAKE_BINARY_DIR}/libb2-build)
+
+  file(DOWNLOAD "${libb2_url}" "${CMAKE_BINARY_DIR}/libb2.tar.gz")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/libb2.tar.gz"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+  file(WRITE "${libb2_dir}/src/config.h.cmake.in" [=[
+    /* Define if you have the `explicit_bzero' function. */
+    #cmakedefine HAVE_EXPLICIT_BZERO
+    /* Define if you have the `explicit_memset' function. */
+    #cmakedefine HAVE_EXPLICIT_MEMSET
+    /* Define if you have the `memset' function. */
+    #cmakedefine HAVE_MEMSET
+    /* Define if you have the `memset_s' function. */
+    #cmakedefine HAVE_MEMSET_S
+    ]=])
+
+  file(WRITE "${libb2_dir}/src/CMakeLists.txt" [=[
+    project(libb2 C)
+
+    include(CheckFunctionExists)
+    foreach(func IN ITEMS
+    explicit_bzero
+    explicit_memset
+    memset
+    memset_s
+    )
+    string(TOUPPER ${func} func_var)
+    set(func_var HAVE_${func_var})
+    check_function_exists(${func} ${func_var})
+    endforeach()
+
+    configure_file(config.h.cmake.in config.h)
+    set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+    add_library(libblake2b_ref STATIC blake2b-ref.c blake2s-ref.c)
+    target_compile_definitions(libblake2b_ref PRIVATE SUFFIX=_ref)
+
+    function(add_libblake2b name suffix)
+    add_library(${name} STATIC blake2b.c blake2s.c)
+    target_compile_definitions(${name} PRIVATE ${suffix})
+    target_compile_options(${name} PRIVATE ${ARGN})
+    endfunction()
+
+    add_libblake2b(libblake2b_sse2 SUFFIX=_sse2 -msse2)
+    add_libblake2b(libblake2b_ssse3 SUFFIX=_ssse3 -msse2 -mssse3)
+    add_libblake2b(libblake2b_sse41 SUFFIX=_sse41 -msse2 -mssse3 -msse4.1)
+    add_libblake2b(libblake2s_avx SUFFIX=_avx -msse2 -mssse3 -msse4.1 -mavx)
+    add_libblake2b(libblake2b_xop SUFFIX=_xop -msse2 -mssse3 -msse4.1 -mavx -mxop)
+
+    add_library(libb2 STATIC blake2-dispatch.c)
+    target_link_libraries(libb2
+    PUBLIC
+      libblake2b_ref libblake2b_sse2 libblake2b_ssse3
+      libblake2b_sse41 libblake2s_avx libblake2b_xop
+    )
+  ]=])
+  add_subdirectory("${libb2_dir}/src" "${libb2_build}" EXCLUDE_FROM_ALL)
+
+  add_library(libb2::libb2 ALIAS libb2)
+  set_target_properties(libb2 PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${libb2_dir}/src"
+  )
+
+  set(libb2_FOUND TRUE)
+else()
+  find_library(LIBB2_LIBRARY b2)
+  find_path(LIBB2_INCLUDE_DIR blake2b.h)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(libb2
+    DEFAULT_MSG
+    LIBB2_INCLUDE_DIR LIBB2_LIBRARY
+  )
+  mark_as_advanced(LIBB2_INCLUDE_DIR LIBB2_LIBRARY)
+
+  add_library(libb2::libb2 UNKNOWN IMPORTED)
+  set_target_properties(libb2::libb2 PROPERTIES
+    IMPORTED_LOCATION "${LIBB2_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${LIBB2_INCLUDE_DIR}"
+  )
+endif()
+
+
+include(FeatureSummary)
+set_package_properties(libb2 PROPERTIES
+  URL "http://blake2.net/"
+  DESCRIPTION "C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp")

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -1,0 +1,47 @@
+if (zstd_FOUND)
+  return()
+endif()
+
+if (USE_LIBZSTD_FROM_INTERNET)
+  set(zstd_version ${zstd_FIND_VERSION})
+  set(zstd_url https://github.com/facebook/zstd/releases/download/v${zstd_version}/zstd-${zstd_version}.tar.gz)
+
+  set(zstd_dir ${CMAKE_BINARY_DIR}/zstd-${zstd_version})
+  set(zstd_build ${CMAKE_BINARY_DIR}/zstd-build)
+
+  file(DOWNLOAD "${zstd_url}" "${CMAKE_BINARY_DIR}/zstd.tar.gz")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/zstd.tar.gz"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+  set(ZSTD_BUILD_SHARED OFF)
+  add_subdirectory("${zstd_dir}/build/cmake" "${zstd_build}" EXCLUDE_FROM_ALL)
+
+  add_library(ZSTD::ZSTD ALIAS libzstd_static)
+  set_target_properties(libzstd_static PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${zstd_dir}/lib"
+  )
+
+  set(zstd_FOUND TRUE)
+else()
+  find_library(ZSTD_LIBRARY zstd)
+  find_path(ZSTD_INCLUDE_DIR zstd.h)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(zstd
+    DEFAULT_MSG
+    ZSTD_INCLUDE_DIR ZSTD_LIBRARY
+  )
+  mark_as_advanced(ZSTD_INCLUDE_DIR ZSTD_LIBRARY)
+
+  add_library(ZSTD::ZSTD UNKNOWN IMPORTED)
+  set_target_properties(ZSTD::ZSTD PROPERTIES
+    IMPORTED_LOCATION "${ZSTD_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIR}"
+  )
+endif()
+
+include(FeatureSummary)
+set_package_properties(zstd PROPERTIES
+  URL "https://facebook.github.io/zstd"
+  DESCRIPTION "Zstandard - Fast real-time compression algorithm")

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -1,0 +1,144 @@
+/* config.h. Originally generated from configure.ac by autoheader.  */
+
+#pragma once
+
+/* Define to 1 if your compiler supports extern inline */
+#cmakedefine HAVE_EXTERN_INLINE
+
+/* Define to 1 if you have the `GetFinalPathNameByHandleW' function. */
+#cmakedefine01 HAVE_GETFINALPATHNAMEBYHANDLEW
+
+/* Define to 1 if you have the `gethostname' function. */
+#cmakedefine01 HAVE_GETHOSTNAME
+
+/* Define to 1 if you have the `getopt_long' function. */
+#cmakedefine01 HAVE_GETOPT_LONG
+
+/* Define to 1 if you have the `getpwuid' function. */
+#cmakedefine HAVE_GETPWUID
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#cmakedefine HAVE_GETTIMEOFDAY
+
+/* Define to 1 if you have the `localtime_r' function. */
+#cmakedefine HAVE_LOCALTIME_R
+
+/* Define to 1 if the system has the type `long long'. */
+#cmakedefine01 HAVE_LONG_LONG
+
+/* Define to 1 if you have the `mkstemp' function. */
+#cmakedefine01 HAVE_MKSTEMP
+
+/* Define to 1 if you have the <pwd.h> header file. */
+#cmakedefine HAVE_PWD_H
+
+/* Define to 1 if you have the `realpath' function. */
+#cmakedefine01 HAVE_REALPATH
+
+/* Define to 1 if you have the `setenv' function. */
+#cmakedefine HAVE_SETENV
+
+/* Define to 1 if you have the `strndup' function. */
+#cmakedefine HAVE_STRNDUP
+
+/* Define to 1 if you have the `strtok_r' function. */
+#cmakedefine01 HAVE_STRTOK_R
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#cmakedefine HAVE_SYS_MMAN_H
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#cmakedefine HAVE_SYS_TIME_H
+
+/* Define to 1 if you have <sys/wait.h> that is POSIX.1 compatible. */
+#cmakedefine HAVE_SYS_WAIT_H
+
+/* Define to 1 if you have the <termios.h> header file. */
+#cmakedefine HAVE_TERMIOS_H
+
+/* Define to 1 if you have the `unsetenv' function. */
+#cmakedefine HAVE_UNSETENV
+
+/* Define to 1 if you have the `utimes' function. */
+#cmakedefine HAVE_UTIMES
+
+/* Define to the address where bug reports for this package should be sent. */
+#cmakedefine01 PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#cmakedefine01 PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#cmakedefine01 PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#cmakedefine01 PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#cmakedefine01 PACKAGE_URL
+
+/* Define to the version of this package. */
+#cmakedefine01 PACKAGE_VERSION
+
+/* Define to 1 if you have the ANSI C header files. */
+#cmakedefine01 STDC_HEADERS
+
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+#cmakedefine01 TIME_WITH_SYS_TIME
+
+/* Define on OpenBSD to activate all library features */
+#cmakedefine _BSD_SOURCE
+
+/* Define on Irix to enable u_int */
+#cmakedefine _BSD_TYPES
+
+/* Define on Darwin to activate all library features */
+#cmakedefine _DARWIN_C_SOURCE
+
+/* Define on Linux to activate all library features */
+#cmakedefine01 _GNU_SOURCE
+
+/* Define on NetBSD to activate all library features */
+#cmakedefine _NETBSD_SOURCE
+
+/* Define to activate features from IEEE Stds 1003.1-2001 */
+#cmakedefine01 _POSIX_C_SOURCE
+
+/* Windows Vista or newer is required */
+#define _WIN32_WINNT @_WIN32_WINNT@
+
+/* Define to the level of X/Open that your system supports */
+#cmakedefine _XOPEN_SOURCE
+
+/* Define to activate Unix95-and-earlier features */
+#cmakedefine _XOPEN_SOURCE_EXTENDED
+
+/* Define on FreeBSD to activate all library features */
+#cmakedefine __BSD_VISIBLE
+
+/* Define to activate Unix95-and-earlier features */
+#cmakedefine __EXTENSIONS__
+
+/* Define to empty if `const' does not conform to ANSI C. */
+#cmakedefine const
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+#cmakedefine inline
+#endif
+
+/* Define to the widest signed integer type if <stdint.h> and <inttypes.h> do
+   not define. */
+#cmakedefine intmax_t
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+#cmakedefine size_t
+
+/* Define to the widest unsigned integer type if <stdint.h> and <inttypes.h>
+   do not define. */
+#cmakedefine uintmax_t
+
+/* Define to the type of an unsigned integer type wide enough to hold a
+   pointer, if such a type exists, and if the system does not define it. */
+#cmakedefine uintptr_t


### PR DESCRIPTION
This MR contains "the build with CMake commit" from my [fork](https://github.com/cristianadam/ccache).

It supports building `ccache` itself, and the `unittests`.

Many of the current build system targets are provided by CMake itself. 

CMake usually does out of tree builds, so one can pack the whole source directory as a sources release.

Integrating [Clang-Tidy](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_CLANG_TIDY.html) or [Cppcheck](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_CPPCHECK.html) can be done with configuration parameters.

[compile_commands.json](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html) is also handled by CMake via a configuration parameter.

My fork has a GitHub actions setup where ccache builds with CMake on Windows MinGW, Linux, and macOS. Since ccache can be build on more platforms, some adjustments might be needed.

Fixes: ccache#430