### PR TITLE
Use Config for init_log()

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -3487,11 +3487,14 @@ initialize()
 #endif
   }
 
+  set_up_config(g_config);
+
+  init_log(g_config);
+
   exitfn_init();
   exitfn_add_nullary(stats_flush);
   exitfn_add_nullary(clean_up_pending_tmp_files);
 
-  set_up_config(g_config);
 
   cc_log("=== CCACHE %s STARTED =========================================",
          CCACHE_VERSION);

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -22,6 +22,9 @@
 
 #include <string>
 
+class Config;
+
+bool init_log(const Config& config);
 void cc_log(const char* format, ...) ATTR_FORMAT(printf, 1, 2);
 void cc_bulklog(const char* format, ...) ATTR_FORMAT(printf, 1, 2);
 void cc_log_argv(const char* prefix, char** argv);


### PR DESCRIPTION
Note that `initialize()` and therefore `init_log()` is called multiple times in `ccache_main_options()`, so for now `init_log()` still needs to tolerate being called multiple times.