### PR TITLE
Add Context, move two globals into in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -39,6 +39,7 @@ non_third_party_sources = \
     src/Compression.cpp \
     src/Compressor.cpp \
     src/Config.cpp \
+    src/Context.cpp \
     src/Decompressor.cpp \
     src/NullCompressor.cpp \
     src/NullDecompressor.cpp \

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -16,13 +16,8 @@
 // this program; if not, write to the Free Software Foundation, Inc., 51
 // Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#pragma once
+#include "Context.hpp"
 
-struct Context;
-
-void exitfn_init();
-void exitfn_add_nullary(void (*function)());
-void exitfn_add(void (*function)(void*), void* context);
-void exitfn_add_last(void (*function)(void*), void* context);
-void exitfn_delete_context(Context* ctx);
-void exitfn_call();
+Context::~Context()
+{
+}

--- a/src/Context.hpp
+++ b/src/Context.hpp
@@ -27,4 +27,6 @@ struct Context : NonCopyable
 {
   Context() = default;
   ~Context();
+
+  ArgsInfo args_info;
 };

--- a/src/Context.hpp
+++ b/src/Context.hpp
@@ -18,11 +18,13 @@
 
 #pragma once
 
-struct Context;
+#include "system.hpp"
 
-void exitfn_init();
-void exitfn_add_nullary(void (*function)());
-void exitfn_add(void (*function)(void*), void* context);
-void exitfn_add_last(void (*function)(void*), void* context);
-void exitfn_delete_context(Context* ctx);
-void exitfn_call();
+#include "ArgsInfo.hpp"
+#include "NonCopyable.hpp"
+
+struct Context : NonCopyable
+{
+  Context() = default;
+  ~Context();
+};

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -3487,11 +3487,14 @@ initialize()
 #endif
   }
 
+  set_up_config(g_config);
+
+  init_log(g_config);
+
   exitfn_init();
   exitfn_add_nullary(stats_flush);
   exitfn_add_nullary(clean_up_pending_tmp_files);
 
-  set_up_config(g_config);
 
   cc_log("=== CCACHE %s STARTED =========================================",
          CCACHE_VERSION);

--- a/src/legacy_globals.cpp
+++ b/src/legacy_globals.cpp
@@ -25,9 +25,6 @@ char* current_working_dir = nullptr;
 extern struct args* orig_args;
 struct args* orig_args = nullptr;
 
-// The output file being compiled to.
-char* output_obj;
-
 // The path to the dependency file (implicit or specified with -MF).
 char* output_dep;
 

--- a/src/legacy_globals.cpp
+++ b/src/legacy_globals.cpp
@@ -25,9 +25,6 @@ char* current_working_dir = nullptr;
 extern struct args* orig_args;
 struct args* orig_args = nullptr;
 
-// The source file.
-char* input_file;
-
 // The output file being compiled to.
 char* output_obj;
 

--- a/src/legacy_globals.hpp
+++ b/src/legacy_globals.hpp
@@ -34,8 +34,6 @@ extern unsigned lock_staleness_limit;
 
 extern struct args* orig_args;
 
-extern char* input_file;
-
 extern char* output_obj;
 
 extern char* output_dep;

--- a/src/legacy_globals.hpp
+++ b/src/legacy_globals.hpp
@@ -34,8 +34,6 @@ extern unsigned lock_staleness_limit;
 
 extern struct args* orig_args;
 
-extern char* output_obj;
-
 extern char* output_dep;
 
 extern char* output_cov;

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -22,6 +22,9 @@
 
 #include <string>
 
+class Config;
+
+bool init_log(const Config& config);
 void cc_log(const char* format, ...) ATTR_FORMAT(printf, 1, 2);
 void cc_bulklog(const char* format, ...) ATTR_FORMAT(printf, 1, 2);
 void cc_log_argv(const char* prefix, char** argv);

--- a/unittest/test_argument_processing.cpp
+++ b/unittest/test_argument_processing.cpp
@@ -84,7 +84,6 @@ cc_process_args(Context& ctx,
                                  extra_args_to_hash,
                                  compiler_args);
 
-  output_obj = x_strdup(ctx.args_info.output_obj.c_str());
   output_dep = x_strdup(ctx.args_info.output_dep.c_str());
   output_cov = x_strdup(ctx.args_info.output_cov.c_str());
   output_su = x_strdup(ctx.args_info.output_su.c_str());


### PR DESCRIPTION
As discussed in #526, the Context argument is now only added as-needed.