### PR TITLE
Fix out of tree build

### DIFF
--- a/src/args.hpp
+++ b/src/args.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "src/ScopeGuard.hpp"
+#include "ScopeGuard.hpp"
 
 struct args
 {


### PR DESCRIPTION
The CPPFLAGS contain "-I.", but not "-I$(srcdir)", which means "src/ScopeGuard.hpp" was only
found when building from the source root.
