### PR TITLE
Out of tree commands

### DIFF
--- a/dev.mk.in
+++ b/dev.mk.in
@@ -188,8 +188,8 @@ check-syntax:
 
 .PHONY: cppcheck
 cppcheck:
-	$(CPPCHECK) --suppressions-list=$(CPPCHECK_SUPPRESSIONS) \
-	  --inline-suppr -q --enable=all --force -I . \
+	cd $(srcdir) && $(CPPCHECK) --suppressions-list=$(CPPCHECK_SUPPRESSIONS) \
+	  --inline-suppr -q --enable=all --force -I $(CURDIR) \
 	  --template='cppcheck: warning: {id}:{file}:{line}: {message}' \
 	  $(non_third_party_sources) src/main.cpp $(test_sources)
 
@@ -199,7 +199,7 @@ shellcheck: test/suites/*.bash
 
 .PHONY: format
 format:
-	@echo $(non_third_party_headers) $(non_third_party_sources) $(test_sources) | xargs -n1 -P8 \
+	@cd $(srcdir) && echo $(non_third_party_headers) $(non_third_party_sources) $(test_sources) | xargs -n1 -P8 \
 	    misc/run-clang-format
 
 # Not using parallel execution because target is most likely being run on non-interactive CI system,
@@ -207,7 +207,7 @@ format:
 .PHONY: check_format
 check_format:
 	@[ -t 1 ] && export cf_diff_color="--color=always"; \
-	echo $(non_third_party_headers) $(non_third_party_sources) $(test_sources) | xargs -n1 -P1 \
+	cd $(srcdir) && echo $(non_third_party_headers) $(non_third_party_sources) $(test_sources) | xargs -n1 -P1 \
 	    misc/run-clang-format --check || \
 		{  echo; echo "Error: Sources are not formatted with clang-format."; \
 		   echo 'Run "make format" or apply the above diff.'; }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -401,13 +401,12 @@ normalize_absolute_path(string_view path)
   std::string result = "/";
   const size_t npos = string_view::npos;
   size_t left = 1;
-  size_t right = 1;
 
   while (true) {
     if (left >= path.length()) {
       break;
     }
-    right = path.find('/', left);
+    const auto right = path.find('/', left);
     string_view part = path.substr(left, right == npos ? npos : right - left);
     if (part == "..") {
       if (result.length() > 1) {

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -3399,7 +3399,7 @@ initialize(int argc, char* argv[])
 {
   // This object is placed onto the heap so it is available in exit functions
   // which run after main(). It is cleaned up by the last exit function.
-  Context* ctx = new Context{};
+  Context* ctx = new Context;
 
   set_up_config(ctx->config);
 

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1325,7 +1325,7 @@ to_cache(Context& ctx,
     failed(STATS_ERROR);
   }
   stats_update_size(ctx,
-                    ctx.stats_file.c_str(),
+                    ctx.stats_file,
                     new_dest_stat.size_on_disk()
                       - orig_dest_stat.size_on_disk(),
                     orig_dest_stat ? 0 : 1);

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -127,7 +127,7 @@ recompress_file(Context& ctx,
   uint64_t new_size =
     Stat::stat(cache_file.path(), Stat::OnError::log).size_on_disk();
 
-  stats_update_size(ctx, stats_file.c_str(), new_size - old_size, 0);
+  stats_update_size(ctx, stats_file, new_size - old_size, 0);
   cc_log("Recompression of %s done", cache_file.path().c_str());
 }
 

--- a/src/legacy_util.cpp
+++ b/src/legacy_util.cpp
@@ -977,7 +977,7 @@ subst_env_in_string(const char* str, char** errmsg)
   char* result = x_strdup("");
   const char* p = str; // Interval start.
   const char* q = str; // Interval end.
-  for (q = str; *q; ++q) {
+  for (; *q; ++q) {
     if (*q == '$') {
       reformat(&result, "%s%.*s", result, (int)(q - p), p);
       if (!expand_variable(&q, &result, errmsg)) {

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -414,7 +414,7 @@ write_raw_file_entry(Context& ctx,
   auto new_stat = Stat::stat(raw_file);
 
   stats_update_size(ctx,
-                    ctx.stats_file.c_str(),
+                    ctx.stats_file,
                     new_stat.size_on_disk() - old_stat.size_on_disk(),
                     (new_stat ? 1 : 0) - (old_stat ? 1 : 0));
 }

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -439,14 +439,6 @@ stats_update(Context& ctx, enum stats stat)
   ctx.counter_updates->data[stat]++;
 }
 
-// Get the pending update of a counter value.
-unsigned
-stats_get_pending(Context& ctx, enum stats stat)
-{
-  init_counter_updates(ctx);
-  return ctx.counter_updates->data[stat];
-}
-
 // Sum and display the total stats for all cache dirs.
 void
 stats_summary(const Config& config)

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -426,7 +426,7 @@ stats_flush_to_file(const Config& config,
 void
 stats_flush(void* context)
 {
-  Context& ctx = *static_cast<Context*>(context);
+  const Context& ctx = *static_cast<Context*>(context);
   stats_flush_to_file(ctx.config, ctx.stats_file, ctx.counter_updates);
 }
 

--- a/src/stats.hpp
+++ b/src/stats.hpp
@@ -66,7 +66,6 @@ enum stats {
 
 void stats_update(Context& ctx, enum stats stat);
 void stats_flush(void* context);
-unsigned stats_get_pending(Context& ctx, enum stats stat);
 void stats_zero(const Config& config);
 void stats_summary(const Config& config);
 void stats_print(const Config& config);


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
Make it possible to run `make format|check_format|cppcheck` in out-of-tree builds. Also fix some of the warnings reported by cppcheck.