### PR TITLE
Make new installations use XDG base directory

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -212,10 +212,6 @@ highest):
    */etc/ccache.conf* or */usr/local/etc/ccache.conf*).
 4. Compile-time defaults.
 
-As a special case, if the environment variable *CCACHE_CONFIGPATH* is set,
-ccache reads configuration from the specified path instead of the default
-paths.
-
 
 Configuration file syntax
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -121,7 +121,7 @@ private:
   std::string m_secondary_config_path;
 
   std::string m_base_dir = "";
-  std::string m_cache_dir = fmt::format("{}/.ccache", get_home_directory());
+  std::string m_cache_dir = "";
   uint32_t m_cache_dir_levels = 2;
   std::string m_compiler = "";
   std::string m_compiler_check = "mtime";

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -3345,30 +3345,26 @@ tmpdir()
 static void
 set_up_config(Config& config)
 {
-  char* p = getenv("CCACHE_CONFIGPATH");
-  if (p) {
-    config.set_primary_config_path(p);
-  } else {
-    config.set_secondary_config_path(
-      fmt::format("{}/ccache.conf", TO_STRING(SYSCONFDIR)));
-    MTR_BEGIN("config", "conf_read_secondary");
-    // A missing config file in SYSCONFDIR is OK so don't check return value.
-    config.update_from_file(config.secondary_config_path());
-    MTR_END("config", "conf_read_secondary");
+  char* p;
+  config.set_secondary_config_path(
+    fmt::format("{}/ccache.conf", TO_STRING(SYSCONFDIR)));
+  MTR_BEGIN("config", "conf_read_secondary");
+  // A missing config file in SYSCONFDIR is OK so don't check return value.
+  config.update_from_file(config.secondary_config_path());
+  MTR_END("config", "conf_read_secondary");
 
-    if (config.cache_dir().empty()) {
-      fatal("configuration setting \"cache_dir\" must not be the empty string");
-    }
-    if ((p = getenv("CCACHE_DIR"))) {
-      config.set_cache_dir(p);
-    }
-    if (config.cache_dir().empty()) {
-      fatal("CCACHE_DIR must not be the empty string");
-    }
-
-    config.set_primary_config_path(
-      fmt::format("{}/ccache.conf", config.cache_dir()));
+  if (config.cache_dir().empty()) {
+    fatal("configuration setting \"cache_dir\" must not be the empty string");
   }
+  if ((p = getenv("CCACHE_DIR"))) {
+    config.set_cache_dir(p);
+  }
+  if (config.cache_dir().empty()) {
+    fatal("CCACHE_DIR must not be the empty string");
+  }
+
+  config.set_primary_config_path(
+    fmt::format("{}/ccache.conf", config.cache_dir()));
 
   bool should_create_initial_config = false;
   MTR_BEGIN("config", "conf_read_primary");

--- a/test/run
+++ b/test/run
@@ -281,7 +281,6 @@ $(env | sed -n 's/^\(CCACHE_[A-Z0-9_]*\)=.*$/\1/p')
 EOF
     unset GCC_COLORS
 
-    export CCACHE_CONFIGPATH=$ABS_TESTDIR/ccache.conf
     export CCACHE_DETECT_SHEBANG=1
     export CCACHE_DIR=$ABS_TESTDIR/.ccache
     export CCACHE_LOGFILE=$ABS_TESTDIR/ccache.log

--- a/test/suites/upgrade.bash
+++ b/test/suites/upgrade.bash
@@ -1,7 +1,7 @@
 SUITE_upgrade() {
     TEST "Keep maxfiles and maxsize settings"
 
-    rm -f $CCACHE_CONFIGPATH
+    rm -f $ABS_TESTDIR/ccache.conf
     mkdir -p $CCACHE_DIR/0
     echo "0 0 0 0 0 0 0 0 0 0 0 0 0 2000 131072" >$CCACHE_DIR/0/stats
     expect_stat 'max files' 32000

--- a/unittest/test_Config.cpp
+++ b/unittest/test_Config.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Config: default values")
 {
   Config config;
   CHECK(config.base_dir().empty());
-  CHECK(config.cache_dir() == std::string(get_home_directory()) + "/.ccache");
+  CHECK(config.cache_dir().empty());
   CHECK(config.cache_dir_levels() == 2);
   CHECK(config.compiler().empty());
   CHECK(config.compiler_check() == "mtime");


### PR DESCRIPTION
This effectively deprecates `~/.ccache` as the default directory.

It is still possible to revert to the old behaviour by either setting
this directory in the secondary config file, or by setting the
`CCACHE_DIR` environment variable.

The new directories are `~/.config/ccache` for the configuration file, and
`~/.cache/ccache` for all other files.  We may want to introduce a third
directory, `~/.local/share/ccache`, for statistics, but I wanted to
validate the new behaviour first.

Fixes #191.