### PR TITLE
Avoid duplicate stat calls

### DIFF
--- a/src/hashutil.cpp
+++ b/src/hashutil.cpp
@@ -264,7 +264,10 @@ hash_source_code_string(const Config& config,
 // Hash a file ignoring comments. Returns a bitmask of HASH_SOURCE_CODE_*
 // results.
 int
-hash_source_code_file(const Config& config, struct hash* hash, const char* path)
+hash_source_code_file(const Config& config,
+                      struct hash* hash,
+                      const char* path,
+                      size_t size_hint)
 {
   if (is_precompiled_header(path)) {
     if (hash_file(hash, path)) {
@@ -275,7 +278,7 @@ hash_source_code_file(const Config& config, struct hash* hash, const char* path)
   } else {
     char* data;
     size_t size;
-    if (!read_file(path, 0, &data, &size)) {
+    if (!read_file(path, size_hint, &data, &size)) {
       return HASH_SOURCE_CODE_ERROR;
     }
     int result = hash_source_code_string(config, hash, data, size, path);

--- a/src/hashutil.hpp
+++ b/src/hashutil.hpp
@@ -43,7 +43,8 @@ int hash_source_code_string(const Config& config,
                             const char* path);
 int hash_source_code_file(const Config& config,
                           struct hash* hash,
-                          const char* path);
+                          const char* path,
+                          size_t size_hint = 0);
 bool hash_command_output(struct hash* hash,
                          const char* command,
                          const char* compiler);

--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -447,7 +447,7 @@ verify_result(const Context& ctx,
     auto hashed_files_iter = hashed_files.find(path);
     if (hashed_files_iter == hashed_files.end()) {
       struct hash* hash = hash_init();
-      int ret = hash_source_code_file(ctx.config, hash, path.c_str());
+      int ret = hash_source_code_file(ctx.config, hash, path.c_str(), fs.size);
       if (ret & HASH_SOURCE_CODE_ERROR) {
         cc_log("Failed hashing %s", path.c_str());
         hash_free(hash);


### PR DESCRIPTION
hash_source_code_string will, in read_file, stat the file to get the file
size. But when called from verify_result, the file size is already known so by
using this size the number of stat calls in a normal run can be cut in half.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
