### PR TITLE
Read/write optimizations

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -175,7 +175,7 @@ hash_int(struct hash* hash, int x)
 }
 
 bool
-hash_fd(struct hash* hash, int fd)
+hash_fd(struct hash* hash, int fd, bool fd_is_file)
 {
   char buf[READ_BUFFER_SIZE];
   ssize_t n;
@@ -187,7 +187,7 @@ hash_fd(struct hash* hash, int fd)
     if (n > 0) {
       do_hash_buffer(hash, buf, n);
       do_debug_text(hash, buf, n);
-      if (static_cast<size_t>(n) < sizeof(buf)) {
+      if (fd_is_file && static_cast<size_t>(n) < sizeof(buf)) {
         break;
       }
     }
@@ -204,7 +204,7 @@ hash_file(struct hash* hash, const char* fname)
     return false;
   }
 
-  bool ret = hash_fd(hash, fd);
+  bool ret = hash_fd(hash, fd, true);
   close(fd);
   return ret;
 }

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -187,9 +187,12 @@ hash_fd(struct hash* hash, int fd)
     if (n > 0) {
       do_hash_buffer(hash, buf, n);
       do_debug_text(hash, buf, n);
+      if (static_cast<size_t>(n) < sizeof(buf)) {
+        break;
+      }
     }
   }
-  return n == 0;
+  return n >= 0;
 }
 
 bool

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -106,7 +106,7 @@ void hash_int(struct hash* hash, int x);
 // file.
 //
 // Returns true on success, otherwise false.
-bool hash_fd(struct hash* hash, int fd);
+bool hash_fd(struct hash* hash, int fd, bool fd_is_file = false);
 
 // Add contents of a file to the hash.
 //

--- a/src/legacy_util.cpp
+++ b/src/legacy_util.cpp
@@ -88,7 +88,7 @@ write_fd(int fd, const void* buf, size_t size)
 
 // Copy all data from fd_in to fd_out.
 bool
-copy_fd(int fd_in, int fd_out)
+copy_fd(int fd_in, int fd_out, bool fd_in_is_file)
 {
   ssize_t n;
   char buf[READ_BUFFER_SIZE];
@@ -97,7 +97,7 @@ copy_fd(int fd_in, int fd_out)
       return false;
     }
 
-    if (static_cast<size_t>(n) < sizeof(buf)) {
+    if (fd_in_is_file && static_cast<size_t>(n) < sizeof(buf)) {
       break;
     }
   }
@@ -230,7 +230,7 @@ copy_file(const char* src, const char* dest, bool via_tmp_file)
     }
   }
 
-  if (copy_fd(src_fd, dest_fd)) {
+  if (copy_fd(src_fd, dest_fd, true)) {
     result = true;
   }
 

--- a/src/legacy_util.hpp
+++ b/src/legacy_util.hpp
@@ -24,6 +24,7 @@
 
 void fatal(const char* format, ...) ATTR_FORMAT(printf, 1, 2) ATTR_NORETURN;
 
+bool write_fd(int fd, const void* buf, size_t size);
 bool copy_fd(int fd_in, int fd_out);
 bool clone_file(const char* src, const char* dest, bool via_tmp_file);
 bool copy_file(const char* src, const char* dest, bool via_tmp_file);

--- a/src/legacy_util.hpp
+++ b/src/legacy_util.hpp
@@ -25,7 +25,7 @@
 void fatal(const char* format, ...) ATTR_FORMAT(printf, 1, 2) ATTR_NORETURN;
 
 bool write_fd(int fd, const void* buf, size_t size);
-bool copy_fd(int fd_in, int fd_out);
+bool copy_fd(int fd_in, int fd_out, bool fd_in_is_file = false);
 bool clone_file(const char* src, const char* dest, bool via_tmp_file);
 bool copy_file(const char* src, const char* dest, bool via_tmp_file);
 bool move_file(const char* src, const char* dest);


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->

This PR improves `read_file` to avoid doing a realloc + read when the whole file has already been read in the first read call. Similar logic is then applied in other places where `read` is used.

Additionally, I've changed `read_embedded_file_entry` to use `write` instead of `fwrite` to write the result file. This since I noticed that each call to `fwrite` resulted in two calls to `write` (on my system). It seemed like it would be more efficient to write directly to the fd instead of going via stdio.