### PR TITLE
Enable check_format and clang-tidy checks in CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,0 @@
----
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,-clang-analyzer-optin.performance.Padding'
-HeaderFilterRegex: 'src/.*|unittest/.*'
-CheckOptions:    
-  - key:             readability-braces-around-statements.ShortStatementLines
-    value:           1
-...
-

--- a/.travis.sh
+++ b/.travis.sh
@@ -8,3 +8,5 @@ make travis CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix CONFIGU
 make travis CC=clang CXX=clang++ CFLAGS="-fsanitize=undefined" LDFLAGS="-fsanitize=undefined" ASAN_OPTIONS="detect_leaks=0"
 make travis CC=clang CXX=clang++ CFLAGS="-fsanitize=address -g" LDFLAGS="-fsanitize=address" ASAN_OPTIONS="detect_leaks=0"
 make travis CC=/usr/bin/clang CXX=/usr/bin/clang++ TEST=analyze
+make travis CC=/usr/bin/clang CXX=/usr/bin/clang++ TEST=tidy
+make travis CC=/usr/bin/clang CXX=/usr/bin/clang++ TEST=check_format

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - ./autogen.sh
   - test -z $BUILD_DIR || { mkdir -p $BUILD_DIR; cd $BUILD_DIR; }
   - ${SRC_DIR:-.}/configure $CONFIGURE
-  - make
+  - test "$NO_COMPILE" || make
   - make ${TEST:-test}
 
 matrix:
@@ -111,3 +111,50 @@ matrix:
         - libb2-dev
     before_install:
     - source ./.travis/install_cuda.sh
+
+  # Job: Clang tidy
+  - os: linux
+    env: V=1 PATH="/usr/bin:$PATH" NO_COMPILE=1 TEST=tidy
+    addons:
+      apt:
+        packages:
+        - elfutils
+        - libzstd1-dev
+        - libb2-dev
+    before_install:
+    - pip install --user compiledb
+
+  # Job: Check formatting
+  - os: linux
+    env: V=1 PATH="/usr/bin:$PATH" NO_COMPILE=1 TEST=check_format
+    addons:
+      apt:
+        packages:
+        - elfutils
+        - libzstd1-dev
+        - libb2-dev
+
+  # New Jobs go here until they are established for some weeks
+  allow_failures:
+
+  # Job: Clang tidy
+  - os: linux
+    env: V=1 PATH="/usr/bin:$PATH" NO_COMPILE=1 TEST=tidy
+    addons:
+      apt:
+        packages:
+        - elfutils
+        - libzstd1-dev
+        - libb2-dev
+    before_install:
+    - pip install --user compiledb
+
+  # Job: Check formatting
+  - os: linux
+    env: V=1 PATH="/usr/bin:$PATH" NO_COMPILE=1 TEST=check_format
+    addons:
+      apt:
+        packages:
+        - elfutils
+        - libzstd1-dev
+        - libb2-dev

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,83 @@
+# This .clang-tidy file is used by CI to ensure commits do not worsen the
+# codebase. If you want to improve the codebase this config is not for you.
+# Some checks are highly style dependant. The goal is NOT to activate all
+# of them.
+
+---
+Checks:          '-*,
+                  readability-*,
+                  -readability-implicit-bool-conversion,
+                  -readability-magic-numbers,
+                  -readability-else-after-return,
+                  -readability-named-parameter,
+                  -readability-qualified-auto,
+                  -readability-magic-numbers,
+                  -readability-isolate-declaration,
+                  -readability-inconsistent-declaration-parameter-name,
+                  -readability-simplify-boolean-expr,
+                  performance-*,
+                  -performance-unnecessary-value-param,
+                  -performance-faster-string-find,
+                  modernize-*,
+                  -modernize-avoid-c-arrays,
+                  -modernize-deprecated-headers,
+                  -modernize-loop-convert,
+                  -modernize-pass-by-value,
+                  -modernize-use-auto,
+                  -modernize-use-bool-literals,
+                  -modernize-use-using,
+                  -modernize-use-trailing-return-type,
+                  cppcoreguidelines-*,
+                  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+                  -cppcoreguidelines-pro-type-vararg,
+                  -cppcoreguidelines-owning-memory,
+                  -cppcoreguidelines-avoid-magic-numbers,
+                  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+                  -cppcoreguidelines-no-malloc,
+                  -cppcoreguidelines-init-variables,
+                  -cppcoreguidelines-avoid-c-arrays,
+                  -cppcoreguidelines-pro-bounds-constant-array-index,
+                  -cppcoreguidelines-pro-type-cstyle-cast,
+                  -cppcoreguidelines-avoid-goto,
+                  -cppcoreguidelines-pro-type-member-init,
+                  -cppcoreguidelines-macro-usage,
+                  -cppcoreguidelines-pro-type-reinterpret-cast,
+                  -cppcoreguidelines-pro-type-union-access,
+                  -cppcoreguidelines-narrowing-conversions,
+                  bugprone-*,
+                  -bugprone-signed-char-misuse,
+                  -bugprone-branch-clone,
+                  -bugprone-narrowing-conversions,
+                  cert-*,
+                  -cert-err34-c,
+                  -cert-dcl50-cpp,
+                  -cert-err58-cpp,
+                  clang-diagnostic-*,
+                  clang-analyzer-*,
+                  -clang-analyzer-alpha*,
+                  -clang-analyzer-valist.Uninitialized,
+                  -clang-analyzer-optin.performance.Padding'
+WarningsAsErrors: '*'
+# Exclude subdirectories (currently there is only thrid_party)
+HeaderFilterRegex: 'src/[^\\/]*^'
+CheckOptions:    
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           2
+
+  # extremly high limits, they are just here to ensure the situation doesn't
+  # get worse than it already is.
+  # If you hit the limits, please change the code and not the limits!!
+  - key:             readability-function-size.LineThreshold
+    value:           1100
+  - key:             readability-function-size.StatementThreshold
+    value:           760
+  - key:             readability-function-size.BranchThreshold
+    value:           170
+  - key:             readability-function-size.ParameterThreshold
+    value:           6
+  - key:             readability-function-size.NestingThreshold
+    value:           6
+  - key:             readability-function-size.VariableThreshold
+    value:           80
+...
+

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,6 +1,6 @@
-# This .clang-tidy file is used by CI to ensure commits do not worsen the
+# This .clang-tidy file is used by CI to ensure that commits do not worsen the
 # codebase. If you want to improve the codebase this config is not for you.
-# Some checks are highly style dependant. The goal is NOT to activate all
+# Some checks are highly style dependent. The goal is NOT to activate all
 # of them.
 
 ---
@@ -58,14 +58,13 @@ Checks:          '-*,
                   -clang-analyzer-valist.Uninitialized,
                   -clang-analyzer-optin.performance.Padding'
 WarningsAsErrors: '*'
-# Exclude subdirectories (currently there is only thrid_party)
+# Exclude subdirectories (currently there is only third_party)
 HeaderFilterRegex: 'src/[^\\/]*^'
 CheckOptions:    
+  # Always add braces (added here just in case clang-tidy default changes).
   - key:             readability-braces-around-statements.ShortStatementLines
-    value:           2
+    value:           0
 
-  # extremly high limits, they are just here to ensure the situation doesn't
-  # get worse than it already is.
   # If you hit the limits, please change the code and not the limits!!
   - key:             readability-function-size.LineThreshold
     value:           1100

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -65,7 +65,7 @@ CheckOptions:
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           0
 
-  # If you hit the limits, please change the code and not the limits!!
+  # If you hit a limit, please consider changing the code instead of the limit.
   - key:             readability-function-size.LineThreshold
     value:           1100
   - key:             readability-function-size.StatementThreshold
@@ -79,4 +79,3 @@ CheckOptions:
   - key:             readability-function-size.VariableThreshold
     value:           80
 ...
-

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,5 +1,8 @@
 # This .clang-tidy file is used by CI to ensure that commits do not worsen the
-# codebase. If you want to improve the codebase this config is not for you.
+# codebase. The checks and values below are the minimum standard for new code.
+(Without claiming that they are 100% correct. They can be modified on demand!)
+If you want to improve the codebase try enabling some additional checks or
+playing with the configuration values.
 # Some checks are highly style dependent. The goal is NOT to activate all
 # of them.
 

--- a/src/Counters.cpp
+++ b/src/Counters.cpp
@@ -26,8 +26,12 @@ Counters::Counters() : m_counters(STATS_END)
 {
 }
 
+// Return type is on separate line since clang-format 10.
+// Since different people use different versions, auto formatting is disabled.
+// clang-format off
 unsigned&
 Counters::operator[](size_t index)
+// clang-format on
 {
   if (index >= m_counters.size()) {
     m_counters.resize(index + 1);
@@ -35,8 +39,12 @@ Counters::operator[](size_t index)
   return m_counters.at(index);
 }
 
+// Return type is on separate line since clang-format 10.
+// Since different people use different versions, auto formatting is disabled.
+// clang-format off
 unsigned
 Counters::operator[](size_t index) const
+// clang-format on
 {
   return index < m_counters.size() ? m_counters.at(index) : 0;
 }

--- a/src/Counters.cpp
+++ b/src/Counters.cpp
@@ -26,7 +26,8 @@ Counters::Counters() : m_counters(STATS_END)
 {
 }
 
-unsigned& Counters::operator[](size_t index)
+unsigned&
+Counters::operator[](size_t index)
 {
   if (index >= m_counters.size()) {
     m_counters.resize(index + 1);
@@ -34,7 +35,8 @@ unsigned& Counters::operator[](size_t index)
   return m_counters.at(index);
 }
 
-unsigned Counters::operator[](size_t index) const
+unsigned
+Counters::operator[](size_t index) const
 {
   return index < m_counters.size() ? m_counters.at(index) : 0;
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -112,7 +112,7 @@ log_prefix(bool log_updated_time)
     struct tm tm;
     struct timeval tv;
     gettimeofday(&tv, nullptr);
-    if (localtime_r((time_t*)&tv.tv_sec, &tm) != NULL) {
+    if (localtime_r((time_t*)&tv.tv_sec, &tm) != nullptr) {
       strftime(timestamp, sizeof(timestamp), "%Y-%m-%dT%H:%M:%S", &tm);
     } else {
       snprintf(timestamp, sizeof(timestamp), "%lu", tv.tv_sec);

--- a/src/third_party/.clang-tidy
+++ b/src/third_party/.clang-tidy
@@ -1,5 +1,5 @@
 # It's currently not possible to disable all checkers within a subdirectory via
-# config file... So just pick a check that will never fail.
+# config file... So just pick a fast check that will never fail.
 ---
 Checks:          '-*,readability-function-size'
 CheckOptions:    

--- a/src/third_party/.clang-tidy
+++ b/src/third_party/.clang-tidy
@@ -1,0 +1,9 @@
+# It's currently not possible to disable all checkers within a subdirectory via
+# config file... So just pick a check that will never fail.
+---
+Checks:          '-*,readability-function-size'
+CheckOptions:    
+  - key:             readability-function-size.LineThreshold
+    value:           99999999
+...
+

--- a/unittest/.clang-tidy
+++ b/unittest/.clang-tidy
@@ -3,14 +3,13 @@ Checks:          '-*,readability-function-size'
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'unittest/.*'
 CheckOptions:    
+  # Always add braces (added here just in case clang-tidy default changes).
   - key:             readability-braces-around-statements.ShortStatementLines
-    value:           2
+    value:           0
 
-  # extremly high limits, they are just here to ensure the situation doesn't
-  # get worse than it already is
   # If you hit the limits, please change the code and not the limits!!
-  # Note: some limits disabled due to TEST_SUITE macro.
-  # It generates hundreds of statements, branches and variables.
+  # Note: some limits "disabled" due to TEST_SUITE macro.
+  # The macro generates hundreds of statements, branches and variables.
   - key:             readability-function-size.LineThreshold
     value:           130
   - key:             readability-function-size.StatementThreshold

--- a/unittest/.clang-tidy
+++ b/unittest/.clang-tidy
@@ -1,0 +1,27 @@
+---
+Checks:          '-*,readability-function-size'
+WarningsAsErrors: '*'
+HeaderFilterRegex: 'unittest/.*'
+CheckOptions:    
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           2
+
+  # extremly high limits, they are just here to ensure the situation doesn't
+  # get worse than it already is
+  # If you hit the limits, please change the code and not the limits!!
+  # Note: some limits disabled due to TEST_SUITE macro.
+  # It generates hundreds of statements, branches and variables.
+  - key:             readability-function-size.LineThreshold
+    value:           130
+  - key:             readability-function-size.StatementThreshold
+    value:           999999
+  - key:             readability-function-size.ParameterThreshold
+    value:           7
+  - key:             readability-function-size.NestingThreshold
+    value:           6
+  - key:             readability-function-size.NestingThreshold
+    value:           999999
+  - key:             readability-function-size.VariableThreshold
+    value:           999999
+...
+


### PR DESCRIPTION
Add clang-tidy (and check_format) to CI to prevent regressions.
Over time more checks could be enabled as they are fixed in code.

Some checks might require further configuration, this can be done over time.

Important: some checks are style/opinion based. Enabling all of them is not the point!

P.S. I have no idea what .travis.sh is used for. I've added something there too.