### PR TITLE
Backport cuda fixes to v3.7 branch

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -2167,7 +2167,7 @@ calculate_object_hash(struct args *args, struct args *preprocessor_args,
 		hash_delimiter(hash, "/dev/null dependency file");
 	}
 
-	if (!found_ccbin && str_eq(actual_language, "cuda")) {
+	if (!found_ccbin && str_eq(actual_language, "cu")) {
 		hash_nvcc_host_compiler(hash, NULL, NULL);
 	}
 

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -3436,7 +3436,7 @@ cc_process_args(struct args *args,
 		goto out;
 	}
 
-	if (!conf->run_second_cpp && str_eq(actual_language, "cuda")) {
+	if (!conf->run_second_cpp && str_eq(actual_language, "cu")) {
 		cc_log("Using CUDA compiler; not compiling preprocessed code");
 		conf->run_second_cpp = true;
 	}

--- a/src/language.c
+++ b/src/language.c
@@ -86,6 +86,7 @@ static const struct {
 	{"objc++-cpp-output",        "objective-c++-cpp-output"},
 	{"objective-c++-header",     "objective-c++-cpp-output"},
 	{"objective-c++-cpp-output", "objective-c++-cpp-output"},
+	{"cu"  ,                     "cuda-output"},
 	{"cuda",                     "cuda-output"},
 	{"assembler-with-cpp",       "assembler"},
 	{"assembler",                "assembler"},

--- a/src/language.c
+++ b/src/language.c
@@ -1,4 +1,6 @@
-// Copyright (C) 2010-2018 Joel Rosdahl
+// Copyright (C) 2010-2019 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
 //
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the Free
@@ -62,8 +64,7 @@ static const struct {
 	{".HXX", "c++-header"},
 	{".tcc", "c++-header"},
 	{".TCC", "c++-header"},
-	{".cu",  "cuda"},
-	{".ic",  "cuda-output"},
+	{".cu",  "cu"},
 	{NULL,  NULL}
 };
 
@@ -78,6 +79,7 @@ static const struct {
 	{"c++",                      "c++-cpp-output"},
 	{"c++-cpp-output",           "c++-cpp-output"},
 	{"c++-header",               "c++-cpp-output"},
+	{"cu",                       "cpp-output"},
 	{"objective-c",              "objective-c-cpp-output"},
 	{"objective-c-header",       "objective-c-cpp-output"},
 	{"objc-cpp-output",          "objective-c-cpp-output"},
@@ -86,8 +88,6 @@ static const struct {
 	{"objc++-cpp-output",        "objective-c++-cpp-output"},
 	{"objective-c++-header",     "objective-c++-cpp-output"},
 	{"objective-c++-cpp-output", "objective-c++-cpp-output"},
-	{"cu"  ,                     "cuda-output"},
-	{"cuda",                     "cuda-output"},
 	{"assembler-with-cpp",       "assembler"},
 	{"assembler",                "assembler"},
 	{NULL,  NULL}

--- a/test/suites/nvcc.bash
+++ b/test/suites/nvcc.bash
@@ -53,7 +53,7 @@ nvcc_tests() {
     # instead of comparing the binary object files, we compare the dumps of
     # "cuobjdump -all -elf -symbols -ptx -sass test1.o".
     nvcc_opts_cpp="-Wno-deprecated-gpu-targets -c --x c++"
-    nvcc_opts_cuda="-Wno-deprecated-gpu-targets -c"
+    nvcc_opts_cuda="-Wno-deprecated-gpu-targets -c -x cu"
     nvcc_opts_gpu1="--generate-code arch=compute_50,code=compute_50"
     nvcc_opts_gpu2="--generate-code arch=compute_52,code=sm_52"
     ccache_nvcc_cpp="$CCACHE $REAL_NVCC $nvcc_opts_cpp"
@@ -127,6 +127,26 @@ nvcc_tests() {
     expect_stat 'files in cache' 3
     $cuobjdump test_cuda.o > test1.dump
     expect_equal_files reference_test3.dump test1.dump
+    
+    # -------------------------------------------------------------------------
+    TEST "Option -dc"
+    
+    $REAL_NVCC $nvcc_opts_cuda -dc -o reference_test4.o test_cuda.cu
+    $cuobjdump reference_test4.o > reference_test4.dump
+
+    $ccache_nvcc_cuda -dc -o test_cuda.o test_cuda.cu
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+    $cuobjdump test_cuda.o > test4.dump
+    expect_equal_files test4.dump reference_test4.dump
+
+    $ccache_nvcc_cuda -dc -o test_cuda.o test_cuda.cu
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+    $cuobjdump test_cuda.o > test4.dump
+    expect_equal_files test4.dump reference_test4.dump
 
     # -------------------------------------------------------------------------
     TEST "Different defines"


### PR DESCRIPTION
Backport https://github.com/ccache/ccache/pull/381

I ran into various "Illegal instruction" issues on CI servers with libzstd on v4 branch. It would be advisable if ccache could compile libzstd such that it doesn't optimize for the cpu features present on the machine performing the compilation.
In the meantime, it's helpful to backport this fix to the 3.7 branch.