### PR TITLE
Ignore fmessage-length=... as a cache parameter

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2805,6 +2805,10 @@ process_args(Context& ctx,
       continue;
     }
 
+    if (str_startswith(argv[i], "-fmessage-length=")) {
+        continue;
+    }
+
     // Options taking an argument that we may want to rewrite to relative paths
     // to get better hit rate. A secondary effect is that paths in the standard
     // error output produced by the compiler will be normalized.


### PR DESCRIPTION
I've noticed that my build system (Xcode) will change this, e.g. in one invocation it's `-fmessage-length=20` and in another it's `-fmessage-length=70` for the same file. I'd like to have ccache ignore this flag, since it appears only to affect formatting of diagnostics.