### PR TITLE
Make ccache build on Solaris 11.4

### DIFF
--- a/m4/feature_macros.m4
+++ b/m4/feature_macros.m4
@@ -119,6 +119,8 @@ then
       AC_DEFINE(_XOPEN_SOURCE, 500,
                 Define to the level of X/Open that your system supports)
       ;;
+    SunOS/5.11)
+      ;;
     *)
       AC_DEFINE(_XOPEN_SOURCE, 700,
                 Define to the level of X/Open that your system supports)

--- a/src/ProgressBar.cpp
+++ b/src/ProgressBar.cpp
@@ -27,6 +27,10 @@
 #  include <sys/ioctl.h>
 #endif
 
+#ifdef __sun
+#  include <termios.h>
+#endif
+
 namespace {
 
 const size_t k_max_width = 120;


### PR DESCRIPTION
These changes enable building on Oracle Solaris 11.4 for both i386 and sparc.