### PR TITLE
Fix #559 (setting base_dir and cache_dir_levels)

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -305,9 +305,9 @@ conf_set_value_in_file(const char *path, const char *key, const char *value,
 		return false;
 	}
 
-	char dummy[8] = {0}; // The maximum entry size in struct conf.
-	if (!item->parser(value, (void *)dummy, errmsg)
-	    || (item->verifier && !item->verifier(value, errmsg))) {
+	char parsed[8] = {0}; // The maximum entry size in struct conf.
+	if (!item->parser(value, (void *)parsed, errmsg)
+	    || (item->verifier && !item->verifier(&parsed, errmsg))) {
 		return false;
 	}
 


### PR DESCRIPTION
Verified manually (on linux only):

    ./ccache --set-config=cache_dir_levels=5
    ./ccache --set-config=base_dir=/tmp
    ./ccache --set-config=max_size=5G
    ./ccache --show-config
    ./ccache --set-config=cache_dir_levels=3
    ./ccache --set-config=base_dir=/home/alex
    ./ccache --set-config=max_size=15G
    ./ccache --show-config


Before this patch it would fail with:
* cache_dir_levels was comparing pointer to <= 8 --> cache directory levels must be between 1 and 8
* base_dir was comparing jibberish with is_absolute_path --> not an absolute path

Those are the only two validations done on config input, therefore I verified with max_size that nothing else got broken here.

//edit: there is no automatic link created from title or commit messages, so here we go: #559 😄 