### PR TITLE
Fix path length issue on Windows 10, fix base_dir: hash issue fixed, …

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -811,7 +811,9 @@ make_relative_path(char *path)
 		path = double_backslash_to_backslash(path);
 	}
 	if(strchr(path, '/')) {
-		path = slash_to_backslash(path);
+		cc_log("path: %s", path);
+        path = slash_to_backslash(path);
+        cc_log("path: %s", path);
 	}
 #endif
 	if (str_eq(conf->base_dir, "") || !str_startswith(path, conf->base_dir)) {

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -806,6 +806,14 @@ print_included_files(FILE *fp)
 static char *
 make_relative_path(char *path)
 {
+#ifdef _WIN32
+	if(strchr(path, '\\')) {
+		path = double_backslash_to_backslash(path);
+	}
+	if(strchr(path, '/')) {
+		path = slash_to_backslash(path);
+	}
+#endif
 	if (str_eq(conf->base_dir, "") || !str_startswith(path, conf->base_dir)) {
 		return path;
 	}

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -811,9 +811,7 @@ make_relative_path(char *path)
 		path = double_backslash_to_backslash(path);
 	}
 	if(strchr(path, '/')) {
-		cc_log("path: %s", path);
         path = slash_to_backslash(path);
-        cc_log("path: %s", path);
 	}
 #endif
 	if (str_eq(conf->base_dir, "") || !str_startswith(path, conf->base_dir)) {

--- a/src/ccache.h
+++ b/src/ccache.h
@@ -160,6 +160,8 @@ const char *get_hostname(void);
 const char *tmp_string(void);
 char *format_hash_as_string(const unsigned char *hash, int size);
 int create_cachedirtag(const char *dir);
+char *slash_to_backslash(char* str);
+char *double_backslash_to_backslash(const char *path);
 char *format(const char *format, ...) ATTR_FORMAT(printf, 1, 2);
 void reformat(char **ptr, const char *format, ...) ATTR_FORMAT(printf, 2, 3);
 char *x_strdup(const char *s);

--- a/src/util.c
+++ b/src/util.c
@@ -706,7 +706,7 @@ slash_to_backslash(char* str)
 	}
 	temp[len] = 0;
 
-	return str;
+	return temp;
 }
 #endif
 
@@ -1462,7 +1462,7 @@ common_dir_prefix_length(const char *s1, const char *s2)
 		++p1;
 		++p2;
 	}
-	while ((*p1 && *p1 != '/' && *p1 != '\\') || (*p2 && *p2 != '/' && *p2 != '\\')) {
+	while ((*p1 && (*p1 != '/' || *p1 != '\\')) || (*p2 && (*p2 != '/' || *p2 != '\\'))) {
 		p1--;
 		p2--;
 	}
@@ -1519,7 +1519,7 @@ get_relative_path(const char *from, const char *to)
 	if (strlen(to) > common_prefix_len) {
 		reformat(&result, "%s%s", result, to + common_prefix_len + 1);
 	}
-	for (int i = strlen(result) - 1; i >= 0 && result[i] == '/' && result[i] == '\\'; i--) {
+	for (int i = strlen(result) - 1; i >= 0 && (result[i] == '/' || result[i] == '\\'); i--) {
 		result[i] = '\0';
 	}
 	if (str_eq(result, "")) {

--- a/src/util.c
+++ b/src/util.c
@@ -1452,12 +1452,20 @@ common_dir_prefix_length(const char *s1, const char *s2)
 {
 	const char *p1 = s1;
 	const char *p2 = s2;
+    char separator = NULL;
+
+    if(strchr(p1, '/') != NULL)
+    {
+        separator = '/';
+    } else {
+        separator = '\\';
+    }
 
 	while (*p1 && *p2 && *p1 == *p2) {
 		++p1;
 		++p2;
 	}
-	while ((*p1 && *p1 != '/') || (*p1 && *p1 != '\\') || (*p2 && *p2 != '/')  || (*p2 && *p2 != '\\')) {
+	while ((*p1 && *p1 != separator) || (*p2 && *p2 != separator)) {
 		p1--;
 		p2--;
 	}
@@ -1499,22 +1507,25 @@ get_relative_path(const char *from, const char *to)
 #endif
 
 	result = x_strdup("");
+    char separator = NULL;
 	common_prefix_len = common_dir_prefix_length(from, to);
 	if (common_prefix_len > 0 || !str_eq(from, "/")) {
 		const char *p;
 		for (p = from + common_prefix_len; *p; p++) {
 			if (*p == '/') {
 				reformat(&result, "../%s", result);
+                separator = '/';
 			}
 			if (*p == '\\') {
 				reformat(&result, "..\\%s", result);
+                separator = '\\';
 			}
 		}
 	}
 	if (strlen(to) > common_prefix_len) {
 		reformat(&result, "%s%s", result, to + common_prefix_len + 1);
 	}
-	for (int i = strlen(result) - 1; i >= 0 && (result[i] == '/' || result[i] == '\\'); i--) {
+	for (int i = strlen(result) - 1; i >= 0 && (result[i] == separator); i--) {
 		result[i] = '\0';
 	}
 	if (str_eq(result, "")) {

--- a/src/util.c
+++ b/src/util.c
@@ -696,17 +696,12 @@ error:
 char* 
 slash_to_backslash(char* str)
 {
-	char temp[256];
-	int len = (int)strlen(str);
-	int i;
-	if (len > 255) len = 255;
-	
-	for (i = 0; i < len; i++) {
-		temp[i] = str[i] == '/' ? '\\' : str[i];
-	}
-	temp[len] = 0;
-
-	return temp;
+    char *current_pos = strchr(str,"/");
+    while (current_pos){
+        *current_pos = "\\";
+        current_pos = strchr(current_pos,"/");
+    }
+    return str;
 }
 #endif
 

--- a/src/util.c
+++ b/src/util.c
@@ -1327,10 +1327,14 @@ create_tmp_fd(char **fname)
 		int maxlen=190;
 		int pathlen = strlen(format("%s.%s", *fname, tmp_string()));
 
-		if(pathlen > maxlen && atof(format("%ld.%ld", (DWORD)(LOBYTE(LOWORD(GetVersion()))), (DWORD)(HIBYTE(LOWORD(GetVersion()))))) > 6.1) {
+		if(pathlen > maxlen && atof(format("%ld.%ld", (DWORD)(LOBYTE(LOWORD(GetVersion()))), (DWORD)(HIBYTE(LOWORD(GetVersion()))))) > 6.0) {
 			char* temp = slash_to_backslash(format("%s.%s", *fname, tmp_string()));
 			char* currentdir = slash_to_backslash(current_working_dir);
-			template = format("\\\\?\\%s\\%s", currentdir, temp);
+			if(strstr(temp, currentdir)) {
+				template = format("\\\\?\\%s", temp);
+			} else {
+				template = format("\\\\?\\%s\\%s", currentdir, temp);
+			}
 		} else {
 			template = format("%s.%s", *fname, tmp_string());
 		}

--- a/src/util.c
+++ b/src/util.c
@@ -696,10 +696,10 @@ error:
 char* 
 slash_to_backslash(char* str)
 {
-    char *current_pos = strchr(str,"/");
+    char *current_pos = strchr(str,'/');
     while (current_pos){
-        *current_pos = "\\";
-        current_pos = strchr(current_pos,"/");
+        *current_pos = '\\';
+        current_pos = strchr(current_pos,'/');
     }
     return str;
 }
@@ -1457,7 +1457,7 @@ common_dir_prefix_length(const char *s1, const char *s2)
 		++p1;
 		++p2;
 	}
-	while ((*p1 && (*p1 != '/' || *p1 != '\\')) || (*p2 && (*p2 != '/' || *p2 != '\\'))) {
+	while ((*p1 && *p1 != '/') || (*p1 && *p1 != '\\') || (*p2 && *p2 != '/')  || (*p2 && *p2 != '\\')) {
 		p1--;
 		p2--;
 	}

--- a/src/util.c
+++ b/src/util.c
@@ -1452,7 +1452,7 @@ common_dir_prefix_length(const char *s1, const char *s2)
 {
 	const char *p1 = s1;
 	const char *p2 = s2;
-    char separator = NULL;
+    char separator = '\0';
 
     if(strchr(p1, '/') != NULL)
     {
@@ -1507,7 +1507,7 @@ get_relative_path(const char *from, const char *to)
 #endif
 
 	result = x_strdup("");
-    char separator = NULL;
+    char separator = '\0';
 	common_prefix_len = common_dir_prefix_length(from, to);
 	if (common_prefix_len > 0 || !str_eq(from, "/")) {
 		const char *p;

--- a/src/util.c
+++ b/src/util.c
@@ -1398,14 +1398,7 @@ common_dir_prefix_length(const char *s1, const char *s2)
 {
 	const char *p1 = s1;
 	const char *p2 = s2;
-    char separator = '\0';
-
-    if(strchr(p1, '/') != NULL)
-    {
-        separator = '/';
-    } else {
-        separator = '\\';
-    }
+    const char separator = strchr(p1, '/') ? '/' : '\\';
 
 	while (*p1 && *p2 && *p1 == *p2) {
 		++p1;


### PR DESCRIPTION
Fix for long path on Windows 10:
- Add \\\\?\\ prefix to bypass Windows length limitation (255 characters). Works only with **Windows 10**
-> Then, absolute path becomes: \\\\?\\<absolute_path_to_project>

Fix base_dir issues:
- If path contains double backslashes, replace by single backslashes
Example:
`c:\\project\\folder1/file1`
 -> 
`c:\\\\project\\\\folder1\\file1`

- Do not try to remove \\\\?\\, if it is not part of the path
- In function x_realpath, if path_handle is not INVALID_HANDLE_VALUE, it will remove the first 4 chars, which are supposed to be \\\\?\\, even if the string is not part of the path. 
- Make test first to ensure that the string exists, before removing the 4 first chars.

- Make sure that there path with only back or forward slashes
Example:
`c:**\\**project**\\**folder1**/**file1`
 -> 
`c:\\project\\folder1\\file1`

- Consider backslashes for conditions to remove the last / char from path: 
Consider also the Windows format of the path to remove the last \\

**Note: For Windows Only**