### PR TITLE
Disable hardlink testing on AFS

### DIFF
--- a/test/suites/hardlink.bash
+++ b/test/suites/hardlink.bash
@@ -1,6 +1,7 @@
 SUITE_hardlink_PROBE() {
-    touch file1
-    if ! ln file1 file2 >/dev/null 2>&1; then
+    mkdir dir;
+    touch dir/file1;
+    if ! ln dir/file1 file2 >/dev/null 2>&1; then
         echo "file system doesn't support hardlinks"
     fi
 }

--- a/test/suites/hardlink.bash
+++ b/test/suites/hardlink.bash
@@ -1,5 +1,5 @@
 SUITE_hardlink_PROBE() {
-    # AFS kind of supports hardlinks, but not really - you can't make hardlinks across directories, only within them.
+    # Probe hard link across directories since AFS doesn't support those.
     mkdir dir;
     touch dir/file1;
     if ! ln dir/file1 file2 >/dev/null 2>&1; then

--- a/test/suites/hardlink.bash
+++ b/test/suites/hardlink.bash
@@ -1,7 +1,7 @@
 SUITE_hardlink_PROBE() {
     # Probe hard link across directories since AFS doesn't support those.
-    mkdir dir;
-    touch dir/file1;
+    mkdir dir
+    touch dir/file1
     if ! ln dir/file1 file2 >/dev/null 2>&1; then
         echo "file system doesn't support hardlinks"
     fi

--- a/test/suites/hardlink.bash
+++ b/test/suites/hardlink.bash
@@ -1,4 +1,5 @@
 SUITE_hardlink_PROBE() {
+    # AFS kind of supports hardlinks, but not really - you can't make hardlinks across directories, only within them.
     mkdir dir;
     touch dir/file1;
     if ! ln dir/file1 file2 >/dev/null 2>&1; then


### PR DESCRIPTION
AFS _kind of_ supports hardlinks, but not really - you can't make hardlinks across directories, only within them. This basically defeats the point of the ccache hardlink mode - the only way to use it would be if your cache directory is the same as your compilation directory, which is silly. Unfortunately the current hardlink probe doesn't test this case and proceeds with the test suite anyway, which fails.