### PR TITLE
Extract formatting logic from make.

### DIFF
--- a/dev.mk.in
+++ b/dev.mk.in
@@ -109,7 +109,7 @@ dist_files = \
     $(built_dist_files)
 
 ifneq ($(shell sed 's/.*"\(.*\)".*/\1/' src/version.cpp 2>/dev/null),$(version))
-  $(shell echo 'extern const char CCACHE_VERSION[]; const char CCACHE_VERSION[] = "$(version)";' >src/version.cpp)
+  $(shell echo 'extern const char CCACHE_VERSION[];\nconst char CCACHE_VERSION[] = "$(version)";' >src/version.cpp)
 endif
 src/version.o: src/version.cpp
 
@@ -202,16 +202,14 @@ shellcheck: test/suites/*.bash
 
 .PHONY: format
 format:
-	@cd $(srcdir) && echo $(non_third_party_headers) $(non_third_party_sources) $(test_sources) | xargs -n1 -P8 \
-	    misc/run-clang-format
+	@cd $(srcdir) && misc/format.sh
 
 # Not using parallel execution because target is most likely being run on non-interactive CI system,
 # so no user is waiting for immediate results, and it avoids possibly interleaved output.
 .PHONY: check_format
 check_format:
 	@[ -t 1 ] && export cf_diff_color="--color=always"; \
-	cd $(srcdir) && echo $(non_third_party_headers) $(non_third_party_sources) $(test_sources) | xargs -n1 -P1 \
-	    misc/run-clang-format --check || \
+	cd $(srcdir) && misc/check_format.sh || \
 	        { echo; echo "Error: Sources are not formatted with clang-format."; \
 	          echo 'Run "make format" or apply the above diff.'; echo; exit 1; } 1>&2
 

--- a/misc/check_format.sh
+++ b/misc/check_format.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+
+# xarg returns 1 if any run-clang-format call returns 1.
+find src unittest -path src/third_party -prune -o -regex ".*\.[ch]p?p?" -print0 | xargs -0 -n1 misc/run-clang-format --check

--- a/misc/format.sh
+++ b/misc/format.sh
@@ -1,0 +1,2 @@
+#!/bin/sh -ex
+find src unittest -path src/third_party -prune -o -regex ".*\.[ch]p?p?" -exec misc/run-clang-format {} \;

--- a/misc/run-clang-format
+++ b/misc/run-clang-format
@@ -28,6 +28,11 @@ if [[ ! -e "$file" ]]; then
     exit 1
 fi
 
+if [[ -d "$file" ]]; then
+    echo "Please pass files and not directories: $file"
+    exit 1
+fi
+
 tmp_file="$file.$$.clang-format.tmp"
 trap "rm -f \"$tmp_file\"" EXIT
 


### PR DESCRIPTION
This way it is executable without running configure first.
Formatting is in no way dependent on running autogen/configure/cmake/make.

Which will in turn simplify CMake transition as CMake does not need to support that.

This commit preserves `make check_format` and `make format` targets.
In addition formatting is executable via `misc/check_format.sh` and `misc/format.sh`.