### PR TITLE
Generic function for parsing integers

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -3,9 +3,7 @@
 # (Without claiming that they are 100% correct. They can be modified on demand!)
 # If you want to improve the codebase try enabling some additional checks or
 # playing with the configuration values.
-#
-# Some checks are highly style dependent. The goal is NOT to activate all of
-# them.
+# Some checks are highly style dependent. Activating all of them is NOT the goal.
 
 ---
 Checks:          '-*,

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -342,23 +342,6 @@ format_umask(uint32_t umask)
   }
 }
 
-unsigned
-parse_unsigned(const std::string& value)
-{
-  size_t end;
-  long result;
-  bool failed = false;
-  try {
-    result = std::stol(value, &end, 10);
-  } catch (std::exception&) {
-    failed = true;
-  }
-  if (failed || end != value.size() || result < 0) {
-    throw Error(fmt::format("invalid unsigned integer: \"{}\"", value));
-  }
-  return result;
-}
-
 void
 verify_absolute_path(const std::string& value)
 {
@@ -693,7 +676,7 @@ Config::set_item(const std::string& key,
     break;
 
   case ConfigItem::cache_dir_levels:
-    m_cache_dir_levels = parse_unsigned(value);
+    m_cache_dir_levels = Util::stoi<uint32_t>(value, "cache directory levels");
     if (m_cache_dir_levels < 1 || m_cache_dir_levels > 8) {
       throw Error("cache directory levels must be between 1 and 8");
     }
@@ -712,11 +695,7 @@ Config::set_item(const std::string& key,
     break;
 
   case ConfigItem::compression_level: {
-    auto level = Util::parse_int(value);
-    if (level < -128 || level > 127) {
-      throw Error("compression level must be between -128 and 127");
-    }
-    m_compression_level = level;
+    m_compression_level = Util::stoi<int8_t>(value, "compression level");
     break;
   }
 
@@ -773,7 +752,7 @@ Config::set_item(const std::string& key,
     break;
 
   case ConfigItem::max_files:
-    m_max_files = parse_unsigned(value);
+    m_max_files = Util::stoi<uint32_t>(value);
     break;
 
   case ConfigItem::max_size:

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -512,23 +512,6 @@ normalize_absolute_path(string_view path)
 #endif
 }
 
-int
-parse_int(const std::string& value)
-{
-  size_t end;
-  long result;
-  bool failed = false;
-  try {
-    result = std::stoi(value, &end, 10);
-  } catch (std::exception&) {
-    failed = true;
-  }
-  if (failed || end != value.size()) {
-    throw Error(fmt::format("invalid integer: \"{}\"", value));
-  }
-  return result;
-}
-
 std::string
 read_file(const std::string& path)
 {

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2308,7 +2308,7 @@ handle_main_options(int argc, const char* const* argv)
     case 'F': { // --max-files
       Config::set_value_in_file(
         ctx.config.primary_config_path(), "max_files", optarg);
-      unsigned files = atoi(optarg);
+      const unsigned files = Util::stoi<unsigned>(optarg, "max files");
       if (files == 0) {
         printf("Unset cache file limit\n");
       } else {
@@ -2372,10 +2372,7 @@ handle_main_options(int argc, const char* const* argv)
       if (std::string(optarg) == "uncompressed") {
         level = 0;
       } else {
-        level = Util::parse_int(optarg);
-        if (level < -128 || level > 127) {
-          throw Error("compression level must be between -128 and 127");
-        }
+        level = Util::stoi<int8_t>(optarg, "compression level");
         if (level == 0) {
           level = ctx.config.compression_level();
         }

--- a/unittest/.clang-tidy
+++ b/unittest/.clang-tidy
@@ -1,3 +1,10 @@
+# This .clang-tidy file is used by CI to ensure that commits do not worsen the
+# codebase. The checks and values below are the minimum standard for new code.
+# (Without claiming that they are 100% correct. They can be modified on demand!)
+# If you want to improve the codebase try enabling some additional checks or
+# playing with the configuration values.
+# Some checks are highly style dependent. Activating all of them is NOT the goal.
+
 ---
 Checks:          '-*,readability-function-size'
 WarningsAsErrors: '*'
@@ -11,7 +18,7 @@ CheckOptions:
   # Note: some limits "disabled" due to TEST_SUITE macro.
   # The macro generates hundreds of statements, branches and variables.
   - key:             readability-function-size.LineThreshold
-    value:           130
+    value:           200
   - key:             readability-function-size.StatementThreshold
     value:           999999
   - key:             readability-function-size.ParameterThreshold

--- a/unittest/test_Config.cpp
+++ b/unittest/test_Config.cpp
@@ -235,19 +235,37 @@ TEST_CASE("Config::update_from_file, error handling")
   SECTION("invalid unsigned")
   {
     Util::write_file("ccache.conf", "max_files =");
-    REQUIRE_THROWS_WITH(
-      config.update_from_file("ccache.conf"),
-      Equals("ccache.conf:1: invalid unsigned integer: \"\""));
+    REQUIRE_THROWS_WITH(config.update_from_file("ccache.conf"),
+                        Equals("ccache.conf:1: invalid number: \"\""));
 
     Util::write_file("ccache.conf", "max_files = -42");
     REQUIRE_THROWS_WITH(
       config.update_from_file("ccache.conf"),
-      Equals("ccache.conf:1: invalid unsigned integer: \"-42\""));
+      Equals("ccache.conf:1: invalid number (negative value passed "
+             "where positive was expected): \"-42\""));
 
     Util::write_file("ccache.conf", "max_files = foo");
+    REQUIRE_THROWS_WITH(config.update_from_file("ccache.conf"),
+                        Equals("ccache.conf:1: invalid number: \"foo\""));
+  }
+
+  SECTION("invalid compression_level")
+  {
+    Util::write_file("ccache.conf", "compression_level =");
     REQUIRE_THROWS_WITH(
       config.update_from_file("ccache.conf"),
-      Equals("ccache.conf:1: invalid unsigned integer: \"foo\""));
+      Equals("ccache.conf:1: invalid compression level: \"\""));
+
+    Util::write_file("ccache.conf", "compression_level = -400");
+    REQUIRE_THROWS_WITH(
+      config.update_from_file("ccache.conf"),
+      Equals(
+        "ccache.conf:1: invalid compression level (out of range): \"-400\""));
+
+    Util::write_file("ccache.conf", "compression_level = foo");
+    REQUIRE_THROWS_WITH(
+      config.update_from_file("ccache.conf"),
+      Equals("ccache.conf:1: invalid compression level: \"foo\""));
   }
 
   SECTION("missing file")

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -440,38 +440,99 @@ TEST_CASE("Util::normalize_absolute_path")
 #endif
 }
 
-TEST_CASE("Util::parse_int")
+TEST_CASE("Util::stoi<int>")
 {
-  CHECK(Util::parse_int("0") == 0);
-  CHECK(Util::parse_int("2") == 2);
-  CHECK(Util::parse_int("-17") == -17);
-  CHECK(Util::parse_int("42") == 42);
-  CHECK(Util::parse_int("0666") == 666);
-  CHECK(Util::parse_int(" 777") == 777);
+  CHECK(Util::stoi<int>("0") == 0);
+  CHECK(Util::stoi<int>("2") == 2);
+  CHECK(Util::stoi<int>("-17") == -17);
+  CHECK(Util::stoi<int>("42") == 42);
+  CHECK(Util::stoi<int>("0666") == 666);
+  CHECK(Util::stoi<int>(" 777") == 777);
 
-  CHECK_THROWS_WITH(Util::parse_int(""), Equals("invalid integer: \"\""));
-  CHECK_THROWS_WITH(Util::parse_int("x"), Equals("invalid integer: \"x\""));
-  CHECK_THROWS_WITH(Util::parse_int("0x"), Equals("invalid integer: \"0x\""));
-  CHECK_THROWS_WITH(Util::parse_int("0x4"), Equals("invalid integer: \"0x4\""));
-  CHECK_THROWS_WITH(Util::parse_int("0 "), Equals("invalid integer: \"0 \""));
+  CHECK_THROWS_WITH(Util::stoi<int>(""), Equals("invalid number: \"\""));
+  CHECK_THROWS_WITH(Util::stoi<int>("x"), Equals("invalid number: \"x\""));
+  CHECK_THROWS_WITH(Util::stoi<int>("0x"),
+                    Equals("invalid number (no suffix allowed): \"0x\""));
+  CHECK_THROWS_WITH(Util::stoi<int>("0x4"),
+                    Equals("invalid number (no suffix allowed): \"0x4\""));
+  CHECK_THROWS_WITH(Util::stoi<int>("0 "),
+                    Equals("invalid number (no suffix allowed): \"0 \""));
 
   // check boundary values
   if (sizeof(int) == 2) {
-    CHECK(Util::parse_int("-32768") == -32768);
-    CHECK(Util::parse_int("32767") == 32767);
-    CHECK_THROWS_WITH(Util::parse_int("-32768"),
-                      Equals("invalid integer: \"-32768\""));
-    CHECK_THROWS_WITH(Util::parse_int("32768"),
-                      Equals("invalid integer: \"32768\""));
+    CHECK(Util::stoi<int>("-32768") == -32768);
+    CHECK(Util::stoi<int>("32767") == 32767);
+    CHECK_THROWS_WITH(Util::stoi<int>("-32768"),
+                      Equals("invalid number: \"-32768\""));
+    CHECK_THROWS_WITH(Util::stoi<int>("32768"),
+                      Equals("invalid number: \"32768\""));
   }
   if (sizeof(int) == 4) {
-    CHECK(Util::parse_int("-2147483648") == -2147483648);
-    CHECK(Util::parse_int("2147483647") == 2147483647);
-    CHECK_THROWS_WITH(Util::parse_int("-2147483649"),
-                      Equals("invalid integer: \"-2147483649\""));
-    CHECK_THROWS_WITH(Util::parse_int("2147483648"),
-                      Equals("invalid integer: \"2147483648\""));
+    CHECK(Util::stoi<int>("-2147483648") == -2147483648);
+    CHECK(Util::stoi<int>("2147483647") == 2147483647);
+    CHECK_THROWS_WITH(Util::stoi<int>("-2147483649"),
+                      Equals("invalid number: \"-2147483649\""));
+    CHECK_THROWS_WITH(Util::stoi<int>("2147483648"),
+                      Equals("invalid number: \"2147483648\""));
   }
+}
+
+TEST_CASE("Util::stoi<unsigned>")
+{
+  CHECK(Util::stoi<unsigned>("0") == 0);
+  CHECK(Util::stoi<unsigned>("2") == 2);
+  CHECK(Util::stoi<unsigned>("42") == 42);
+  CHECK(Util::stoi<unsigned>("0666") == 666);
+  CHECK(Util::stoi<unsigned>(" 777") == 777);
+
+  CHECK_THROWS_WITH(Util::stoi<unsigned>("-17"),
+                    Equals("invalid number (negative value passed "
+                           "where positive was expected): \"-17\""));
+
+  CHECK_THROWS_WITH(Util::stoi<unsigned>(""), Equals("invalid number: \"\""));
+  CHECK_THROWS_WITH(Util::stoi<unsigned>("x"), Equals("invalid number: \"x\""));
+  CHECK_THROWS_WITH(Util::stoi<unsigned>("0x"),
+                    Equals("invalid number (no suffix allowed): \"0x\""));
+  CHECK_THROWS_WITH(Util::stoi<unsigned>("0x4"),
+                    Equals("invalid number (no suffix allowed): \"0x4\""));
+  CHECK_THROWS_WITH(Util::stoi<unsigned>("0 "),
+                    Equals("invalid number (no suffix allowed): \"0 \""));
+
+  // check boundary values
+  if (sizeof(unsigned) == 2) {
+    CHECK(Util::stoi<unsigned>("65535") == 65535);
+    CHECK_THROWS_WITH(Util::stoi<unsigned>("65535"),
+                      Equals("invalid number: \"65536\""));
+  }
+  if (sizeof(unsigned) == 4) {
+    CHECK(Util::stoi<unsigned>("4294967295") == 4294967295);
+    CHECK_THROWS_WITH(Util::stoi<unsigned>("4294967296"),
+                      Equals("invalid number: \"4294967296\""));
+  }
+}
+
+TEST_CASE("Util::stoi<int8_t>")
+{
+  CHECK(Util::stoi<int8_t>("0") == 0);
+  CHECK(Util::stoi<int8_t>("2") == 2);
+  CHECK(Util::stoi<int8_t>("-17") == -17);
+  CHECK(Util::stoi<int8_t>("42") == 42);
+
+  CHECK_THROWS_WITH(Util::stoi<int8_t>(""), Equals("invalid number: \"\""));
+  CHECK_THROWS_WITH(Util::stoi<int8_t>("x"), Equals("invalid number: \"x\""));
+  CHECK_THROWS_WITH(Util::stoi<int8_t>("0x"),
+                    Equals("invalid number (no suffix allowed): \"0x\""));
+  CHECK_THROWS_WITH(Util::stoi<int8_t>("0x4"),
+                    Equals("invalid number (no suffix allowed): \"0x4\""));
+  CHECK_THROWS_WITH(Util::stoi<int8_t>("0 "),
+                    Equals("invalid number (no suffix allowed): \"0 \""));
+
+  CHECK(Util::stoi<int8_t>("-128") == -128);
+  CHECK(Util::stoi<int8_t>("127") == 127);
+  CHECK_THROWS_WITH(Util::stoi<int8_t>("-129"),
+                    Equals("invalid number (out of range): \"-129\""));
+  CHECK_THROWS_WITH(Util::stoi<int8_t>("128"),
+                    Equals("invalid number (out of range): \"128\""));
 }
 
 TEST_CASE("Util::read_file and Util::write_file")


### PR DESCRIPTION
There are lots of places where ccache is parsing integers and mostly they are parsed to a slightly wrong datatype and then cast implicitly or explicitly to the right one. This function will enable parsing the exact type needed and providing proper error messages for out of bounds etc.

One example application of parsing compression_level is included in this commit. The rest I would apply after this one has been accepted and merged.

I'm truly amazed at the number of lines required for this function. But there is no way to make it shorter. At least none I can figure out.
I was not able to find such a function off the shelf anywhere.

--
Off topic I've included a fix for casting between signed and unsigned bytes. Conversion relies on undefined behavior. One has to use memcpy for that. C++20 will provide [std::bit_cast](https://en.cppreference.com/w/cpp/numeric/bit_cast).