### PR TITLE
Add support for icpc

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2345,6 +2345,10 @@ process_args(Context& ctx,
     }
     if (str_startswith(argv[i], "-x")) {
       if (args_info.input_file.empty()) {
+        if (str_eq(&argv[i][2], "Host")) {
+            // Skip -xHost for Intel compiler support
+            continue;
+        }
         explicit_language = &argv[i][2];
       }
       continue;


### PR DESCRIPTION
-xHost should be ignored as a compiler language for icpc.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
