### PR TITLE
Don't depend on how echo interprets backslash escapes

### DIFF
--- a/dev.mk.in
+++ b/dev.mk.in
@@ -109,7 +109,8 @@ dist_files = \
     $(built_dist_files)
 
 ifneq ($(shell sed 's/.*"\(.*\)".*/\1/' src/version.cpp 2>/dev/null),$(version))
-  $(shell echo 'extern const char CCACHE_VERSION[];\nconst char CCACHE_VERSION[] = "$(version)";' >src/version.cpp)
+  $(shell echo 'extern const char CCACHE_VERSION[];' >src/version.cpp)
+  $(shell echo 'const char CCACHE_VERSION[] = "$(version)";' >>src/version.cpp)
 endif
 src/version.o: src/version.cpp
 


### PR DESCRIPTION
The escape sequence '\n' should be translated to a new line character
when printed to version.cpp. Default mode might be implementation
dependent, thus add the command line switch to make it portable. At
least in Fedora /usr/bin/echo defaults to -E.