### PR TITLE
Support clang options for compiling with sampled profiles

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -147,16 +147,20 @@ process_profiling_option(Context& ctx, const std::string& arg)
     ctx.args_info.profile_generate = true;
     new_profile_path = arg.substr(arg.find('=') + 1);
   } else if (arg == "-fprofile-use" || arg == "-fprofile-instr-use"
-             || arg == "-fbranch-probabilities" || arg == "-fauto-profile") {
+             || arg == "-fprofile-sample-use" || arg == "-fbranch-probabilities"
+             || arg == "-fauto-profile") {
     new_profile_use = true;
     if (ctx.args_info.profile_path.empty()) {
       new_profile_path = ".";
     }
   } else if (Util::starts_with(arg, "-fprofile-use=")
              || Util::starts_with(arg, "-fprofile-instr-use=")
+             || Util::starts_with(arg, "-fprofile-sample-use=")
              || Util::starts_with(arg, "-fauto-profile=")) {
     new_profile_use = true;
     new_profile_path = arg.substr(arg.find('=') + 1);
+  } else if (arg == "-fprofile-sample-accurate") {
+    return true;
   } else {
     cc_log("Unknown profiling option: %s", arg.c_str());
     return false;

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1558,9 +1558,9 @@ hash_profile_data_file(const Context& ctx, struct hash* hash)
     fmt::format("{}/{}.gcda", profile_path, base_name),
     // -fprofile-use[=dir]/-fbranch-probabilities (GCC >=9)
     fmt::format("{}/{}#{}.gcda", profile_path, hashified_cwd, base_name),
-    // -fprofile(-instr)-use=file (Clang), -fauto-profile=file (GCC >=5)
+    // -fprofile(-instr|-sample)-use=file (Clang), -fauto-profile=file (GCC >=5)
     profile_path,
-    // -fprofile(-instr)-use=dir (Clang)
+    // -fprofile(-instr|-sample)-use=dir (Clang)
     fmt::format("{}/default.profdata", profile_path),
     // -fauto-profile (GCC >=5)
     "fbdata.afdo", // -fprofile-dir is not used
@@ -1763,14 +1763,15 @@ calculate_result_name(Context& ctx,
   // For profile generation (-fprofile(-instr)-generate[=path])
   // - hash profile path
   //
-  // For profile usage (-fprofile(-instr)-use, -fbranch-probabilities):
+  // For profile usage (-fprofile(-instr|-sample)-use, -fbranch-probabilities):
   // - hash profile data
   //
   // -fbranch-probabilities and -fvpt usage is covered by
   // -fprofile-generate/-fprofile-use.
   //
   // The profile directory can be specified as an argument to
-  // -fprofile(-instr)-generate=, -fprofile(-instr)-use= or -fprofile-dir=.
+  // -fprofile(-instr)-generate=, -fprofile(-instr|-sample)-use= or
+  // -fprofile-dir=.
 
   if (ctx.args_info.profile_generate) {
     assert(!ctx.args_info.profile_path.empty());

--- a/test/suites/profiling_clang.bash
+++ b/test/suites/profiling_clang.bash
@@ -95,4 +95,37 @@ SUITE_profiling_clang() {
     $CCACHE_COMPILE -fprofile-instr-use=foo.profdata -c test.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache miss' 3
+
+    # -------------------------------------------------------------------------
+    TEST "-fprofile-sample-use"
+
+    echo 'main:1:1' > sample.prof
+
+    $CCACHE_COMPILE -fprofile-sample-use=sample.prof -c test.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache miss' 1
+
+    $CCACHE_COMPILE -fprofile-sample-use=sample.prof -fprofile-sample-accurate -c test.c
+    expect_stat 'cache hit (direct)' 0
+    expect_stat 'cache miss' 2
+
+    $CCACHE_COMPILE -fprofile-sample-use=sample.prof -c test.c
+    expect_stat 'cache hit (direct)' 1
+    expect_stat 'cache miss' 2
+
+    $CCACHE_COMPILE -fprofile-sample-use=sample.prof -fprofile-sample-accurate -c test.c
+    expect_stat 'cache hit (direct)' 2
+    expect_stat 'cache miss' 2
+
+    echo 'main:2:2' > sample.prof
+
+    $CCACHE_COMPILE -fprofile-sample-use=sample.prof -c test.c
+    expect_stat 'cache hit (direct)' 2
+    expect_stat 'cache miss' 3
+
+     echo 'main:1:1' > sample.prof
+
+    $CCACHE_COMPILE -fprofile-sample-use=sample.prof -c test.c
+    expect_stat 'cache hit (direct)' 3
+    expect_stat 'cache miss' 3
 }


### PR DESCRIPTION
Add support for -fprofile-sample-use and -fprofile-sample-accurate.