### PR TITLE
Reduce number of memory allocations in hashing

### DIFF
--- a/src/InodeCache.cpp
+++ b/src/InodeCache.cpp
@@ -206,10 +206,7 @@ InodeCache::hash_inode(const char* path, ContentType type, Digest& digest)
 #  endif
   key.st_size = stat.size();
 
-  struct hash* hash = hash_init();
-  hash_buffer(hash, &key, sizeof(Key));
-  digest = hash_result(hash);
-  hash_free(hash);
+  digest = hash_buffer_once(&key, sizeof(Key));
   return true;
 }
 

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -101,13 +101,24 @@ hash_buffer(struct hash* hash, const void* s, size_t len)
 }
 
 Digest
+hash_buffer_once(const void* s, size_t len)
+{
+  blake3_hasher hasher;
+  blake3_hasher_init(&hasher);
+  blake3_hasher_update(&hasher, s, len);
+
+  Digest digest;
+  blake3_hasher_finalize(&hasher, digest.bytes(), digest.size());
+  return digest;
+}
+
+Digest
 hash_result(struct hash* hash)
 {
-  // make a copy before altering state
-  struct hash* copy = hash_copy(hash);
+  // Note that blake3_hasher_finalize doesn't modify the hasher itself, thus it
+  // is possible to finalize again after more data has been added.
   Digest digest;
-  blake3_hasher_finalize(&copy->hasher, digest.bytes(), digest.size());
-  hash_free(copy);
+  blake3_hasher_finalize(&hash->hasher, digest.bytes(), digest.size());
   return digest;
 }
 

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -61,6 +61,11 @@ void hash_delimiter(struct hash* hash, const char* type);
 // input file.
 void hash_buffer(struct hash* hash, const void* s, size_t len);
 
+// Hash bytes in a buffer.
+//
+// Returns the digest.
+Digest hash_buffer_once(const void* s, size_t len);
+
 // Hash a NUL terminated string.
 //
 // If hash debugging is enabled, the string is written to the text input file

--- a/unittest/test_hash.cpp
+++ b/unittest/test_hash.cpp
@@ -93,3 +93,9 @@ TEST_CASE("hash_result digest bytes")
   CHECK(memcmp(d.bytes(), expected, sizeof(Digest::size())) == 0);
   hash_free(h);
 }
+
+TEST_CASE("hash_once")
+{
+  CHECK(hash_buffer_once("a", 1).to_string()
+        == "17762fddd969a453925d65717ac3eea21320b66b");
+}


### PR DESCRIPTION
Add hash_buffer_once method for hashing a given text immediately using a
stack allocated hasher. Also skip copying the hasher in hash_result as
blake3 is not modifying the hasher.