### PR TITLE
Run compilation and tests with multiple threads

### DIFF
--- a/ci/build
+++ b/ci/build
@@ -11,11 +11,15 @@ fi
 if [ -n "${SPECIAL:-}" ]; then
     exec "ci/$SPECIAL"
 else
+    [ -z ${JOBS+x} ] && JOBS=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
+    [ -z ${JOBS+x} ] && JOBS=2
+
     mkdir -p ${BUILDDIR:-build}
     cd ${BUILDDIR:-build}
-    ${CMAKE_PREFIX:-} cmake "${CCACHE_LOC:-..}" ${CMAKE_PARAMS:-}
+    ${CMAKE_PREFIX:-} cmake ${CMAKE_PARAMS:-} ${CCACHE_LOC:-..}
     # 4 jobs seem to be a reasonable default for Travis.
-    ${CMAKE_PREFIX:-} cmake --build . ${BUILDEXTRAFLAGS:-} -- -j4
+    ${CMAKE_PREFIX:-} cmake --build . ${BUILDEXTRAFLAGS:-} -- -j${JOBS}
     # Warning: Rare random failures when running with -j4.
-    [ "${RUN_TESTS:-1}" -ne "1" ] || ctest --output-on-failure -j1
+    [ "${RUN_TESTS:-1}" -ne "1" ] || ctest --output-on-failure -j${JOBS}
 fi
+exit 0


### PR DESCRIPTION
Tested with CTest parameter `--repeat-until-fail 50` locally, locally in docker and on [travis](https://travis-ci.com/github/AlexanderLanin/ccache/builds/172374665). No random problems encountered (Besides Travis killing the MacOS job after a 50 minute timeout).
While this is "only nice" for daily work, it's critical for testing multiple images with docker as the runtime is just too long otherwise.