### PR TITLE
Make ccache aware of -fdirectives-only as a preprocessor option

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -495,6 +495,15 @@ might be incorrect.
     change. The list separator is semicolon on Windows systems and colon on
     other systems.
 
+[[config_ignore_options]] *ignore_options* (*CCACHE_IGNOREOPTIONS*)::
+
+    This setting is a list of options that ccache will exlude from the hash.
+    This is useful in scenarios where some compiler options that don't affect
+    compilation results might affect the hash produced by ccache. If an option
+    in the list is suffixed with an asterisk (`*`), the option is matched as a
+    prefix. For example, `-fmessage-length=*` will match both
+    `-fmessage-length=20` and `-fmessage-length=70`.
+
 [[config_inode_cache]] *inode_cache* (*CCACHE_INODECACHE* or *CCACHE_NOINODECACHE*, see <<_boolean_values,Boolean values>> above)::
 
     If true, enables caching of source file hashes based on device, inode and

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -54,6 +54,7 @@ enum class ConfigItem {
   hard_link,
   hash_dir,
   ignore_headers_in_manifest,
+  ignore_options,
   inode_cache,
   keep_comments_cpp,
   limit_multiple,
@@ -92,6 +93,7 @@ const std::unordered_map<std::string, ConfigItem> k_config_key_table = {
   {"hard_link", ConfigItem::hard_link},
   {"hash_dir", ConfigItem::hash_dir},
   {"ignore_headers_in_manifest", ConfigItem::ignore_headers_in_manifest},
+  {"ignore_options", ConfigItem::ignore_options},
   {"inode_cache", ConfigItem::inode_cache},
   {"keep_comments_cpp", ConfigItem::keep_comments_cpp},
   {"limit_multiple", ConfigItem::limit_multiple},
@@ -132,6 +134,7 @@ const std::unordered_map<std::string, std::string> k_env_variable_table = {
   {"HARDLINK", "hard_link"},
   {"HASHDIR", "hash_dir"},
   {"IGNOREHEADERS", "ignore_headers_in_manifest"},
+  {"IGNOREOPTIONS", "ignore_options"},
   {"INODECACHE", "inode_cache"},
   {"LIMIT_MULTIPLE", "limit_multiple"},
   {"LOGFILE", "log_file"},
@@ -559,6 +562,9 @@ Config::get_string_value(const std::string& key) const
   case ConfigItem::ignore_headers_in_manifest:
     return m_ignore_headers_in_manifest;
 
+  case ConfigItem::ignore_options:
+    return m_ignore_options;
+
   case ConfigItem::inode_cache:
     return format_bool(m_inode_cache);
 
@@ -764,6 +770,10 @@ Config::set_item(const std::string& key,
 
   case ConfigItem::ignore_headers_in_manifest:
     m_ignore_headers_in_manifest = parse_env_string(value);
+    break;
+
+  case ConfigItem::ignore_options:
+    m_ignore_options = parse_env_string(value);
     break;
 
   case ConfigItem::inode_cache:

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -55,6 +55,7 @@ public:
   bool hard_link() const;
   bool hash_dir() const;
   const std::string& ignore_headers_in_manifest() const;
+  const std::string& ignore_options() const;
   bool inode_cache() const;
   bool keep_comments_cpp() const;
   double limit_multiple() const;
@@ -80,6 +81,7 @@ public:
   void set_depend_mode(bool value);
   void set_debug(bool value);
   void set_direct_mode(bool value);
+  void set_ignore_options(const std::string& value);
   void set_inode_cache(bool value);
   void set_limit_multiple(double value);
   void set_max_files(uint32_t value);
@@ -142,6 +144,7 @@ private:
   bool m_hard_link = false;
   bool m_hash_dir = true;
   std::string m_ignore_headers_in_manifest = "";
+  std::string m_ignore_options = "";
   bool m_inode_cache = false;
   bool m_keep_comments_cpp = false;
   double m_limit_multiple = 0.8;
@@ -274,6 +277,12 @@ inline const std::string&
 Config::ignore_headers_in_manifest() const
 {
   return m_ignore_headers_in_manifest;
+}
+
+inline const std::string&
+Config::ignore_options() const
+{
+  return m_ignore_options;
 }
 
 inline bool
@@ -421,6 +430,12 @@ inline void
 Config::set_direct_mode(bool value)
 {
   m_direct_mode = value;
+}
+
+inline void
+Config::set_ignore_options(const std::string& value)
+{
+  m_ignore_options = value;
 }
 
 inline void

--- a/src/Context.hpp
+++ b/src/Context.hpp
@@ -107,6 +107,10 @@ public:
   // Headers (or directories with headers) to ignore in manifest mode.
   std::vector<std::string> ignore_header_paths;
 
+  // Options to completely ignore on the command line. They will not be passed
+  // to either the preprocessor or the compiler.
+  std::vector<std::string> ignore_options;
+
 #ifdef INODE_CACHE_SUPPORTED
   // InodeCache that caches source file hashes when enabled.
   mutable InodeCache inode_cache;

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -222,6 +222,14 @@ process_arg(Context& ctx,
     return nullopt;
   }
 
+  for (const std::string& option : ctx.ignore_options) {
+    if (option == args[i] || (Util::ends_with(option, "*") &&
+          Util::starts_with(args[i], option.substr(0, option.length() - 1)))) {
+      cc_log("Skipping argument: %s", args[i].c_str());
+      return nullopt;
+    }
+  }
+
   // Special case for -E.
   if (args[i] == "-E") {
     return STATS_PREPROCESSING;

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1881,6 +1881,8 @@ set_up_context(Context& ctx, int argc, const char* const* argv)
   ctx.orig_args = Args::from_argv(argc, argv);
   ctx.ignore_header_paths = Util::split_into_strings(
     ctx.config.ignore_headers_in_manifest(), PATH_DELIM);
+  ctx.ignore_options = Util::split_into_strings(
+      ctx.config.ignore_options(), " ");
 }
 
 // Initialize ccache, must be called once before anything else is run.

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -93,6 +93,7 @@ static const struct compopt compopts[] = {
   {"-bind_at_load", AFFECTS_COMP},
   {"-bundle", AFFECTS_COMP},
   {"-ccbin", AFFECTS_CPP | TAKES_ARG}, // nvcc
+  {"-fdirectives-only", AFFECTS_CPP},
   {"-fno-working-directory", AFFECTS_CPP},
   {"-fplugin=libcc1plugin", TOO_HARD}, // interaction with GDB
   {"-frepo", TOO_HARD},

--- a/unittest/test_Config.cpp
+++ b/unittest/test_Config.cpp
@@ -56,6 +56,7 @@ TEST_CASE("Config: default values")
   CHECK(!config.hard_link());
   CHECK(config.hash_dir());
   CHECK(config.ignore_headers_in_manifest().empty());
+  CHECK(config.ignore_options().empty());
   CHECK_FALSE(config.keep_comments_cpp());
   CHECK(config.limit_multiple() == Approx(0.8));
   CHECK(config.log_file().empty());
@@ -119,6 +120,7 @@ TEST_CASE("Config::update_from_file")
     "hard_link = true\n"
     "hash_dir = false\n"
     "ignore_headers_in_manifest = a:b/c\n"
+    "ignore_options = -a=* -b\n"
     "keep_comments_cpp = true\n"
     "limit_multiple = 1.0\n"
     "log_file = $USER${USER} \n"
@@ -157,6 +159,7 @@ TEST_CASE("Config::update_from_file")
   CHECK(config.hard_link());
   CHECK_FALSE(config.hash_dir());
   CHECK(config.ignore_headers_in_manifest() == "a:b/c");
+  CHECK(config.ignore_options() == "-a=* -b");
   CHECK(config.keep_comments_cpp());
   CHECK(config.limit_multiple() == Approx(1.0));
   CHECK(config.log_file() == fmt::format("{0}{0}", user));
@@ -403,6 +406,7 @@ TEST_CASE("Config::visit_items")
     "hard_link = true\n"
     "hash_dir = false\n"
     "ignore_headers_in_manifest = ihim\n"
+    "ignore_options = -a=* -b\n"
     "inode_cache = false\n"
     "keep_comments_cpp = true\n"
     "limit_multiple = 0.0\n"
@@ -457,6 +461,7 @@ TEST_CASE("Config::visit_items")
     "(test.conf) hard_link = true",
     "(test.conf) hash_dir = false",
     "(test.conf) ignore_headers_in_manifest = ihim",
+    "(test.conf) ignore_options = -a=* -b",
     "(test.conf) inode_cache = false",
     "(test.conf) keep_comments_cpp = true",
     "(test.conf) limit_multiple = 0.0",

--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -27,6 +27,8 @@
 
 #include "third_party/catch.hpp"
 
+#include <iostream>
+
 using TestUtil::TestContext;
 
 namespace {
@@ -695,6 +697,30 @@ TEST_CASE("cuda_option_file")
   Util::write_file("foo.c", "");
   Util::write_file("foo.optf", "-c foo.c -g -Wall -o");
   Util::write_file("bar.optf", "out -DX");
+  CHECK(!process_args(ctx, act_cpp, act_extra, act_cc));
+  CHECK(exp_cpp == act_cpp);
+  CHECK(exp_extra == act_extra);
+  CHECK(exp_cc == act_cc);
+}
+
+TEST_CASE("ignore_options")
+{
+  TestContext test_context;
+
+  Context ctx;
+
+  ctx.orig_args = Args::from_string(
+    "cc -c foo.c -fmessage-length=20 -Wall -Werror -ignored-option -g");
+  ctx.ignore_options = Util::split_into_strings(
+      "-fmessage-length=* -ignored-option", " ");
+  Args exp_cpp = Args::from_string("cc -Wall -g");
+  Args exp_extra = Args::from_string(" -Werror");
+  Args exp_cc = Args::from_string("cc -Wall -g -Werror -c");
+  Args act_cpp;
+  Args act_extra;
+  Args act_cc;
+
+  Util::write_file("foo.c", "");
   CHECK(!process_args(ctx, act_cpp, act_extra, act_cc));
   CHECK(exp_cpp == act_cpp);
   CHECK(exp_extra == act_extra);

--- a/unittest/test_compopt.cpp
+++ b/unittest/test_compopt.cpp
@@ -133,3 +133,8 @@ TEST_CASE("dash_dash_analyze_too_hard")
 {
   CHECK(compopt_too_hard("--analyze"));
 }
+
+TEST_CASE("dash_fdirectives_only_affects_cpp")
+{
+  CHECK(compopt_affects_cpp("-fdirectives-only"));
+}


### PR DESCRIPTION
If the `-fdirectives-only` option is specified on the compler command line, ccache does not correctly flag it as a preprocessor-only option. This can cause problems if the flag were ever passed to a different tool (such as Icecream) that *also* doesn't know the option is preprocessor-only. In such cases, GCC will try to preprocess the same source twice after making changes to it that don't allow it to be preprocessed a second time, leading to a compiler failure.

I tested this change locally, and it solved my particular problem (see #617).

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
