### PR TITLE
Make ccache aware of -fdirectives-only as a preprocessor option

### DIFF
--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -93,6 +93,7 @@ static const struct compopt compopts[] = {
   {"-bind_at_load", AFFECTS_COMP},
   {"-bundle", AFFECTS_COMP},
   {"-ccbin", AFFECTS_CPP | TAKES_ARG}, // nvcc
+  {"-fdirectives-only", AFFECTS_CPP},
   {"-fno-working-directory", AFFECTS_CPP},
   {"-fplugin=libcc1plugin", TOO_HARD}, // interaction with GDB
   {"-frepo", TOO_HARD},

--- a/unittest/test_compopt.cpp
+++ b/unittest/test_compopt.cpp
@@ -133,3 +133,8 @@ TEST_CASE("dash_dash_analyze_too_hard")
 {
   CHECK(compopt_too_hard("--analyze"));
 }
+
+TEST_CASE("dash_fdirectives_only_affects_cpp")
+{
+  CHECK(compopt_affects_cpp("-fdirectives-only"));
+}


### PR DESCRIPTION
If the `-fdirectives-only` option is specified on the compler command line, ccache does not correctly flag it as a preprocessor-only option. This can cause problems if the flag were ever passed to a different tool (such as Icecream) that *also* doesn't know the option is preprocessor-only. In such cases, GCC will try to preprocess the same source twice after making changes to it that don't allow it to be preprocessed a second time, leading to a compiler failure.

I tested this change locally, and it solved my particular problem (see #617).

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
