### PR TITLE
Update for Windows compatibility, fix issues with base_dir -> create relative path during hash calculation

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -43,7 +43,9 @@
 #endif
 
 // clang-format off
+#ifndef _WIN32_WINNT
 #cmakedefine _WIN32_WINNT @_WIN32_WINNT@
+#endif
 // clang-format on
 
 #define SYSCONFDIR "@CMAKE_INSTALL_FULL_SYSCONFDIR@"

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -398,12 +398,18 @@ inline void
 Config::set_base_dir(const std::string& value)
 {
   m_base_dir = value;
+#ifdef _WIN32
+  std::replace(m_base_dir.begin(), m_base_dir.end(), '\\', '/');
+#endif
 }
 
 inline void
 Config::set_cache_dir(const std::string& value)
 {
   m_cache_dir = value;
+#ifdef _WIN32
+  std::replace(m_cache_dir.begin(), m_cache_dir.end(), '\\', '/');
+#endif
   if (!m_temporary_dir_configured_explicitly) {
     m_temporary_dir = default_temporary_dir(m_cache_dir);
   }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1100,7 +1100,15 @@ real_path(const std::string& path, bool return_empty_on_error)
     if (!ok) {
       return path;
     }
+#ifdef _WIN32
+    if(starts_with(buffer, "\\\\?\\")) {
+        resolved = buffer + 4; // Strip \\?\ from the file name.
+    } else {
+        resolved = buffer;
+    }
+#else
     resolved = buffer + 4; // Strip \\?\ from the file name.
+#endif
   } else {
     snprintf(buffer, buffer_size, "%s", c_path);
     resolved = buffer;

--- a/src/Win32Util.hpp
+++ b/src/Win32Util.hpp
@@ -18,6 +18,10 @@
 
 #pragma once
 
+#ifdef __MINGW32__
+#include <windows.h>
+#endif
+
 #include "system.hpp"
 
 #include <string>


### PR DESCRIPTION
Environment:
  - Windows 10
  - MinGW64

- Fix for Windows
  - fix the issues detected during build
  - Add windows.h when using MinGW
  - Convert the "\" to "/", then we avoid future issues
- Fix BaseDir function:
  - When base_dir option is set, get the relative path to calculate the file hash in cache. 
  
Only tested on Windows.