### PR TITLE
Util::unlink_tmp: Log with correct errno

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1393,6 +1393,7 @@ unlink_tmp(const std::string& path, UnlinkLog unlink_log)
 
   bool success =
     unlink(path.c_str()) == 0 || (errno == ENOENT || errno == ESTALE);
+  saved_errno = errno;
   if (success || unlink_log == UnlinkLog::log_failure) {
     log("Unlink {}", path);
     if (!success) {


### PR DESCRIPTION
Don't log "Unlink failed: Success" on failure.