### PR TITLE
Fix override usage

### DIFF
--- a/src/ResultDumper.hpp
+++ b/src/ResultDumper.hpp
@@ -28,13 +28,13 @@ class ResultDumper : public Result::Reader::Consumer
 public:
   ResultDumper(FILE* stream);
 
-  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_header(CacheEntryReader& cache_entry_reader) override;
   void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file) final;
-  void on_entry_data(const uint8_t* data, size_t size) final;
-  void on_entry_end() final;
+                              nonstd::optional<std::string> raw_file) override;
+  void on_entry_data(const uint8_t* data, size_t size) override;
+  void on_entry_end() override;
 
 private:
   FILE* m_stream;

--- a/src/ResultDumper.hpp
+++ b/src/ResultDumper.hpp
@@ -28,13 +28,13 @@ class ResultDumper : public Result::Reader::Consumer
 public:
   ResultDumper(FILE* stream);
 
-  virtual void on_header(CacheEntryReader& cache_entry_reader);
-  virtual void on_entry_start(uint32_t entry_number,
+  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file);
-  virtual void on_entry_data(const uint8_t* data, size_t size);
-  virtual void on_entry_end();
+                              nonstd::optional<std::string> raw_file) final;
+  void on_entry_data(const uint8_t* data, size_t size) final;
+  void on_entry_end() final;
 
 private:
   FILE* m_stream;

--- a/src/ResultExtractor.hpp
+++ b/src/ResultExtractor.hpp
@@ -31,13 +31,13 @@ class ResultExtractor : public Result::Reader::Consumer
 public:
   ResultExtractor(const std::string& directory);
 
-  virtual void on_header(CacheEntryReader& cache_entry_reader);
-  virtual void on_entry_start(uint32_t entry_number,
+  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file);
-  virtual void on_entry_data(const uint8_t* data, size_t size);
-  virtual void on_entry_end();
+                              nonstd::optional<std::string> raw_file) final;
+  void on_entry_data(const uint8_t* data, size_t size) final;
+  void on_entry_end() final;
 
 private:
   const std::string m_directory;

--- a/src/ResultExtractor.hpp
+++ b/src/ResultExtractor.hpp
@@ -31,13 +31,13 @@ class ResultExtractor : public Result::Reader::Consumer
 public:
   ResultExtractor(const std::string& directory);
 
-  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_header(CacheEntryReader& cache_entry_reader) override;
   void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file) final;
-  void on_entry_data(const uint8_t* data, size_t size) final;
-  void on_entry_end() final;
+                              nonstd::optional<std::string> raw_file) override;
+  void on_entry_data(const uint8_t* data, size_t size) override;
+  void on_entry_end() override;
 
 private:
   const std::string m_directory;

--- a/src/ResultRetriever.hpp
+++ b/src/ResultRetriever.hpp
@@ -31,13 +31,13 @@ class ResultRetriever : public Result::Reader::Consumer
 public:
   ResultRetriever(Context& ctx, bool rewrite_dependency_target);
 
-  virtual void on_header(CacheEntryReader& cache_entry_reader);
-  virtual void on_entry_start(uint32_t entry_number,
+  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file);
-  virtual void on_entry_data(const uint8_t* data, size_t size);
-  virtual void on_entry_end();
+                              nonstd::optional<std::string> raw_file) final;
+  void on_entry_data(const uint8_t* data, size_t size) final;
+  void on_entry_end() final;
 
 private:
   Context& m_ctx;

--- a/src/ResultRetriever.hpp
+++ b/src/ResultRetriever.hpp
@@ -31,13 +31,13 @@ class ResultRetriever : public Result::Reader::Consumer
 public:
   ResultRetriever(Context& ctx, bool rewrite_dependency_target);
 
-  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_header(CacheEntryReader& cache_entry_reader) override;
   void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file) final;
-  void on_entry_data(const uint8_t* data, size_t size) final;
-  void on_entry_end() final;
+                              nonstd::optional<std::string> raw_file) override;
+  void on_entry_data(const uint8_t* data, size_t size) override;
+  void on_entry_end() override;
 
 private:
   Context& m_ctx;

--- a/src/third_party/fmt/core.h
+++ b/src/third_party/fmt/core.h
@@ -99,7 +99,7 @@
 #endif
 
 #ifndef FMT_OVERRIDE
-#  if FMT_HAS_FEATURE(cxx_override) || \
+#  if FMT_HAS_FEATURE(cxx_override_control) || \
       (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
 #    define FMT_OVERRIDE override
 #  else


### PR DESCRIPTION
This change is required to make ccache compile with clangs trunk version. It seems they improved the "missing override" warning.

The change within fmt is reported as https://github.com/fmtlib/fmt/pull/1836
If we do not want to change fmt directly we could instead disable the warning via CMakeLists or upgrade to fmt trunk version.