### PR TITLE
Fix asm compiler detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4.3)
 
-project(ccache LANGUAGES ASM C CXX)
+project(ccache LANGUAGES C CXX ASM)
 set(CMAKE_PROJECT_DESCRIPTION "a fast C/C++ compiler cache")
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
I stumbled upon this due to a new setup.
Turns out CMake requires ASM to be the last parameter so it can try whether the C compiler can compile asm.
See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/1560/diffs


### How to reproduce ###
This might be not 100% accurate, it's from memory:
1. Install Ubuntu 18.04
2. `sudo apt update`
3. `sudo apt upgrade`
4. `sudo apt install clang-10`
5. `sudo ln -s /usr/local/bin/c++ /usr/bin/clang++-10`
6. `sudo ln -s /usr/local/bin/cc /usr/bin/clang-10`

And out of desperation:
7. `sudo apt install build-essential`

### Actual behavior ###
```
-- The ASM compiler identification is unknown
-- Found assembler: /usr/local/bin/cc
-- The C compiler identification is Clang 10.0.0
-- The CXX compiler identification is Clang 10.0.0
-- Warning: Did not find file Compiler/-ASM
-- Check for working C compiler: /usr/local/bin/cc
-- Check for working C compiler: /usr/local/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/bin/c++
-- Check for working CXX compiler: /usr/local/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
```


A little later blake3 fails since it doesn't expect to have no ASM compiler.
We could fix blake3 to use C code in case there is no ASM compiler.
But I guess we do want the ASM version since they specifically offer it.