### PR TITLE
Refactor: introduce splitKeyAndValue

### DIFF
--- a/src/Arg.cpp
+++ b/src/Arg.cpp
@@ -29,3 +29,26 @@ Arg::Arg(nonstd::string_view full) : m_full(full), m_split_char(0)
     m_value = nonstd::string_view(m_full).substr(sep_pos + 1);
   }
 }
+
+Arg::Arg(const Arg& other)
+  : m_full(other.m_full), m_split_char(other.m_split_char)
+{
+  if (other.has_been_split()) {
+    m_key = nonstd::string_view(m_full).substr(0, other.key().size());
+    m_value = nonstd::string_view(m_full).substr(other.key().size() + 1);
+  }
+  assert(*this == other);
+}
+
+Arg&
+Arg::operator=(const Arg& other)
+{
+  m_full = other.full();
+  m_split_char = other.m_split_char;
+  if (other.has_been_split()) {
+    m_key = nonstd::string_view(m_full).substr(0, other.key().size());
+    m_value = nonstd::string_view(m_full).substr(other.key().size() + 1);
+  }
+  assert(*this == other);
+  return *this;
+}

--- a/src/Arg.cpp
+++ b/src/Arg.cpp
@@ -18,6 +18,8 @@
 
 #include "Arg.hpp"
 
+#include "FormatNonstdStringView.hpp"
+
 static const std::string emptyString;
 
 Arg::Arg(nonstd::string_view full) : m_full(full), m_split_char(0)
@@ -28,6 +30,16 @@ Arg::Arg(nonstd::string_view full) : m_full(full), m_split_char(0)
     m_key = nonstd::string_view(m_full).substr(0, sep_pos);
     m_value = nonstd::string_view(m_full).substr(sep_pos + 1);
   }
+}
+
+Arg::Arg(const nonstd::string_view key,
+         const char split_char,
+         const nonstd::string_view value)
+  : m_full(fmt::format("{}{}{}", key, split_char, value)),
+    m_split_char(split_char)
+{
+  m_key = nonstd::string_view(m_full).substr(0, key.length());
+  m_value = nonstd::string_view(m_full).substr(key.length() + 1);
 }
 
 Arg::Arg(const Arg& other)

--- a/src/Arg.cpp
+++ b/src/Arg.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "Arg.hpp"
+
+static const std::string emptyString;
+
+Arg::Arg(nonstd::string_view full) : m_full(full), m_split_char(0)
+{
+  const size_t sep_pos = m_full.find('=');
+  if (sep_pos != nonstd::string_view::npos) {
+    m_split_char = '=';
+    m_key = nonstd::string_view(m_full).substr(0, sep_pos);
+    m_value = nonstd::string_view(m_full).substr(sep_pos + 1);
+  }
+}

--- a/src/Arg.cpp
+++ b/src/Arg.cpp
@@ -35,11 +35,15 @@ Arg::Arg(nonstd::string_view full) : m_full(full), m_split_char(0)
 Arg::Arg(const nonstd::string_view key,
          const char split_char,
          const nonstd::string_view value)
-  : m_full(fmt::format("{}{}{}", key, split_char, value)),
-    m_split_char(split_char)
+  : m_split_char(split_char)
 {
+  if (split_char)
+    m_full = fmt::format("{}{}{}", key, split_char, value);
+  else
+    m_full = fmt::format("{}{}", key, value);
   m_key = nonstd::string_view(m_full).substr(0, key.length());
-  m_value = nonstd::string_view(m_full).substr(key.length() + 1);
+  m_value =
+    nonstd::string_view(m_full).substr(key.length() + (split_char != 0));
 }
 
 Arg::Arg(const Arg& other)
@@ -47,7 +51,8 @@ Arg::Arg(const Arg& other)
 {
   if (other.has_been_split()) {
     m_key = nonstd::string_view(m_full).substr(0, other.key().size());
-    m_value = nonstd::string_view(m_full).substr(other.key().size() + 1);
+    m_value = nonstd::string_view(m_full).substr(other.key().size()
+                                                 + (m_split_char != 0));
   }
   assert(*this == other);
 }
@@ -59,7 +64,8 @@ Arg::operator=(const Arg& other)
   m_split_char = other.m_split_char;
   if (other.has_been_split()) {
     m_key = nonstd::string_view(m_full).substr(0, other.key().size());
-    m_value = nonstd::string_view(m_full).substr(other.key().size() + 1);
+    m_value = nonstd::string_view(m_full).substr(other.key().size()
+                                                 + (m_split_char != 0));
   }
   assert(*this == other);
   return *this;

--- a/src/Arg.hpp
+++ b/src/Arg.hpp
@@ -1,0 +1,96 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#pragma once
+
+#include "third_party/nonstd/string_view.hpp"
+
+class Arg
+{
+public:
+  // Splits strings like "key=value" into key and value.
+  Arg(nonstd::string_view full);
+
+  // Enable passing arg as if it were a simple string.
+  operator const nonstd::string_view() const;
+  operator const std::string&() const;
+
+  // When compared to a string literal behave as if arg were a simple string.
+  bool operator==(const char* str) const;
+
+  const std::string& full() const;
+  nonstd::string_view key() const;
+  nonstd::string_view value() const;
+
+  bool has_been_split() const;
+
+private:
+  // These point into m_full.
+  nonstd::string_view m_key, m_value;
+  std::string m_full;
+
+  // Will support ' ' in the future like "-key value".
+  char m_split_char;
+};
+
+inline Arg::operator const nonstd::string_view() const
+{
+  return full();
+}
+
+inline Arg::operator const std::string&() const
+{
+  return full();
+}
+
+inline bool
+Arg::operator==(const char* str) const
+{
+  return full() == str;
+}
+
+inline const std::string&
+Arg::full() const
+{
+  return m_full;
+}
+
+inline nonstd::string_view
+Arg::key() const
+{
+  return m_key;
+}
+
+inline nonstd::string_view
+Arg::value() const
+{
+  return m_value;
+}
+
+inline bool
+Arg::has_been_split() const
+{
+  return m_split_char != 0;
+}
+
+inline bool
+operator==(const Arg& lhs, const Arg& rhs)
+{
+  return lhs.full() == rhs.full() && lhs.key() == rhs.key()
+         && lhs.value() == rhs.value();
+}

--- a/src/Arg.hpp
+++ b/src/Arg.hpp
@@ -28,6 +28,9 @@ class Arg
 public:
   // Splits strings like "key=value" into key and value.
   Arg(nonstd::string_view full);
+  Arg(nonstd::string_view key,
+      const char split_char,
+      nonstd::string_view value);
 
   Arg(const Arg&);
   Arg& operator=(const Arg&);

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -247,3 +247,41 @@ Args::replace(size_t index, const Args& args)
     insert(index, args);
   }
 }
+
+template<typename T>
+static bool
+contains(const std::vector<T>& vec, const T& element)
+{
+  return std::find(std::begin(vec), std::end(vec), element) != std::end(vec);
+}
+
+size_t
+Args::add_param(std::string param, std::vector<char> allowed_split_chars)
+{
+  size_t found = 0;
+
+  if (contains(allowed_split_chars, ' ')) {
+    for (size_t i = 0; i < m_args.size(); ++i) {
+      if (m_args[i].full() == param) {
+        if (i + 1 >= m_args.size()) {
+          return -1; // FIXME throw Failure?! Which one?
+        }
+        m_args[i] = Arg(param, ' ', m_args[i + 1]);
+        m_args.erase(std::begin(m_args) + i + 1);
+        ++found;
+      }
+    }
+  }
+
+  if (contains(allowed_split_chars, (char)0)) {
+    for (Arg& arg : m_args) {
+      if (arg.has_been_split() == false
+          && Util::starts_with(arg.full(), param)) {
+        arg = Arg(param, (char)0, arg.full().substr(param.length()));
+        ++found;
+      }
+    }
+  }
+
+  return found;
+}

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -32,7 +32,9 @@ Args
 Args::from_argv(int argc, const char* const* argv)
 {
   Args args;
-  args.m_args.assign(argv, argv + argc);
+  for (int i = 0; i < argc; ++i) {
+    args.push_back(Arg(argv[i]));
+  }
   return args;
 }
 
@@ -136,7 +138,7 @@ Args::to_argv() const
   std::vector<const char*> result;
   result.reserve(m_args.size() + 1);
   for (const auto& arg : m_args) {
-    result.push_back(arg.c_str());
+    result.push_back(arg.full().c_str());
   }
   result.push_back(nullptr);
   return result;
@@ -188,7 +190,7 @@ Args::pop_front(size_t count)
 }
 
 void
-Args::push_back(const std::string& arg)
+Args::push_back(const string_view arg)
 {
   m_args.push_back(arg);
 }
@@ -200,7 +202,7 @@ Args::push_back(const Args& args)
 }
 
 void
-Args::push_front(const std::string& arg)
+Args::push_front(const string_view arg)
 {
   m_args.push_front(arg);
 }

--- a/src/Args.hpp
+++ b/src/Args.hpp
@@ -65,6 +65,14 @@ public:
   // in arguments is performed.
   std::string to_string() const;
 
+  // Reparse arguments and detects such `param` as indicated by
+  // `allowed_split_chars`. In case of ' ' it would detect a standalone
+  // `param` which is followed by a value. Special value in
+  // `allowed_split_chars` is 0 which will then detect "paramvalue". Returns how
+  // many such keys have been found.
+  // TBD: is allowed_split_chars really any char or is it an enum?
+  size_t add_param(std::string param, std::vector<char> allowed_split_chars);
+
   // Remove all arguments with prefix `prefix`.
   void erase_with_prefix(nonstd::string_view prefix);
 

--- a/src/Args.hpp
+++ b/src/Args.hpp
@@ -29,12 +29,20 @@
 class Args
 {
 public:
+  struct ParamAndSplitChars
+  {
+    std::string param;
+    std::vector<char> allowed_split_chars;
+  };
+
   Args() = default;
   Args(const Args& other) = default;
   Args(Args&& other) noexcept;
 
   static Args from_argv(int argc, const char* const* argv);
-  static Args from_string(const std::string& command);
+  static Args from_string(
+    const std::string& command,
+    const std::vector<ParamAndSplitChars>& params_and_split_chars = {});
   static nonstd::optional<Args> from_gcc_atfile(const std::string& filename);
 
   Args& operator=(const Args& other) = default;
@@ -72,11 +80,14 @@ public:
   // Add `arg` to the end.
   void push_back(const nonstd::string_view arg);
 
+  // Add `arg` to the end.
+  void push_back(const Arg& arg);
+
   // Add `args` to the end.
   void push_back(const Args& args);
 
   // Add `arg` to the front.
-  void push_front(const nonstd::string_view arg);
+  void push_front(const Arg& arg);
 
   // Replace the argument at `index` with all arguments in `args`.
   void replace(size_t index, const Args& args);

--- a/src/Args.hpp
+++ b/src/Args.hpp
@@ -18,10 +18,7 @@
 
 #pragma once
 
-#include "system.hpp"
-
-#include "NonCopyable.hpp"
-#include "Util.hpp"
+#include "Arg.hpp"
 
 #include "third_party/nonstd/optional.hpp"
 #include "third_party/nonstd/string_view.hpp"
@@ -48,8 +45,8 @@ public:
 
   bool empty() const;
   size_t size() const;
-  const std::string& operator[](size_t i) const;
-  std::string& operator[](size_t i);
+  const Arg& operator[](size_t i) const;
+  Arg& operator[](size_t i);
 
   // Return the argument list as a vector of raw string pointers. Callers can
   // use `const_cast<char* const*>(args.to_argv().data())` to get an array
@@ -73,19 +70,19 @@ public:
   void pop_front(size_t count = 1);
 
   // Add `arg` to the end.
-  void push_back(const std::string& arg);
+  void push_back(const nonstd::string_view arg);
 
   // Add `args` to the end.
   void push_back(const Args& args);
 
   // Add `arg` to the front.
-  void push_front(const std::string& arg);
+  void push_front(const nonstd::string_view arg);
 
   // Replace the argument at `index` with all arguments in `args`.
   void replace(size_t index, const Args& args);
 
 private:
-  std::deque<std::string> m_args;
+  std::deque<Arg> m_args;
 };
 
 inline bool
@@ -113,7 +110,7 @@ Args::size() const
 }
 
 // clang-format off
-inline const std::string&
+inline const Arg&
 Args::operator[](size_t i) const
 // clang-format on
 {
@@ -121,7 +118,7 @@ Args::operator[](size_t i) const
 }
 
 // clang-format off
-inline std::string&
+inline Arg&
 Args::operator[](size_t i)
 // clang-format on
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(
   source_files
+  Arg.cpp
   Args.cpp
   AtomicFile.cpp
   CacheEntryReader.cpp

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1320,7 +1320,7 @@ strip_ansi_csi_seqs(string_view string)
 }
 
 std::string
-strip_whitespace(const std::string& string)
+strip_whitespace(nonstd::string_view string)
 {
   auto is_space = [](int ch) { return std::isspace(ch); };
   auto start = std::find_if_not(string.begin(), string.end(), is_space);

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -421,7 +421,7 @@ starts_with(nonstd::string_view string, nonstd::string_view prefix)
 [[nodiscard]] std::string strip_ansi_csi_seqs(nonstd::string_view string);
 
 // Strip whitespace from left and right side of a string.
-[[nodiscard]] std::string strip_whitespace(const std::string& string);
+[[nodiscard]] std::string strip_whitespace(nonstd::string_view string);
 
 // Convert a string to lowercase.
 [[nodiscard]] std::string to_lowercase(nonstd::string_view string);

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -243,7 +243,7 @@ process_arg(Context& ctx,
 
   // Handle "@file" argument.
   if (Util::starts_with(args[i], "@") || Util::starts_with(args[i], "-@")) {
-    const char* argpath = args[i].c_str() + 1;
+    const char* argpath = args[i].full().c_str() + 1;
 
     if (argpath[-1] == '-') {
       ++argpath;
@@ -390,8 +390,8 @@ process_arg(Context& ctx,
     return nullopt;
   }
 
-  if (args[i].length() >= 3 && Util::starts_with(args[i], "-x")
-      && !islower(args[i][2])) {
+  if (args[i].full().length() >= 3 && Util::starts_with(args[i], "-x")
+      && !islower(args[i].full()[2])) {
     // -xCODE (where CODE can be e.g. Host or CORE-AVX2, always starting with an
     // uppercase letter) is an ordinary Intel compiler option, not a language
     // specification. (GCC's "-x" language argument is always lowercase.)
@@ -414,7 +414,7 @@ process_arg(Context& ctx,
   }
   if (Util::starts_with(args[i], "-x")) {
     if (args_info.input_file.empty()) {
-      state.explicit_language = args[i].substr(2);
+      state.explicit_language = args[i].full().substr(2);
     }
     return nullopt;
   }
@@ -774,10 +774,10 @@ process_arg(Context& ctx,
 
   // Same as above but options with concatenated argument beginning with a
   // slash.
-  if (args[i][0] == '-') {
-    size_t slash_pos = args[i].find('/');
+  if (args[i].full()[0] == '-') {
+    size_t slash_pos = args[i].full().find('/');
     if (slash_pos != std::string::npos) {
-      std::string option = args[i].substr(0, slash_pos);
+      std::string option = args[i].full().substr(0, slash_pos);
       if (compopt_takes_concat_arg(option) && compopt_takes_path(option)) {
         auto relpath =
           Util::make_relative_path(ctx, string_view(args[i]).substr(slash_pos));
@@ -812,7 +812,7 @@ process_arg(Context& ctx,
   }
 
   // Other options.
-  if (args[i][0] == '-') {
+  if (args[i].full()[0] == '-') {
     if (compopt_affects_cpp(args[i]) || compopt_prefix_affects_cpp(args[i])) {
       state.cpp_args.push_back(args[i]);
     } else {
@@ -841,7 +841,7 @@ process_arg(Context& ctx,
       return Statistic::multiple_source_files;
     } else if (!state.found_c_opt && !state.found_dc_opt) {
       log("Called for link with {}", args[i]);
-      if (args[i].find("conftest.") != std::string::npos) {
+      if (args[i].full().find("conftest.") != std::string::npos) {
         return Statistic::autoconf_test;
       } else {
         return Statistic::called_for_link;

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -441,14 +441,14 @@ process_arg(Context& ctx,
   const auto arg = Arg(args[i]);
   if (arg.key() == "-fdebug-prefix-map" || arg.key() == "-ffile-prefix-map") {
     args_info.debug_prefix_maps.emplace_back(arg.value());
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     return nullopt;
   }
 
   // Debugging is handled specially, so that we know if we can strip line
   // number info.
   if (Util::starts_with(arg.full(), "-g")) {
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
 
     if (Util::starts_with(arg.full(), "-gdwarf")) {
       // Selection of DWARF format (-gdwarf or -gdwarf-<version>) enables
@@ -484,7 +484,7 @@ process_arg(Context& ctx,
   if (arg == "-MD" || arg == "-MMD") {
     args_info.generating_dependencies = true;
     args_info.seen_MD_MMD = true;
-    state.dep_args.push_back(arg.full());
+    state.dep_args.push_back(arg);
     return nullopt;
   }
 
@@ -526,7 +526,7 @@ process_arg(Context& ctx,
         log("Missing argument to {}", arg.full());
         return Statistic::bad_compiler_arguments;
       }
-      state.dep_args.push_back(arg.full());
+      state.dep_args.push_back(arg);
       std::string relpath = Util::make_relative_path(ctx, args[i + 1]);
       state.dep_args.push_back(relpath);
       i++;
@@ -541,19 +541,19 @@ process_arg(Context& ctx,
 
   if (arg == "-fprofile-arcs") {
     args_info.profile_arcs = true;
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     return nullopt;
   }
 
   if (arg == "-ftest-coverage") {
     args_info.generating_coverage = true;
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     return nullopt;
   }
 
   if (arg == "-fstack-usage") {
     args_info.generating_stackusage = true;
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     return nullopt;
   }
 
@@ -561,7 +561,7 @@ process_arg(Context& ctx,
       || arg == "-coverage") { // Undocumented but still works.
     args_info.profile_arcs = true;
     args_info.generating_coverage = true;
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     return nullopt;
   }
 
@@ -572,13 +572,13 @@ process_arg(Context& ctx,
       // The failure is logged by process_profiling_option.
       return Statistic::unsupported_compiler_option;
     }
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     return nullopt;
   }
 
   if (arg.key() == "-fsanitize-blacklist") {
     args_info.sanitize_blacklists.emplace_back(arg.value());
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     return nullopt;
   }
 
@@ -595,7 +595,7 @@ process_arg(Context& ctx,
       log("Missing argument to {}", arg.full());
       return Statistic::bad_compiler_arguments;
     }
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     auto relpath = Util::make_relative_path(ctx, args[i + 1]);
     state.common_args.push_back(relpath);
     i++;
@@ -608,7 +608,7 @@ process_arg(Context& ctx,
       log("Missing argument to {}", arg.full());
       return Statistic::bad_compiler_arguments;
     }
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     state.common_args.push_back(args[i + 1]);
     i++;
     return nullopt;
@@ -628,7 +628,7 @@ process_arg(Context& ctx,
       state.dependency_filename_specified = true;
       args_info.output_dep =
         Util::make_relative_path(ctx, string_view(arg.full()).substr(8));
-      state.dep_args.push_back(arg.full());
+      state.dep_args.push_back(arg);
       return nullopt;
     } else if (Util::starts_with(arg.full(), "-Wp,-MMD,")
                && arg.full().find(',', 9) == std::string::npos) {
@@ -636,7 +636,7 @@ process_arg(Context& ctx,
       state.dependency_filename_specified = true;
       args_info.output_dep =
         Util::make_relative_path(ctx, string_view(arg.full()).substr(9));
-      state.dep_args.push_back(arg.full());
+      state.dep_args.push_back(arg);
       return nullopt;
     } else if (Util::starts_with(arg.full(), "-Wp,-D")
                && arg.full().find(',', 6) == std::string::npos) {
@@ -651,7 +651,7 @@ process_arg(Context& ctx,
                        || arg.full()[6] == 'T')
                    && arg.full().find(',', 8) == std::string::npos)) {
       // TODO: Make argument to MF/MQ/MT relative.
-      state.dep_args.push_back(arg.full());
+      state.dep_args.push_back(arg);
       return nullopt;
     } else if (config.direct_mode()) {
       // -Wp, can be used to pass too hard options to the preprocessor.
@@ -661,12 +661,12 @@ process_arg(Context& ctx,
     }
 
     // Any other -Wp,* arguments are only relevant for the preprocessor.
-    state.cpp_args.push_back(arg.full());
+    state.cpp_args.push_back(arg);
     return nullopt;
   }
 
   if (arg == "-MP") {
-    state.dep_args.push_back(arg.full());
+    state.dep_args.push_back(arg);
     return nullopt;
   }
 
@@ -716,13 +716,13 @@ process_arg(Context& ctx,
 
   if (arg == "-fno-pch-timestamp") {
     args_info.fno_pch_timestamp = true;
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     return nullopt;
   }
 
   if (arg == "-fpch-preprocess") {
     state.found_fpch_preprocess = true;
-    state.common_args.push_back(arg.full());
+    state.common_args.push_back(arg);
     return nullopt;
   }
 

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1713,7 +1713,7 @@ find_compiler(Context& ctx, const char* const* argv)
     base = ctx.config.compiler();
   }
 
-  std::string compiler = find_executable(ctx, base, CCACHE_NAME);
+  const std::string compiler = find_executable(ctx, base, CCACHE_NAME);
   if (compiler.empty()) {
     throw Fatal("Could not find compiler \"{}\" in PATH", base);
   }
@@ -1722,7 +1722,7 @@ find_compiler(Context& ctx, const char* const* argv)
       "Recursive invocation (the name of the ccache binary must be \"{}\")",
       CCACHE_NAME);
   }
-  ctx.orig_args[0] = compiler;
+  ctx.orig_args[0] = Arg(compiler);
 }
 
 static void

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -162,9 +162,9 @@ add_prefix(const Context& ctx, Args& args, const std::string& prefix_command)
     return;
   }
 
-  Args prefix;
+  std::vector<std::string> prefix;
   for (const auto& word : Util::split_into_strings(prefix_command, " ")) {
-    std::string path = find_executable(ctx, word, CCACHE_NAME);
+    const std::string path = find_executable(ctx, word, CCACHE_NAME);
     if (path.empty()) {
       throw Fatal("{}: {}", word, strerror(errno));
     }
@@ -173,8 +173,8 @@ add_prefix(const Context& ctx, Args& args, const std::string& prefix_command)
   }
 
   log("Using command-line prefix {}", prefix_command);
-  for (size_t i = prefix.size(); i != 0; i--) {
-    args.push_front(prefix[i - 1]);
+  for (auto iter = prefix.rbegin(); iter != prefix.rend(); iter++) {
+    args.push_front(Arg(*iter));
   }
 }
 

--- a/src/hashutil.cpp
+++ b/src/hashutil.cpp
@@ -393,7 +393,7 @@ hash_command_output(Hash& hash,
 
   for (size_t i = 0; i < args.size(); i++) {
     if (args[i] == "%compiler%") {
-      args[i] = compiler;
+      args[i] = Arg(compiler);
     }
   }
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -2,6 +2,7 @@ set(
   source_files
   TestUtil.cpp
   main.cpp
+  test_Arg.cpp
   test_Args.cpp
   test_AtomicFile.cpp
   test_Checksum.cpp

--- a/unittest/test_Arg.cpp
+++ b/unittest/test_Arg.cpp
@@ -48,7 +48,7 @@ operator==(const Arg& lhs, const NotSplit& rhs)
          && lhs.full() == rhs.full;
 }
 
-TEST_CASE("Arg")
+TEST_CASE("Constructor")
 {
   CHECK(Arg("") == NotSplit{""});
   CHECK(Arg("=") == Split{"", ""});

--- a/unittest/test_Arg.cpp
+++ b/unittest/test_Arg.cpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "../src/Arg.hpp"
+
+#include "third_party/doctest.h"
+#include "third_party/fmt/core.h"
+
+TEST_SUITE_BEGIN("Arg");
+
+struct Split
+{
+  nonstd::string_view key, value;
+};
+static bool
+operator==(const Arg& lhs, const Split& rhs)
+{
+  return lhs.has_been_split() == true && lhs.key() == rhs.key
+         && lhs.value() == rhs.value
+         && lhs.full()
+              == fmt::format(
+                "{}={}", std::string(rhs.key), std::string(rhs.value));
+}
+
+struct NotSplit
+{
+  nonstd::string_view full;
+};
+static bool
+operator==(const Arg& lhs, const NotSplit& rhs)
+{
+  return lhs.has_been_split() == false && lhs.key() == "" && lhs.value() == ""
+         && lhs.full() == rhs.full;
+}
+
+TEST_CASE("Arg")
+{
+  CHECK(Arg("") == NotSplit{""});
+  CHECK(Arg("=") == Split{"", ""});
+  CHECK(Arg("x") == NotSplit{"x"});
+  CHECK(Arg("xy") == NotSplit{"xy"});
+  CHECK(Arg("xy=") == Split{"xy", ""});
+  CHECK(Arg("=xy") == Split{"", "xy"});
+  CHECK(Arg("x=y") == Split{"x", "y"});
+  CHECK(Arg(" x  =   y    ") == Split{" x  ", "   y    "});
+  CHECK(Arg("a very very long string=another very very long string")
+        == Split{"a very very long string", "another very very long string"});
+
+  CHECK(!Arg("").has_been_split());
+  CHECK(Arg("=").has_been_split());
+  CHECK(Arg("x=").has_been_split());
+  CHECK(Arg("=y").has_been_split());
+  CHECK(Arg("x=y").has_been_split());
+}
+
+TEST_SUITE_END();

--- a/unittest/test_Args.cpp
+++ b/unittest/test_Args.cpp
@@ -17,6 +17,7 @@
 // Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include "../src/Args.hpp"
+#include "../src/Util.hpp"
 #include "TestUtil.hpp"
 
 #include "third_party/doctest.h"
@@ -46,20 +47,20 @@ TEST_CASE("Args move constructor")
   Args args1;
   args1.push_back("foo");
   args1.push_back("bar");
-  const char* foo_pointer = args1[0].c_str();
-  const char* bar_pointer = args1[1].c_str();
+  const char* foo_pointer = args1[0].full().c_str();
+  const char* bar_pointer = args1[1].full().c_str();
 
   Args args2(std::move(args1));
   CHECK(args1.size() == 0);
   CHECK(args2.size() == 2);
-  CHECK(args2[0].c_str() == foo_pointer);
-  CHECK(args2[1].c_str() == bar_pointer);
+  CHECK(args2[0] == foo_pointer);
+  CHECK(args2[1] == bar_pointer);
 }
 
 TEST_CASE("Args::from_argv")
 {
   int argc = 2;
-  const char* argv[] = {"a", "b"};
+  const char* argv[] = {"a", "b", nullptr};
   Args args = Args::from_argv(argc, argv);
   CHECK(args.size() == 2);
   CHECK(args[0] == "a");
@@ -151,14 +152,14 @@ TEST_CASE("Args copy assignment operator")
 TEST_CASE("Args move assignment operator")
 {
   Args args1 = Args::from_string("x y");
-  const char* x_pointer = args1[0].c_str();
-  const char* y_pointer = args1[1].c_str();
+  const char* x_pointer = args1[0].full().c_str();
+  const char* y_pointer = args1[1].full().c_str();
 
   Args args2;
   args2 = std::move(args1);
   CHECK(args1.size() == 0);
   CHECK(args2.size() == 2);
-  CHECK(args2[0].c_str() == x_pointer);
+  CHECK(args2[0].full().c_str() == x_pointer);
   CHECK(args2[1] == y_pointer);
 }
 

--- a/unittest/test_Args.cpp
+++ b/unittest/test_Args.cpp
@@ -77,6 +77,16 @@ TEST_CASE("Args::from_string")
   CHECK(args[3] == "f");
 }
 
+TEST_CASE("Args::from_string with space separated param")
+{
+  Args args = Args::from_string("Test Value", {{"Test", {' '}}});
+  CHECK(args.size() == 1);
+  CHECK(args[0].key() == "Test");
+  CHECK(args[0].value() == "Value");
+  CHECK(args[0].split_char() == ' ');
+  CHECK(args[0] == Arg("Test", ' ', "Value"));
+}
+
 TEST_CASE("Args::from_gcc_atfile")
 {
   TestContext test_context;
@@ -279,7 +289,7 @@ TEST_CASE("Args operations")
 
   SUBCASE("push_front string")
   {
-    args.push_front("foo");
+    args.push_front(Arg("foo"));
     CHECK(args == Args::from_string("foo eeny meeny miny moe"));
   }
 

--- a/unittest/test_Config.cpp
+++ b/unittest/test_Config.cpp
@@ -182,8 +182,9 @@ TEST_CASE("Config::update_from_file, error handling")
   SUBCASE("missing equal sign")
   {
     Util::write_file("ccache.conf", "no equal sign");
-    REQUIRE_THROWS_WITH(config.update_from_file("ccache.conf"),
-                        "ccache.conf:1: missing equal sign");
+    REQUIRE_THROWS_WITH(
+      config.update_from_file("ccache.conf"),
+      "ccache.conf:1: missing equal sign in \"no equal sign\"");
   }
 
   SUBCASE("unknown key")

--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -452,7 +452,7 @@ TEST_CASE(
 
   const ProcessArgsResult result = process_args(ctx);
   CHECK(!result.error);
-  CHECK("./foo" == result.preprocessor_args[2]);
+  CHECK(result.preprocessor_args[2] == "./foo");
 }
 
 TEST_CASE("isystem_flag_with_concat_arg_should_be_rewritten_if_basedir_is_used")
@@ -470,7 +470,7 @@ TEST_CASE("isystem_flag_with_concat_arg_should_be_rewritten_if_basedir_is_used")
 
   const ProcessArgsResult result = process_args(ctx);
   CHECK(!result.error);
-  CHECK("-isystem./foo" == result.preprocessor_args[1]);
+  CHECK(result.preprocessor_args[1] == "-isystem./foo");
 }
 
 TEST_CASE("I_flag_with_concat_arg_should_be_rewritten_if_basedir_is_used")
@@ -488,7 +488,7 @@ TEST_CASE("I_flag_with_concat_arg_should_be_rewritten_if_basedir_is_used")
 
   const ProcessArgsResult result = process_args(ctx);
   CHECK(!result.error);
-  CHECK("-I./foo" == result.preprocessor_args[1]);
+  CHECK(result.preprocessor_args[1] == "-I./foo");
 }
 
 TEST_CASE("debug_flag_order_with_known_option_first")


### PR DESCRIPTION
I hope this makes the code more readable and better maintainable over all.
Some strange casts remain as I did not want to convert everything to string_view in the same PR.