### PR TITLE
Add Visual Studio build directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ testdir/
 
 # Visual Studio
 /.vs/
+/out/build/
 
 # Visual Studio Code
 /.vscode/


### PR DESCRIPTION
Visual Studio 2019 builds into /out/ directory. The only way to change that is by adding yet another file named CMakeSettings.json. Adding the default to gitignore seems simpler.

Use Case: running unittests through Visual Studio due to its great debugger.