### PR TITLE
Refactoring: use return syntax for process_args

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -920,11 +920,8 @@ handle_dependency_environment_variables(Context& ctx,
 
 } // namespace
 
-optional<Statistic>
-process_args(Context& ctx,
-             Args& preprocessor_args,
-             Args& extra_args_to_hash,
-             Args& compiler_args)
+ProcessArgsResult
+process_args(Context& ctx)
 {
   assert(!ctx.orig_args.empty());
 
@@ -942,7 +939,7 @@ process_args(Context& ctx,
   for (size_t i = 1; i < args.size(); i++) {
     auto error = process_arg(ctx, args, i, state);
     if (error) {
-      return error;
+      return *error;
     }
   }
 
@@ -1155,7 +1152,7 @@ process_args(Context& ctx,
     args_info.output_su = Util::make_relative_path(ctx, default_sufile_name);
   }
 
-  compiler_args = state.common_args;
+  Args compiler_args = state.common_args;
   compiler_args.push_back(state.compiler_only_args);
 
   if (config.run_second_cpp()) {
@@ -1196,7 +1193,7 @@ process_args(Context& ctx,
     compiler_args.push_back(arch);
   }
 
-  preprocessor_args = state.common_args;
+  Args preprocessor_args = state.common_args;
   preprocessor_args.push_back(state.cpp_args);
 
   if (config.run_second_cpp()) {
@@ -1211,10 +1208,10 @@ process_args(Context& ctx,
     preprocessor_args.push_back(state.dep_args);
   }
 
-  extra_args_to_hash = state.compiler_only_args;
+  Args extra_args_to_hash = state.compiler_only_args;
   if (config.run_second_cpp()) {
     extra_args_to_hash.push_back(state.dep_args);
   }
 
-  return nullopt;
+  return {preprocessor_args, extra_args_to_hash, compiler_args};
 }

--- a/src/argprocessing.hpp
+++ b/src/argprocessing.hpp
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "Args.hpp"
 #include "stats.hpp"
 
 #include "third_party/nonstd/optional.hpp"
@@ -25,15 +26,33 @@
 class Context;
 class Args;
 
-// Process the compiler options into options suitable for passing to the
-// preprocessor (`preprocessor_args`) and the real compiler (`compiler_args`).
-// `preprocessor_args` doesn't include -E; this is added later.
-// `extra_args_to_hash` are the arguments that are not included in
-// `preprocessor_args` but that should be included in the hash.
-//
-// Returns nullopt on success, otherwise the statistics counter that should be
-// incremented.
-nonstd::optional<Statistic> process_args(Context& ctx,
-                                         Args& preprocessor_args,
-                                         Args& extra_args_to_hash,
-                                         Args& compiler_args);
+struct ProcessArgsResult
+{
+  ProcessArgsResult(Statistic err) : error(err)
+  {
+  }
+  ProcessArgsResult(Args preprocessor_args,
+                    Args extra_args_to_hash,
+                    Args compiler_args)
+    : preprocessor_args(preprocessor_args),
+      extra_args_to_hash(extra_args_to_hash),
+      compiler_args(compiler_args)
+  {
+  }
+
+  // nullopt on success, otherwise the statistics counter that should be
+  // incremented.
+  nonstd::optional<Statistic> error;
+
+  // Arguments (except -E) to send to the preprocessor.
+  Args preprocessor_args;
+
+  // Arguments not sent to the preprocessor but that should be part of the
+  // hash.
+  Args extra_args_to_hash;
+
+  // Arguments to send to the real compiler.
+  Args compiler_args;
+};
+
+ProcessArgsResult process_args(Context& ctx);


### PR DESCRIPTION
Using return instead of out-parameters simplifies reasoning about the code. And also usage.

Refactoring done based on [F.21: To return multiple "out" values, prefer returning a struct or tuple](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f21-to-return-multiple-out-values-prefer-returning-a-struct-or-tuple)