### PR TITLE
Refactor: convert Util function to use string_view

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1330,7 +1330,7 @@ strip_ansi_csi_seqs(string_view string)
 std::string
 strip_whitespace(string_view string)
 {
-  auto is_space = [](const int ch) { return std::isspace(ch); };
+  auto is_space = [](int ch) { return std::isspace(ch); };
   auto start = std::find_if_not(string.begin(), string.end(), is_space);
   auto end = std::find_if_not(string.rbegin(), string.rend(), is_space).base();
   return start < end ? std::string(start, end) : std::string();

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1312,7 +1312,7 @@ strip_ansi_csi_seqs(string_view string)
   std::string result;
 
   while (true) {
-    const auto seq_span = find_first_ansi_csi_seq(string.substr(pos));
+    auto seq_span = find_first_ansi_csi_seq(string.substr(pos));
     auto data_start = string.data() + pos;
     auto data_length =
       seq_span.empty() ? string.length() - pos : seq_span.data() - data_start;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1328,7 +1328,7 @@ strip_ansi_csi_seqs(string_view string)
 }
 
 std::string
-strip_whitespace(nonstd::string_view string)
+strip_whitespace(string_view string)
 {
   const auto is_space = [](const int ch) { return std::isspace(ch); };
   const auto start = std::find_if_not(string.begin(), string.end(), is_space);

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1314,7 +1314,7 @@ strip_ansi_csi_seqs(string_view string)
   while (true) {
     const auto seq_span = find_first_ansi_csi_seq(string.substr(pos));
     auto data_start = string.data() + pos;
-    const auto data_length =
+    auto data_length =
       seq_span.empty() ? string.length() - pos : seq_span.data() - data_start;
     result.append(data_start, data_length);
     if (seq_span.empty()) {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1312,9 +1312,9 @@ strip_ansi_csi_seqs(string_view string)
   std::string result;
 
   while (true) {
-    auto seq_span = find_first_ansi_csi_seq(string.substr(pos));
+    const auto seq_span = find_first_ansi_csi_seq(string.substr(pos));
     auto data_start = string.data() + pos;
-    auto data_length =
+    const auto data_length =
       seq_span.empty() ? string.length() - pos : seq_span.data() - data_start;
     result.append(data_start, data_length);
     if (seq_span.empty()) {
@@ -1328,11 +1328,12 @@ strip_ansi_csi_seqs(string_view string)
 }
 
 std::string
-strip_whitespace(const std::string& string)
+strip_whitespace(nonstd::string_view string)
 {
-  auto is_space = [](int ch) { return std::isspace(ch); };
-  auto start = std::find_if_not(string.begin(), string.end(), is_space);
-  auto end = std::find_if_not(string.rbegin(), string.rend(), is_space).base();
+  const auto is_space = [](const int ch) { return std::isspace(ch); };
+  const auto start = std::find_if_not(string.begin(), string.end(), is_space);
+  const auto end =
+    std::find_if_not(string.rbegin(), string.rend(), is_space).base();
   return start < end ? std::string(start, end) : std::string();
 }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1330,10 +1330,9 @@ strip_ansi_csi_seqs(string_view string)
 std::string
 strip_whitespace(string_view string)
 {
-  const auto is_space = [](const int ch) { return std::isspace(ch); };
-  const auto start = std::find_if_not(string.begin(), string.end(), is_space);
-  const auto end =
-    std::find_if_not(string.rbegin(), string.rend(), is_space).base();
+  auto is_space = [](const int ch) { return std::isspace(ch); };
+  auto start = std::find_if_not(string.begin(), string.end(), is_space);
+  auto end = std::find_if_not(string.rbegin(), string.rend(), is_space).base();
   return start < end ? std::string(start, end) : std::string();
 }
 

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -426,7 +426,7 @@ starts_with(nonstd::string_view string, nonstd::string_view prefix)
 [[nodiscard]] std::string strip_ansi_csi_seqs(nonstd::string_view string);
 
 // Strip whitespace from left and right side of a string.
-[[nodiscard]] std::string strip_whitespace(const std::string& string);
+[[nodiscard]] std::string strip_whitespace(nonstd::string_view string);
 
 // Convert a string to lowercase.
 [[nodiscard]] std::string to_lowercase(nonstd::string_view string);


### PR DESCRIPTION
The change is small, but once you start using string_view all those small functions have to use string_view as well. Otherwise a string needs to be created out of a string_view just to be discarded a second later.
(Compiler may be able to optimize it away if the function would accept a string object, but using string_view seems cleaner and is more in line to the other functions)

'+ Add some constness in the surrounding lines since we are touching the file anyway.