### PR TITLE
Refactor: slightly improve naming in compopt

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -318,9 +318,9 @@ process_arg(Context& ctx,
       && (args[i + 1] == "-emit-pch" || args[i + 1] == "-emit-pth"
           || args[i + 1] == "-include-pch" || args[i + 1] == "-include-pth"
           || args[i + 1] == "-fno-pch-timestamp")) {
-    if (compopt_affects_comp(args[i + 1])) {
+    if (compopt_affects_compiler_output(args[i + 1])) {
       state.compiler_only_args.push_back(args[i]);
-    } else if (compopt_affects_cpp(args[i + 1])) {
+    } else if (compopt_affects_cpp_output(args[i + 1])) {
       state.cpp_args.push_back(args[i]);
     } else {
       state.common_args.push_back(args[i]);
@@ -329,7 +329,7 @@ process_arg(Context& ctx,
   }
 
   // Handle options that should not be passed to the preprocessor.
-  if (compopt_affects_comp(args[i])) {
+  if (compopt_affects_compiler_output(args[i])) {
     state.compiler_only_args.push_back(args[i]);
     if (compopt_takes_arg(args[i])
         || (ctx.guessed_compiler == GuessedCompiler::nvcc
@@ -343,7 +343,7 @@ process_arg(Context& ctx,
     }
     return nullopt;
   }
-  if (compopt_prefix_affects_comp(args[i])) {
+  if (compopt_prefix_affects_compiler_output(args[i])) {
     state.compiler_only_args.push_back(args[i]);
     return nullopt;
   }
@@ -759,7 +759,7 @@ process_arg(Context& ctx,
 
     std::string relpath = Util::make_relative_path(ctx, args[i + next]);
     auto& dest_args =
-      compopt_affects_cpp(args[i]) ? state.cpp_args : state.common_args;
+      compopt_affects_cpp_output(args[i]) ? state.cpp_args : state.common_args;
     dest_args.push_back(args[i]);
     if (next == 2) {
       dest_args.push_back(args[i + 1]);
@@ -780,7 +780,7 @@ process_arg(Context& ctx,
         auto relpath =
           Util::make_relative_path(ctx, string_view(args[i]).substr(slash_pos));
         std::string new_option = option + relpath;
-        if (compopt_affects_cpp(option)) {
+        if (compopt_affects_cpp_output(option)) {
           state.cpp_args.push_back(new_option);
         } else {
           state.common_args.push_back(new_option);
@@ -797,7 +797,7 @@ process_arg(Context& ctx,
       return Statistic::bad_compiler_arguments;
     }
 
-    if (compopt_affects_cpp(args[i])) {
+    if (compopt_affects_cpp_output(args[i])) {
       state.cpp_args.push_back(args[i]);
       state.cpp_args.push_back(args[i + 1]);
     } else {
@@ -811,7 +811,8 @@ process_arg(Context& ctx,
 
   // Other options.
   if (args[i][0] == '-') {
-    if (compopt_affects_cpp(args[i]) || compopt_prefix_affects_cpp(args[i])) {
+    if (compopt_affects_cpp_output(args[i])
+        || compopt_prefix_affects_cpp_output(args[i])) {
       state.cpp_args.push_back(args[i]);
     } else {
       state.common_args.push_back(args[i]);

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1469,13 +1469,13 @@ calculate_result_name(Context& ctx,
     // might not be the case.
     if (!direct_mode && !ctx.args_info.output_is_precompiled_header
         && !ctx.args_info.using_precompiled_header) {
-      if (compopt_affects_cpp(args[i])) {
+      if (compopt_affects_cpp_output(args[i])) {
         if (compopt_takes_arg(args[i])) {
           i++;
         }
         continue;
       }
-      if (compopt_short(compopt_affects_cpp, args[i])) {
+      if (compopt_affects_cpp_output(args[i].substr(0, 2))) {
         continue;
       }
     }

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -43,13 +43,13 @@
 // The option only affects compilation; not passed to the preprocessor.
 #define AFFECTS_COMP (1 << 6)
 
-struct compopt
+struct CompOpt
 {
   const char* name;
   int type;
 };
 
-const struct compopt compopts[] = {
+const CompOpt compopts[] = {
   {"--Werror", TAKES_ARG},                            // nvcc
   {"--analyze", TOO_HARD},                            // Clang
   {"--compiler-bindir", AFFECTS_CPP | TAKES_ARG},     // nvcc
@@ -137,51 +137,43 @@ const struct compopt compopts[] = {
 static int
 compare_compopts(const void* key1, const void* key2)
 {
-  const struct compopt* opt1 = static_cast<const struct compopt*>(key1);
-  const struct compopt* opt2 = static_cast<const struct compopt*>(key2);
+  const CompOpt* opt1 = static_cast<const CompOpt*>(key1);
+  const CompOpt* opt2 = static_cast<const CompOpt*>(key2);
   return strcmp(opt1->name, opt2->name);
 }
 
 static int
 compare_prefix_compopts(const void* key1, const void* key2)
 {
-  const struct compopt* opt1 = static_cast<const struct compopt*>(key1);
-  const struct compopt* opt2 = static_cast<const struct compopt*>(key2);
+  const CompOpt* opt1 = static_cast<const CompOpt*>(key1);
+  const CompOpt* opt2 = static_cast<const CompOpt*>(key2);
   return strncmp(opt1->name, opt2->name, strlen(opt2->name));
 }
 
-static const struct compopt*
+static const CompOpt*
 find(const std::string& option)
 {
-  struct compopt key;
+  CompOpt key;
   key.name = option.c_str();
   void* result = bsearch(&key,
                          compopts,
                          ARRAY_SIZE(compopts),
                          sizeof(compopts[0]),
                          compare_compopts);
-  return static_cast<compopt*>(result);
+  return static_cast<CompOpt*>(result);
 }
 
-static const struct compopt*
+static const CompOpt*
 find_prefix(const std::string& option)
 {
-  struct compopt key;
+  CompOpt key;
   key.name = option.c_str();
   void* result = bsearch(&key,
                          compopts,
                          ARRAY_SIZE(compopts),
                          sizeof(compopts[0]),
                          compare_prefix_compopts);
-  return static_cast<compopt*>(result);
-}
-
-// Runs fn on the first two characters of option.
-bool
-compopt_short(bool (*fn)(const std::string&), const std::string& option)
-{
-  bool retval = fn(option.substr(0, 2));
-  return retval;
+  return static_cast<CompOpt*>(result);
 }
 
 // Used by unittest/test_compopt.cpp.
@@ -215,70 +207,70 @@ compopt_verify_sortedness_and_flags()
 }
 
 bool
-compopt_affects_cpp(const std::string& option)
+compopt_affects_cpp_output(const std::string& option)
 {
-  const struct compopt* co = find(option);
+  const CompOpt* co = find(option);
   return co && (co->type & AFFECTS_CPP);
 }
 
 bool
-compopt_affects_comp(const std::string& option)
+compopt_affects_compiler_output(const std::string& option)
 {
-  const struct compopt* co = find(option);
+  const CompOpt* co = find(option);
   return co && (co->type & AFFECTS_COMP);
 }
 
 bool
 compopt_too_hard(const std::string& option)
 {
-  const struct compopt* co = find(option);
+  const CompOpt* co = find(option);
   return co && (co->type & TOO_HARD);
 }
 
 bool
 compopt_too_hard_for_direct_mode(const std::string& option)
 {
-  const struct compopt* co = find(option);
+  const CompOpt* co = find(option);
   return co && (co->type & TOO_HARD_DIRECT);
 }
 
 bool
 compopt_takes_path(const std::string& option)
 {
-  const struct compopt* co = find(option);
+  const CompOpt* co = find(option);
   return co && (co->type & TAKES_PATH);
 }
 
 bool
 compopt_takes_arg(const std::string& option)
 {
-  const struct compopt* co = find(option);
+  const CompOpt* co = find(option);
   return co && (co->type & TAKES_ARG);
 }
 
 bool
 compopt_takes_concat_arg(const std::string& option)
 {
-  const struct compopt* co = find(option);
+  const CompOpt* co = find(option);
   return co && (co->type & TAKES_CONCAT_ARG);
 }
 
 // Determines if the prefix of the option matches any option and affects the
 // preprocessor.
 bool
-compopt_prefix_affects_cpp(const std::string& option)
+compopt_prefix_affects_cpp_output(const std::string& option)
 {
   // Prefix options have to take concatenated args.
-  const struct compopt* co = find_prefix(option);
+  const CompOpt* co = find_prefix(option);
   return co && (co->type & TAKES_CONCAT_ARG) && (co->type & AFFECTS_CPP);
 }
 
 // Determines if the prefix of the option matches any option and affects the
 // preprocessor.
 bool
-compopt_prefix_affects_comp(const std::string& option)
+compopt_prefix_affects_compiler_output(const std::string& option)
 {
   // Prefix options have to take concatenated args.
-  const struct compopt* co = find_prefix(option);
+  const CompOpt* co = find_prefix(option);
   return co && (co->type & TAKES_CONCAT_ARG) && (co->type & AFFECTS_COMP);
 }

--- a/src/compopt.hpp
+++ b/src/compopt.hpp
@@ -24,12 +24,12 @@
 
 bool compopt_short(bool (*fn)(const std::string& option),
                    const std::string& option);
-bool compopt_affects_cpp(const std::string& option);
-bool compopt_affects_comp(const std::string& option);
+bool compopt_affects_cpp_output(const std::string& option);
+bool compopt_affects_compiler_output(const std::string& option);
 bool compopt_too_hard(const std::string& option);
 bool compopt_too_hard_for_direct_mode(const std::string& option);
 bool compopt_takes_path(const std::string& option);
 bool compopt_takes_arg(const std::string& option);
 bool compopt_takes_concat_arg(const std::string& option);
-bool compopt_prefix_affects_cpp(const std::string& option);
-bool compopt_prefix_affects_comp(const std::string& option);
+bool compopt_prefix_affects_cpp_output(const std::string& option);
+bool compopt_prefix_affects_compiler_output(const std::string& option);

--- a/unittest/test_compopt.cpp
+++ b/unittest/test_compopt.cpp
@@ -29,111 +29,66 @@ TEST_CASE("option_table_should_be_sorted")
   CHECK(compopt_verify_sortedness_and_flags());
 }
 
-TEST_CASE("dash_I_affects_cpp")
+TEST_CASE("affects_cpp_output")
 {
-  CHECK(compopt_affects_cpp("-I"));
-  CHECK(!compopt_affects_cpp("-Ifoo"));
+  CHECK(compopt_affects_cpp_output("-I"));
+  CHECK(!compopt_affects_cpp_output("-Ifoo"));
+  CHECK(!compopt_affects_cpp_output("-V"));
+  CHECK(!compopt_affects_cpp_output("-doesntexist"));
 }
 
-TEST_CASE("compopt_short")
+TEST_CASE("affects_compiler_output")
 {
-  CHECK(compopt_short(compopt_affects_cpp, "-Ifoo"));
-  CHECK(!compopt_short(compopt_affects_cpp, "-include"));
+  CHECK(compopt_affects_compiler_output("-Xlinker"));
+  CHECK(compopt_affects_compiler_output("-all_load"));
+  CHECK(!compopt_affects_compiler_output("-U"));
 }
 
-TEST_CASE("dash_V_doesnt_affect_cpp")
-{
-  CHECK(!compopt_affects_cpp("-V"));
-}
-
-TEST_CASE("dash_doesntexist_doesnt_affect_cpp")
-{
-  CHECK(!compopt_affects_cpp("-doesntexist"));
-}
-
-TEST_CASE("dash_MM_too_hard")
+TEST_CASE("too_hard")
 {
   CHECK(compopt_too_hard("-MM"));
-}
-
-TEST_CASE("dash_save_temps_too_hard")
-{
   CHECK(compopt_too_hard("-save-temps"));
-}
-
-TEST_CASE("dash_save_temps_cwd_too_hard")
-{
   CHECK(compopt_too_hard("-save-temps=cwd"));
-}
-
-TEST_CASE("dash_save_temps_obj_too_hard")
-{
   CHECK(compopt_too_hard("-save-temps=obj"));
-}
-
-TEST_CASE("dash_MD_not_too_hard")
-{
+  CHECK(compopt_too_hard("-analyze"));
+  CHECK(compopt_too_hard("--analyze"));
   CHECK(!compopt_too_hard("-MD"));
-}
-
-TEST_CASE("dash_fprofile_arcs_not_too_hard")
-{
   CHECK(!compopt_too_hard("-fprofile-arcs"));
-}
-
-TEST_CASE("dash_ftest_coverage_not_too_hard")
-{
   CHECK(!compopt_too_hard("-ftest-coverage"));
-}
-
-TEST_CASE("dash_fstack_usage_not_too_hard")
-{
   CHECK(!compopt_too_hard("-fstack-usage"));
-}
-
-TEST_CASE("dash_doesntexist_not_too_hard")
-{
   CHECK(!compopt_too_hard("-doesntexist"));
 }
 
-TEST_CASE("dash_Xpreprocessor_too_hard_for_direct_mode")
+TEST_CASE("too_hard_for_direct_mode")
 {
   CHECK(compopt_too_hard_for_direct_mode("-Xpreprocessor"));
-}
-
-TEST_CASE("dash_nostdinc_not_too_hard_for_direct_mode")
-{
   CHECK(!compopt_too_hard_for_direct_mode("-nostdinc"));
 }
 
-TEST_CASE("dash_I_takes_path")
+TEST_CASE("compopt_takes_path")
 {
   CHECK(compopt_takes_path("-I"));
+  CHECK(!compopt_takes_path("-L"));
 }
 
-TEST_CASE("dash_Xlinker_takes_arg")
+TEST_CASE("compopt_takes_arg")
 {
   CHECK(compopt_takes_arg("-Xlinker"));
-}
-
-TEST_CASE("dash_xxx_doesnt_take_arg")
-{
   CHECK(!compopt_takes_arg("-xxx"));
 }
 
-TEST_CASE("dash_iframework_prefix_affects_cpp")
+TEST_CASE("prefix_affects_cpp_output")
 {
-  CHECK(compopt_prefix_affects_cpp("-iframework"));
+  CHECK(compopt_prefix_affects_cpp_output("-iframework"));
+  CHECK(compopt_prefix_affects_cpp_output("-iframework42"));
+  CHECK(!compopt_prefix_affects_cpp_output("-iframewor"));
 }
 
-TEST_CASE("dash_analyze_too_hard")
+TEST_CASE("prefix_affects_compiler_output")
 {
-  CHECK(compopt_too_hard("-analyze"));
-}
-
-TEST_CASE("dash_dash_analyze_too_hard")
-{
-  CHECK(compopt_too_hard("--analyze"));
+  CHECK(compopt_prefix_affects_compiler_output("-Wa,"));
+  CHECK(compopt_prefix_affects_compiler_output("-Wa,something"));
+  CHECK(!compopt_prefix_affects_compiler_output("-Wa"));
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
This is a small almost insignificant change.
I was wondering what those functions do, so I improved their names slightly.
+ Tests are cleaned up to less test cases + some border cases added.

I made separate commits for trivial review 👍

I was actually looking into the argument type those functions receive (string, string_view or char*), but that got a little out of hand so I wanted to get this trivial part merged first.