### PR TITLE
Make CCACHE_COMPILER always the highest priority

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1955,11 +1955,10 @@ set_up_config(Config& config)
       config.set_cache_dir(default_cache_dir(home_dir));
     }
   }
-  // else: cache_dir was set explicitly via environment or via secondary
-  // config.
+  // else: cache_dir was set explicitly via environment or via secondary config.
 
-  // We have now determined config.cache_dir and populated the rest of config
-  // in prio order (1. environment, 2. primary config, 3. secondary config).
+  // We have now determined config.cache_dir and populated the rest of config in
+  // prio order (1. environment, 2. primary config, 3. secondary config).
 }
 
 static void
@@ -1982,10 +1981,10 @@ initialize(Context& ctx, int argc, const char* const* argv)
 
   // Set default umask for all files created by ccache from now on (if
   // configured to). This is intentionally done after calling init_log so that
-  // the log file won't be affected by the umask but before creating the
-  // initial configuration file. The intention is that all files and
-  // directories in the cache directory should be affected by the configured
-  // umask and that no other files and directories should.
+  // the log file won't be affected by the umask but before creating the initial
+  // configuration file. The intention is that all files and directories in the
+  // cache directory should be affected by the configured umask and that no
+  // other files and directories should.
   if (ctx.config.umask() != std::numeric_limits<uint32_t>::max()) {
     ctx.original_umask = umask(ctx.config.umask());
   }
@@ -2722,8 +2721,8 @@ handle_main_options(int argc, const char* const* argv)
       exit(EXIT_FAILURE);
     }
 
-    // Some of the above switches might have changed config settings, so run
-    // the setup again.
+    // Some of the above switches might have changed config settings, so run the
+    // setup again.
     ctx.config = Config();
     set_up_config(ctx.config);
   }
@@ -2744,8 +2743,8 @@ ccache_main(int argc, const char* const* argv)
         fmt::print(stderr, USAGE_TEXT, CCACHE_NAME, CCACHE_NAME);
         exit(EXIT_FAILURE);
       }
-      // If the first argument isn't an option, then assume we are being
-      // passed a compiler name and options.
+      // If the first argument isn't an option, then assume we are being passed
+      // a compiler name and options.
       if (argv[1][0] == '-') {
         return handle_main_options(argc, argv);
       }

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1859,7 +1859,6 @@ find_compiler(Context& ctx,
       CCACHE_NAME);
   }
 
-  // Adjust ctx.orig_args
   if (first_param_is_ccache) {
     ctx.orig_args.pop_front();
   }

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -725,6 +725,35 @@ b"
     expect_stat 'cache miss' 2
 
     # -------------------------------------------------------------------------
+    TEST "CCACHE_COMPILER"
+
+    $REAL_COMPILER -c -o reference_test1.o test1.c
+
+    $CCACHE_COMPILE -c test1.c
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+    expect_equal_object_files reference_test1.o test1.o
+
+    CCACHE_COMPILER=$COMPILER $CCACHE non_existing_compiler_will_be_overridden_anyway -c test1.c
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+    expect_equal_object_files reference_test1.o test1.o
+
+    CCACHE_COMPILER=$COMPILER $CCACHE same/for/relative -c test1.c
+    expect_stat 'cache hit (preprocessed)' 2
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+    expect_equal_object_files reference_test1.o test1.o
+
+    CCACHE_COMPILER=$COMPILER $CCACHE /and/even/absolute/compilers -c test1.c
+    expect_stat 'cache hit (preprocessed)' 3
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+    expect_equal_object_files reference_test1.o test1.o
+
+    # -------------------------------------------------------------------------
     TEST "CCACHE_PATH"
 
     override_path=`pwd`/override_path

--- a/unittest/test_ccache.cpp
+++ b/unittest/test_ccache.cpp
@@ -77,17 +77,16 @@ TEST_CASE("find_compiler")
     CHECK(helper("/abs/" CCACHE_NAME " /abs/gcc", "") == "/abs/gcc");
 
     // If gcc points back to ccache throw, unless either ccache or gcc is a
-    // relative or absolute path. If ccache *and* compiler have a relative or
-    // absolute path, call ccache from PATH.
+    // relative or absolute path.
     CHECK_THROWS(helper(CCACHE_NAME " gcc", "", CCACHE_NAME));
     CHECK(helper(CCACHE_NAME " rel/gcc", "", CCACHE_NAME) == "rel/gcc");
     CHECK(helper(CCACHE_NAME " /abs/gcc", "", CCACHE_NAME) == "/abs/gcc");
 
-    CHECK(helper("rel/" CCACHE_NAME " gcc", "", CCACHE_NAME) == "ccache");
+    CHECK_THROWS(helper("rel/" CCACHE_NAME " gcc", "", CCACHE_NAME));
     CHECK(helper("rel/" CCACHE_NAME " rel/gcc", "", CCACHE_NAME) == "rel/gcc");
     CHECK(helper("rel/" CCACHE_NAME " /a/gcc", "", CCACHE_NAME) == "/a/gcc");
 
-    CHECK(helper("/abs/" CCACHE_NAME " gcc", "", CCACHE_NAME) == "ccache");
+    CHECK_THROWS(helper("/abs/" CCACHE_NAME " gcc", "", CCACHE_NAME));
     CHECK(helper("/abs/" CCACHE_NAME " rel/gcc", "", CCACHE_NAME) == "rel/gcc");
     CHECK(helper("/abs/" CCACHE_NAME " /a/gcc", "", CCACHE_NAME) == "/a/gcc");
 
@@ -109,38 +108,39 @@ TEST_CASE("find_compiler")
   SUBCASE("config")
   {
     // In case the first parameter is gcc it must be a link to ccache so use
-    // config value instead.
+    // config value instead. Don't resolve config if it's a relative or absolute
+    // path.
     CHECK(helper("gcc", "config") == "resolved_config");
-    CHECK(helper("gcc", "rel/config") == "resolved_rel/config");
-    CHECK(helper("gcc", "/abs/config") == "resolved_/abs/config");
+    CHECK(helper("gcc", "rel/config") == "rel/config");
+    CHECK(helper("gcc", "/abs/config") == "/abs/config");
     CHECK(helper("rel/gcc", "config") == "resolved_config");
-    CHECK(helper("rel/gcc", "rel/config") == "resolved_rel/config");
-    CHECK(helper("rel/gcc", "/abs/config") == "resolved_/abs/config");
+    CHECK(helper("rel/gcc", "rel/config") == "rel/config");
+    CHECK(helper("rel/gcc", "/abs/config") == "/abs/config");
     CHECK(helper("/abs/gcc", "config") == "resolved_config");
-    CHECK(helper("/abs/gcc", "rel/config") == "resolved_rel/config");
-    CHECK(helper("/abs/gcc", "/abs/config") == "resolved_/abs/config");
+    CHECK(helper("/abs/gcc", "rel/config") == "rel/config");
+    CHECK(helper("/abs/gcc", "/abs/config") == "/abs/config");
 
-    // In case the first parameter is ccache, use the configuration value unless
-    // the second parameter is a relative or absolute path.
+    // In case the first parameter is ccache, use the configuration value. Don't
+    // resolve configuration value if it's a relative or absolute path.
     CHECK(helper(CCACHE_NAME " gcc", "config") == "resolved_config");
-    CHECK(helper(CCACHE_NAME " gcc", "rel/config") == "resolved_rel/config");
-    CHECK(helper(CCACHE_NAME " gcc", "/abs/config") == "resolved_/abs/config");
-    CHECK(helper(CCACHE_NAME " rel/gcc", "config") == "rel/gcc");
-    CHECK(helper(CCACHE_NAME " /abs/gcc", "config") == "/abs/gcc");
+    CHECK(helper(CCACHE_NAME " gcc", "rel/config") == "rel/config");
+    CHECK(helper(CCACHE_NAME " gcc", "/abs/config") == "/abs/config");
+    CHECK(helper(CCACHE_NAME " rel/gcc", "config") == "resolved_config");
+    CHECK(helper(CCACHE_NAME " /abs/gcc", "config") == "resolved_config");
 
     // Same as above with relative path to ccache.
     CHECK(helper("r/" CCACHE_NAME " gcc", "conf") == "resolved_conf");
-    CHECK(helper("r/" CCACHE_NAME " gcc", "rel/conf") == "resolved_rel/conf");
-    CHECK(helper("r/" CCACHE_NAME " gcc", "/abs/conf") == "resolved_/abs/conf");
-    CHECK(helper("r/" CCACHE_NAME " rel/gcc", "conf") == "rel/gcc");
-    CHECK(helper("r/" CCACHE_NAME " /abs/gcc", "conf") == "/abs/gcc");
+    CHECK(helper("r/" CCACHE_NAME " gcc", "rel/conf") == "rel/conf");
+    CHECK(helper("r/" CCACHE_NAME " gcc", "/abs/conf") == "/abs/conf");
+    CHECK(helper("r/" CCACHE_NAME " rel/gcc", "conf") == "resolved_conf");
+    CHECK(helper("r/" CCACHE_NAME " /abs/gcc", "conf") == "resolved_conf");
 
     // Same as above with absolute path to ccache.
     CHECK(helper("/a/" CCACHE_NAME " gcc", "conf") == "resolved_conf");
-    CHECK(helper("/a/" CCACHE_NAME " gcc", "rel/conf") == "resolved_rel/conf");
-    CHECK(helper("/a/" CCACHE_NAME " gcc", "/a/conf") == "resolved_/a/conf");
-    CHECK(helper("/a/" CCACHE_NAME " rel/gcc", "conf") == "rel/gcc");
-    CHECK(helper("/a/" CCACHE_NAME " /abs/gcc", "conf") == "/abs/gcc");
+    CHECK(helper("/a/" CCACHE_NAME " gcc", "rel/conf") == "rel/conf");
+    CHECK(helper("/a/" CCACHE_NAME " gcc", "/a/conf") == "/a/conf");
+    CHECK(helper("/a/" CCACHE_NAME " rel/gcc", "conf") == "resolved_conf");
+    CHECK(helper("/a/" CCACHE_NAME " /abs/gcc", "conf") == "resolved_conf");
   }
 }
 


### PR DESCRIPTION
This makes ccache always use `compiler` from its config when it is set.
Resolves #432

Note: the function structure had to change significantly because there was a return statement right in the middle of it and the functionality is actually changed a lot in detail (see unit tests).