### PR TITLE
Add unittest for find_compiler

### DIFF
--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -79,6 +79,7 @@ public:
   void set_base_dir(const std::string& value);
   void set_cache_dir(const std::string& value);
   void set_cpp_extension(const std::string& value);
+  void set_compiler(const std::string& value);
   void set_depend_mode(bool value);
   void set_debug(bool value);
   void set_direct_mode(bool value);
@@ -413,6 +414,12 @@ inline void
 Config::set_cpp_extension(const std::string& value)
 {
   m_cpp_extension = value;
+}
+
+inline void
+Config::set_compiler(const std::string& value)
+{
+  m_compiler = value;
 }
 
 inline void

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1239,13 +1239,14 @@ rename(const std::string& oldpath, const std::string& newpath)
 }
 
 bool
-same_program_name(const std::string& program_name,
-                  const std::string& canonical_program_name)
+same_program_name(nonstd::string_view program_name,
+                  nonstd::string_view canonical_program_name)
 {
 #ifdef _WIN32
   std::string lowercase_program_name = Util::to_lowercase(program_name);
   return lowercase_program_name == canonical_program_name
-         || lowercase_program_name == (canonical_program_name + ".exe");
+         || lowercase_program_name
+              == fmt::format("{}.exe", canonical_program_name);
 #else
   return program_name == canonical_program_name;
 #endif

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -388,8 +388,8 @@ void rename(const std::string& oldpath, const std::string& newpath);
 // Detmine if `program_name` is equal to `canonical_program_name`. On Windows,
 // this means performing a case insensitive equality check with and without a
 // ".exe" suffix. On non-Windows, it is a simple equality check.
-bool same_program_name(const std::string& program_name,
-                       const std::string& canonical_program_name);
+bool same_program_name(nonstd::string_view program_name,
+                       nonstd::string_view canonical_program_name);
 
 // Send `text` to STDERR_FILENO, optionally stripping ANSI color sequences if
 // `ctx.args_info.strip_diagnostics_colors` is true and rewriting paths to

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1749,23 +1749,11 @@ from_cache(Context& ctx, FromCacheCallMode mode)
                                            : Statistic::preprocessed_cache_hit;
 }
 
-// Tested by unittests
-void
-find_compiler(Context& ctx,
-              const std::function<std::string(const Context& ctx,
-                                              const std::string& name,
-                                              const std::string& exclude_name)>&
-                find_executable_function);
-
 // Find the real compiler and put it into ctx.orig_args[0]. We just search the
 // PATH to find an executable of the same name that isn't a link to ourselves.
 // Pass find_executable function as second parameter.
 void
-find_compiler(Context& ctx,
-              const std::function<std::string(const Context& ctx,
-                                              const std::string& name,
-                                              const std::string& exclude_name)>&
-                find_executable_function)
+find_compiler(Context& ctx, FindExecutableFunction find_executable_function)
 {
   const std::string orig_first_arg = ctx.orig_args[0];
 

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1749,10 +1749,23 @@ from_cache(Context& ctx, FromCacheCallMode mode)
                                            : Statistic::preprocessed_cache_hit;
 }
 
+// Tested by unittests
+void
+find_compiler(Context& ctx,
+              const std::function<std::string(const Context& ctx,
+                                              const std::string& name,
+                                              const std::string& exclude_name)>&
+                find_executable_function);
+
 // Find the real compiler and put it into ctx.orig_args[0]. We just search the
 // PATH to find an executable of the same name that isn't a link to ourselves.
-static void
-find_compiler(Context& ctx)
+// Pass find_executable function as second parameter.
+void
+find_compiler(Context& ctx,
+              const std::function<std::string(const Context& ctx,
+                                              const std::string& name,
+                                              const std::string& exclude_name)>&
+                find_executable_function)
 {
   const std::string orig_first_arg = ctx.orig_args[0];
 
@@ -1771,7 +1784,7 @@ find_compiler(Context& ctx)
     base = ctx.config.compiler();
   }
 
-  std::string compiler = find_executable(ctx, base, CCACHE_NAME);
+  std::string compiler = find_executable_function(ctx, base, CCACHE_NAME);
   if (compiler.empty()) {
     throw Fatal("Could not find compiler \"{}\" in PATH", base);
   }
@@ -2135,7 +2148,7 @@ cache_compilation(int argc, const char* const* argv)
     initialize(ctx, argc, argv);
 
     MTR_BEGIN("main", "find_compiler");
-    find_compiler(ctx);
+    find_compiler(ctx, &find_executable);
     MTR_END("main", "find_compiler");
 
     try {

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1753,7 +1753,8 @@ from_cache(Context& ctx, FromCacheCallMode mode)
 // PATH to find an executable of the same name that isn't a link to ourselves.
 // Pass find_executable function as second parameter.
 void
-find_compiler(Context& ctx, FindExecutableFunction find_executable_function)
+find_compiler(Context& ctx,
+              const FindExecutableFunction& find_executable_function)
 {
   const std::string orig_first_arg = ctx.orig_args[0];
 

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -21,6 +21,8 @@
 
 #include "system.hpp"
 
+#include <functional>
+
 extern const char CCACHE_VERSION[];
 
 enum class GuessedCompiler { clang, gcc, nvcc, pump, unknown };
@@ -44,3 +46,13 @@ const uint32_t SLOPPY_CLANG_INDEX_STORE = 1 << 7;
 const uint32_t SLOPPY_LOCALE = 1 << 8;
 // Allow caching even if -fmodules is used.
 const uint32_t SLOPPY_MODULES = 1 << 9;
+
+class Context;
+using FindExecutableFunction =
+  const std::function<std::string(const Context& ctx,
+                                  const std::string& name,
+                                  const std::string& exclude_name)>&;
+
+// Tested by unittests
+void find_compiler(Context& ctx,
+                   FindExecutableFunction find_executable_function);

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -55,6 +55,6 @@ using FindExecutableFunction =
                             const std::string& name,
                             const std::string& exclude_name)>;
 
-// Tested by unittests
+// Tested by unit tests.
 void find_compiler(Context& ctx,
                    const FindExecutableFunction& find_executable_function);

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -48,11 +48,12 @@ const uint32_t SLOPPY_LOCALE = 1 << 8;
 const uint32_t SLOPPY_MODULES = 1 << 9;
 
 class Context;
+
 using FindExecutableFunction =
-  const std::function<std::string(const Context& ctx,
-                                  const std::string& name,
-                                  const std::string& exclude_name)>&;
+  std::function<std::string(const Context& ctx,
+                            const std::string& name,
+                            const std::string& exclude_name)>;
 
 // Tested by unittests
 void find_compiler(Context& ctx,
-                   FindExecutableFunction find_executable_function);
+                   const FindExecutableFunction& find_executable_function);

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -22,6 +22,9 @@
 #include "system.hpp"
 
 #include <functional>
+#include <string>
+
+class Context;
 
 extern const char CCACHE_VERSION[];
 
@@ -46,8 +49,6 @@ const uint32_t SLOPPY_CLANG_INDEX_STORE = 1 << 7;
 const uint32_t SLOPPY_LOCALE = 1 << 8;
 // Allow caching even if -fmodules is used.
 const uint32_t SLOPPY_MODULES = 1 << 9;
-
-class Context;
 
 using FindExecutableFunction =
   std::function<std::string(const Context& ctx,

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,24 +1,25 @@
-set(source_files
-    TestUtil.cpp
-    main.cpp
-    test_Args.cpp
-    test_AtomicFile.cpp
-    test_ccache.cpp
-    test_Checksum.cpp
-    test_Compression.cpp
-    test_Config.cpp
-    test_Counters.cpp
-    test_FormatNonstdStringView.cpp
-    test_Hash.cpp
-    test_Lockfile.cpp
-    test_NullCompression.cpp
-    test_Stat.cpp
-    test_Statistics.cpp
-    test_Util.cpp
-    test_ZstdCompression.cpp
-    test_argprocessing.cpp
-    test_compopt.cpp
-    test_hashutil.cpp)
+set(
+  source_files
+  TestUtil.cpp
+  main.cpp
+  test_Args.cpp
+  test_AtomicFile.cpp
+  test_Checksum.cpp
+  test_Compression.cpp
+  test_Config.cpp
+  test_Counters.cpp
+  test_FormatNonstdStringView.cpp
+  test_Hash.cpp
+  test_Lockfile.cpp
+  test_NullCompression.cpp
+  test_Stat.cpp
+  test_Statistics.cpp
+  test_Util.cpp
+  test_ZstdCompression.cpp
+  test_argprocessing.cpp
+  test_ccache.cpp
+  test_compopt.cpp
+  test_hashutil.cpp)
 
 if(INODE_CACHE_SUPPORTED)
   list(APPEND source_files test_InodeCache.cpp)
@@ -30,8 +31,9 @@ endif()
 
 add_executable(unittest ${source_files})
 
-target_link_libraries(unittest PRIVATE standard_settings standard_warnings
-                                       ccache_lib third_party_lib)
+target_link_libraries(
+  unittest
+  PRIVATE standard_settings standard_warnings ccache_lib third_party_lib)
 
 target_include_directories(unittest PRIVATE ${CMAKE_BINARY_DIR} . ../src)
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,24 +1,24 @@
-set(
-  source_files
-  TestUtil.cpp
-  main.cpp
-  test_Args.cpp
-  test_AtomicFile.cpp
-  test_Checksum.cpp
-  test_Compression.cpp
-  test_Config.cpp
-  test_Counters.cpp
-  test_FormatNonstdStringView.cpp
-  test_Hash.cpp
-  test_Lockfile.cpp
-  test_NullCompression.cpp
-  test_Stat.cpp
-  test_Statistics.cpp
-  test_Util.cpp
-  test_ZstdCompression.cpp
-  test_argprocessing.cpp
-  test_compopt.cpp
-  test_hashutil.cpp)
+set(source_files
+    TestUtil.cpp
+    main.cpp
+    test_Args.cpp
+    test_AtomicFile.cpp
+    test_ccache.cpp
+    test_Checksum.cpp
+    test_Compression.cpp
+    test_Config.cpp
+    test_Counters.cpp
+    test_FormatNonstdStringView.cpp
+    test_Hash.cpp
+    test_Lockfile.cpp
+    test_NullCompression.cpp
+    test_Stat.cpp
+    test_Statistics.cpp
+    test_Util.cpp
+    test_ZstdCompression.cpp
+    test_argprocessing.cpp
+    test_compopt.cpp
+    test_hashutil.cpp)
 
 if(INODE_CACHE_SUPPORTED)
   list(APPEND source_files test_InodeCache.cpp)
@@ -30,9 +30,8 @@ endif()
 
 add_executable(unittest ${source_files})
 
-target_link_libraries(
-  unittest
-  PRIVATE standard_settings standard_warnings ccache_lib third_party_lib)
+target_link_libraries(unittest PRIVATE standard_settings standard_warnings
+                                       ccache_lib third_party_lib)
 
 target_include_directories(unittest PRIVATE ${CMAKE_BINARY_DIR} . ../src)
 

--- a/unittest/test_ccache.cpp
+++ b/unittest/test_ccache.cpp
@@ -56,14 +56,14 @@ TEST_CASE("find_compiler")
   SUBCASE("no config")
   {
     // In case the first parameter is gcc it must be a link to ccache, so
-    // find_compiler shall call find_executable to locate the next best "gcc"
+    // find_compiler should call find_executable to locate the next best "gcc"
     // and return that value.
     CHECK(helper("gcc", "") == "resolved_gcc");
     CHECK(helper("relative/gcc", "") == "resolved_gcc");
     CHECK(helper("/absolute/gcc", "") == "resolved_gcc");
 
-    // In case the first param is ccache, resolve the second param to the real
-    // compiler. Unless it's a relative/absolute path.
+    // In case the first parameter is ccache, resolve the second parameter to
+    // the real compiler unless it's a relative or absolute path.
     CHECK(helper(CCACHE_NAME " gcc", "") == "resolved_gcc");
     CHECK(helper(CCACHE_NAME " rel/gcc", "") == "rel/gcc");
     CHECK(helper(CCACHE_NAME " /abs/gcc", "") == "/abs/gcc");
@@ -76,10 +76,9 @@ TEST_CASE("find_compiler")
     CHECK(helper("/abs/" CCACHE_NAME " rel/gcc", "") == "rel/gcc");
     CHECK(helper("/abs/" CCACHE_NAME " /abs/gcc", "") == "/abs/gcc");
 
-    // If gcc points back to ccache throw. Unless either ccache or gcc is a
-    // relative/absolute path.
-    // If ccache *and* compiler have a relative/absolute path, call ccache from
-    // PATH.
+    // If gcc points back to ccache throw, unless either ccache or gcc is a
+    // relative or absolute path. If ccache *and* compiler have a relative or
+    // absolute path, call ccache from PATH.
     CHECK_THROWS(helper(CCACHE_NAME " gcc", "", CCACHE_NAME));
     CHECK(helper(CCACHE_NAME " rel/gcc", "", CCACHE_NAME) == "rel/gcc");
     CHECK(helper(CCACHE_NAME " /abs/gcc", "", CCACHE_NAME) == "/abs/gcc");
@@ -92,8 +91,8 @@ TEST_CASE("find_compiler")
     CHECK(helper("/abs/" CCACHE_NAME " rel/gcc", "", CCACHE_NAME) == "rel/gcc");
     CHECK(helper("/abs/" CCACHE_NAME " /a/gcc", "", CCACHE_NAME) == "/a/gcc");
 
-    // If compiler is not found throw. Unless compiler has a relative/absolute
-    // path.
+    // If compiler is not found then throw, unless the compiler has a relative
+    // or absolute path.
     CHECK_THROWS(helper(CCACHE_NAME " gcc", "", ""));
     CHECK(helper(CCACHE_NAME " rel/gcc", "", "") == "rel/gcc");
     CHECK(helper(CCACHE_NAME " /abs/gcc", "", "") == "/abs/gcc");
@@ -109,8 +108,8 @@ TEST_CASE("find_compiler")
 
   SUBCASE("config")
   {
-    // In case the first parameter is gcc it must be a link to ccache, use
-    // config value instead. Assume config value to be base name only.
+    // In case the first parameter is gcc it must be a link to ccache so use
+    // config value instead.
     CHECK(helper("gcc", "config") == "resolved_config");
     CHECK(helper("gcc", "rel/config") == "resolved_rel/config");
     CHECK(helper("gcc", "/abs/config") == "resolved_/abs/config");
@@ -121,8 +120,8 @@ TEST_CASE("find_compiler")
     CHECK(helper("/abs/gcc", "rel/config") == "resolved_rel/config");
     CHECK(helper("/abs/gcc", "/abs/config") == "resolved_/abs/config");
 
-    // In case the first param is ccache, use conf value. Unless the second
-    // param is a relative/absolute path.
+    // In case the first parameter is ccache, use the configuration value unless
+    // the second parameter is a relative or absolute path.
     CHECK(helper(CCACHE_NAME " gcc", "config") == "resolved_config");
     CHECK(helper(CCACHE_NAME " gcc", "rel/config") == "resolved_rel/config");
     CHECK(helper(CCACHE_NAME " gcc", "/abs/config") == "resolved_/abs/config");

--- a/unittest/test_ccache.cpp
+++ b/unittest/test_ccache.cpp
@@ -1,0 +1,108 @@
+// Copyright (C) 2020 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "Context.hpp"
+#include "TestUtil.hpp"
+
+#include "third_party/doctest.h"
+#include "third_party/nonstd/optional.hpp"
+
+// Function under test
+void find_compiler(Context& ctx,
+                   const std::function<std::string(
+                     const Context&, const std::string&, const std::string&)>&);
+
+#ifdef MYNAME
+#  define CCACHE_NAME MYNAME
+#else
+#  define CCACHE_NAME "ccache"
+#endif
+
+TEST_SUITE_BEGIN("ccache");
+
+using TestUtil::TestContext;
+
+// Wraps find_compiler in a test friendly interface.
+static std::string
+helper(const char* args,
+       const char* config_compiler,
+       const char* find_executable_return_string = nullptr)
+{
+  const auto find_executable_stub =
+    [&find_executable_return_string](
+      const Context&, const std::string& s, const std::string&) -> std::string {
+    return find_executable_return_string ? find_executable_return_string
+                                         : "resolved_" + s;
+  };
+
+  Context ctx;
+  ctx.config.set_compiler(config_compiler);
+  ctx.orig_args = Args::from_string(args);
+  find_compiler(ctx, find_executable_stub);
+  return ctx.orig_args.to_string();
+}
+
+TEST_CASE("find_compiler")
+{
+  SUBCASE("no config")
+  {
+    // In case the first parameter is gcc it must be a link to ccache, so
+    // find_compiler shall call find_executable to locate the next best "gcc"
+    // and return that value.
+    CHECK(helper("gcc", "") == "resolved_gcc");
+    CHECK(helper("relative/gcc", "") == "resolved_gcc");
+    CHECK(helper("/absolute/gcc", "") == "resolved_gcc");
+
+    // In case the first param is ccache, resolve the second param to the real
+    // compiler. Unless it's a relative/absolute path.
+    CHECK(helper(CCACHE_NAME " gcc", "") == "resolved_gcc");
+    CHECK(helper(CCACHE_NAME " rel/gcc", "") == "rel/gcc");
+    CHECK(helper(CCACHE_NAME " /abs/gcc", "") == "/abs/gcc");
+
+    // If gcc points back to ccache throw. Unless it's a relative/absolute path.
+    CHECK_THROWS(helper(CCACHE_NAME " gcc", "", CCACHE_NAME));
+    CHECK(helper(CCACHE_NAME " rel/gcc", "", CCACHE_NAME) == "rel/gcc");
+    CHECK(helper(CCACHE_NAME " /abs/gcc", "", CCACHE_NAME) == "/abs/gcc");
+
+    // If compiler is not found throw. Unless it's a relative/absolute path.
+    CHECK_THROWS(helper(CCACHE_NAME " gcc", "", ""));
+    CHECK(helper(CCACHE_NAME " rel/gcc", "", "") == "rel/gcc");
+    CHECK(helper(CCACHE_NAME " /abs/gcc", "", "") == "/abs/gcc");
+  }
+
+  SUBCASE("config")
+  {
+    // In case the first parameter is gcc it must be a link to ccache, use
+    // config value instead. Assume config value to be base name only.
+    CHECK(helper("gcc", "config") == "resolved_config");
+    CHECK(helper("relative/gcc", "config") == "resolved_config");
+    CHECK(helper("/absolute/gcc", "config") == "resolved_config");
+    CHECK(helper("gcc", "relative/config") == "resolved_relative/config");
+    CHECK(helper("gcc", "/absolute/config") == "resolved_/absolute/config");
+
+    // In case the first param is ccache, use config value. Unless it's a
+    // relative/absolute path. Assume config value to be base name only.
+    CHECK(helper(CCACHE_NAME " gcc", "config") == "resolved_config");
+    CHECK(helper(CCACHE_NAME " gcc", "rel/config") == "resolved_rel/config");
+    CHECK(helper(CCACHE_NAME " gcc", "/abs/config") == "resolved_/abs/config");
+    CHECK(helper(CCACHE_NAME " rel/gcc", "config") == "rel/gcc");
+    CHECK(helper(CCACHE_NAME " /abs/gcc", "config") == "/abs/gcc");
+  }
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
Since fixing #432 is surprisingly complex as witnessed in #664, this documents current behavior of find_compiler in detail.
Besides helping in development this allows talking about how it should behave in the future.

No functional changes.