### PR TITLE
Remove -lgcov from compiler independent profiling script

### DIFF
--- a/test/suites/profiling.bash
+++ b/test/suites/profiling.bash
@@ -74,7 +74,7 @@ SUITE_profiling() {
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache miss' 1
 
-    $COMPILER -fprofile-generate=data test.o -lgcov -o test
+    $COMPILER -fprofile-generate=data test.o -o test
 
     ./test
     merge_profiling_data data

--- a/test/suites/profiling.bash
+++ b/test/suites/profiling.bash
@@ -74,7 +74,7 @@ SUITE_profiling() {
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache miss' 1
 
-    $COMPILER -fprofile-generate=data test.o -o test
+    $COMPILER -fprofile-generate test.o -o test
 
     ./test
     merge_profiling_data data

--- a/test/suites/profiling_gcc.bash
+++ b/test/suites/profiling_gcc.bash
@@ -17,7 +17,7 @@ SUITE_profiling_gcc() {
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache miss' 1
 
-    $COMPILER -fprofile-generate test.o -lgcov -o test
+    $COMPILER -fprofile-generate test.o -o test
 
     ./test
 
@@ -44,7 +44,7 @@ SUITE_profiling_gcc() {
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache miss' 1
 
-    $COMPILER -fprofile-dir=data -fprofile-generate test.o -lgcov -o test
+    $COMPILER -fprofile-generate test.o -o test
 
     ./test
 
@@ -71,7 +71,7 @@ SUITE_profiling_gcc() {
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache miss' 1
 
-    $COMPILER -fprofile-generate -fprofile-dir=data test.o -lgcov -o test
+    $COMPILER -fprofile-generate test.o -o test
 
     ./test
 
@@ -98,7 +98,7 @@ SUITE_profiling_gcc() {
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache miss' 1
 
-    $COMPILER -fprofile-dir=data2 -fprofile-generate=data test.o -lgcov -o test
+    $COMPILER -fprofile-generate test.o -o test
 
     ./test
 


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->

Fixes a failure seen in `make check` when updating ccache to 3.7.12 in conda-forge (https://github.com/conda-forge/ccache-feedstock/pull/17):

```
Running test suite sanitize_blacklist...
ld: library not found for -lgcov
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
./test/suites/profiling.bash: line 79: ./test: No such file or directory
error: data/*.profraw: No such file or directory
error: Could not read profile data/default.profdata: No such file or directory
1 error generated.
Running test suite profiling.....
FAILED
```

I didn't manage to figure out why this change was made, but I think the GCC specific code should have been isolated to `profiling_gcc.bash` instead of also being included in `profiling_.bash`. In the conda-forge update this patch has been used with both GCC 7.3 and Clang 10 without issues.