### PR TITLE
CI: list all configurations explicitly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,15 +3,15 @@ on:
   push:
   pull_request:
 
+env:
+  CMAKE_GENERATOR: Ninja
+  CTEST_OUTPUT_ON_FAILURE: ON
+  VERBOSE: 1
+
 jobs:
   build_and_test:
     name: ${{ matrix.config.os }}-${{ matrix.config.compiler }}-${{ matrix.config.version }}
     runs-on: ${{ matrix.config.os }}
-    env:
-      CMAKE_GENERATOR: Ninja
-      CTEST_OUTPUT_ON_FAILURE: ON
-      VERBOSE: 1
-
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,41 +4,130 @@ on:
   pull_request:
 
 jobs:
-  # These test the standard build on several systems with GCC + Clang.
-  standard_tests:
-    name: ${{ matrix.os }} & ${{ matrix.compiler.CC }}
-    runs-on: ${{ matrix.os }}
+  build_and_test:
+    name: ${{ matrix.config.os }}-${{ matrix.config.compiler }}-${{ matrix.config.version }}
+    runs-on: ${{ matrix.config.os }}
+    env:
+      CMAKE_GENERATOR: Ninja
+      CTEST_OUTPUT_ON_FAILURE: ON
+      VERBOSE: 1
+
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15]
-        compiler:
-          - CC: gcc
-            CXX: g++
-          - CC: clang
-            CXX: clang++
+        config:
+          - os: ubuntu-16.04
+            compiler: gcc
+            version: "4.8" # results in 4.8.5
 
+          - os: ubuntu-16.04
+            compiler: gcc
+            version: "5"
+
+          - os: ubuntu-18.04
+            compiler: gcc
+            version: "6"
+
+          - os: ubuntu-18.04
+            compiler: gcc
+            version: "7"
+
+          - os: ubuntu-18.04
+            compiler: gcc
+            version: "8"
+
+          - os: ubuntu-18.04
+            compiler: gcc
+            version: "9"
+
+          - os: ubuntu-20.04
+            compiler: gcc
+            version: "10"
+
+          # Enable after https://github.com/ccache/ccache/pull/693
+          # - os: ubuntu-16.04
+          #   compiler: clang
+          #   version: "3.5"
+
+          # Enable after https://github.com/ccache/ccache/pull/693
+          # - os: ubuntu-16.04
+          #   compiler: clang
+          #   version: "5.0"
+
+          - os: ubuntu-16.04
+            compiler: clang
+            version: "6.0"
+
+          - os: ubuntu-18.04
+            compiler: clang
+            version: "7"
+
+          - os: ubuntu-18.04
+            compiler: clang
+            version: "8"
+
+          - os: ubuntu-20.04
+            compiler: clang
+            version: "9"
+
+          - os: ubuntu-20.04
+            compiler: clang
+            version: "10"
+
+          - os: macOS-latest
+            compiler: xcode
+            version: "10.3"
+
+          - os: macOS-latest
+            compiler: xcode
+            version: "11.0.0"
+
+          - os: macOS-latest
+            compiler: xcode
+            version: "12.2"
     steps:
+      - name: Install dependencies
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            if [ "${{ matrix.config.os }}" = "ubuntu-20.04" ]; then
+              sudo apt-get install -y ninja-build elfutils libzstd-dev
+            else
+              sudo apt-get install -y ninja-build elfutils libzstd1-dev
+            fi
+
+            if [ "${{ matrix.config.compiler }}" = "gcc" ]; then
+              echo "CC=gcc-${{ matrix.config.version }}" >> $GITHUB_ENV
+              echo "CXX=g++-${{ matrix.config.version }}" >> $GITHUB_ENV
+
+              sudo apt install -y g++-${{ matrix.config.version }} g++-${{ matrix.config.version }}-multilib
+            else
+              echo "CC=clang-${{ matrix.config.version }}" >> $GITHUB_ENV
+              echo "CXX=clang++-${{ matrix.config.version }}" >> $GITHUB_ENV
+
+              sudo apt update
+              sudo apt install -y clang-${{ matrix.config.version }} g++-multilib
+            fi
+          elif [ "${{ runner.os }}" = "macOS" ]; then
+            brew install ninja
+            if [ "${{ matrix.config.compiler }}" = "gcc" ]; then
+              brew install gcc@${{ matrix.config.version }}
+              echo "CC=gcc-${{ matrix.config.version }}" >> $GITHUB_ENV
+              echo "CXX=g++-${{ matrix.config.version }}" >> $GITHUB_ENV
+            else
+              sudo xcode-select -switch /Applications/Xcode_${{ matrix.config.version }}.app
+              echo "CC=clang" >> $GITHUB_ENV
+              echo "CXX=clang++" >> $GITHUB_ENV
+            fi
+          fi
+
       - name: Get source
         uses: actions/checkout@v2
 
-      - name: Install dependencies (Ubuntu 16 & 18)
-        if: startsWith(matrix.os, 'ubuntu') && matrix.os != 'ubuntu-20.04'
-        run: sudo apt-get install elfutils libzstd1-dev
-
-      - name: Install dependencies (Ubuntu 20)
-        if: matrix.os == 'ubuntu-20.04'
-        run: sudo apt-get install elfutils libzstd-dev
-
       - name: Build and test
-        run: ci/build
+        run:  ci/build
         env:
-          CC: ${{ matrix.compiler.CC }}
-          CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI
-          CTEST_OUTPUT_ON_FAILURE: ON
-          CXX: ${{ matrix.compiler.CXX }}
           ENABLE_CACHE_CLEANUP_TESTS: true
-          VERBOSE: 1
+          CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI
 
       - name: Collect testdir from failed tests
         if: failure()
@@ -48,7 +137,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.os }} - ${{ matrix.compiler.CC }} - testdir.tar.xz
+          name: ${{ matrix.config.os }}-${{ matrix.config.compiler }}-{{ matrix.config.version }}-testdir.tar.xz
           path: testdir.tar.xz
 
   specific_tests:
@@ -104,14 +193,6 @@ jobs:
             CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DCMAKE_SYSTEM_NAME=Windows -DZSTD_FROM_INTERNET=ON
             RUN_TESTS: unittest-in-wine
             apt_get: elfutils mingw-w64 wine
-
-          - name: Linux GCC 4.8.5
-            os: ubuntu-16.04
-            CC: gcc-4.8
-            CXX: g++-4.8
-            ENABLE_CACHE_CLEANUP_TESTS: 1
-            CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DWARNINGS_AS_ERRORS=OFF
-            apt_get: elfutils libzstd1-dev g++-4.8
 
           - name: Clang address & UB sanitizer
             os: ubuntu-20.04
@@ -188,7 +269,6 @@ jobs:
           CCACHE_LOC: ${{ matrix.config.CCACHE_LOC }}
           CFLAGS: ${{ matrix.config.CFLAGS }}
           CMAKE_PARAMS: ${{ matrix.config.CMAKE_PARAMS }}
-          CTEST_OUTPUT_ON_FAILURE: ON
           CXX: ${{ matrix.config.CXX }}
           CXXFLAGS: ${{ matrix.config.CXXFLAGS }}
           ENABLE_CACHE_CLEANUP_TESTS: ${{ matrix.config.ENABLE_CACHE_CLEANUP_TESTS }}
@@ -196,7 +276,6 @@ jobs:
           LDFLAGS: ${{ matrix.config.LDFLAGS }}
           RUN_TESTS: ${{ matrix.config.RUN_TESTS }}
           SPECIAL: ${{ matrix.config.SPECIAL }}
-          VERBOSE: 1
         run: ci/build
 
       - name: Collect testdir from failed tests
@@ -222,8 +301,6 @@ jobs:
 
       - name: Run Clang-Format in check mode
         run: misc/format-files --all --check
-        env:
-          VERBOSE: 1
 
   codespell:
     name: Spelling

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build and test
-        run:  ci/build
+        run: ci/build
         env:
           ENABLE_CACHE_CLEANUP_TESTS: true
           CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,12 +4,14 @@ on:
   pull_request:
 
 env:
-  CMAKE_GENERATOR: Ninja
   CTEST_OUTPUT_ON_FAILURE: ON
   VERBOSE: 1
 
 jobs:
   build_and_test:
+    env:
+      CMAKE_GENERATOR: Ninja
+    
     name: ${{ matrix.config.os }}-${{ matrix.config.compiler }}-${{ matrix.config.version }}
     runs-on: ${{ matrix.config.os }}
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSIO
     "The compiler you are using is rather old.\n"
     "If anything goes wrong you might be better off with one listed here:"
     " https://ccache.dev/platform-compiler-language-support.html")
+  
+  # Warnings of those old compilers are probably useless anyway.
+  option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" FALSE)
 endif()
 
 #


### PR DESCRIPTION
Currently CI runs with:
Part 1:
ubuntu-16.04-gcc-5.5.0
ubuntu-16.04-clang-9.0.1
ubuntu-18.04-gcc-7.5.0
ubuntu-18.04-clang-9.0.0
ubuntu-20.04-gcc-9.3.0
ubuntu-20.04-clang-10.0.0
macos-10.15-gcc-11.0.3 (or is it clang, apple clang or xcode?)
macos-10.15-clang-11.0.3 (or is it clang, apple clang or xcode?)

Part 2:
ubuntu-16.04-gcc-4.8.5
ubuntu-18.04-i686-w64-mingw32-gcc-posix (GCC) 7.3-posix
ubuntu-18.04-x86_64-w64-mingw32-gcc-posix (GCC) 9.3-posix

(Determined via adding `${{ matrix.config/compiler.CC }} --version` to build.yaml)

This is less then obvious from build-yaml. And while it runs lots of jobs it doesn't cover as much as it could by carefully selecting the exact os - compiler combinations.