### PR TITLE
Blake3: use C version on ancient clang

### DIFF
--- a/src/third_party/blake3/CMakeLists.txt
+++ b/src/third_party/blake3/CMakeLists.txt
@@ -2,7 +2,9 @@ add_library(blake3 STATIC blake3.c blake3_dispatch.c blake3_portable.c)
 
 target_link_libraries(blake3 PRIVATE standard_settings)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P EQUAL 8
+   AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+            AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0))
   set(blake_source_type asm)
   set(blake_suffix "_x86-64_unix.S")
 else()


### PR DESCRIPTION
The .S file does not compile with clang 3.4 and 3.5.
It seems it's only some optimization and we can as well trivially fall back to the C version.

(Not tested with clang 4, so let's just apply the fallback to anything before 5.0)

This is probably relevant for #689 for the older MacOS versions since they use clang 3.4 by default.