### PR TITLE
Disable some tests on ancient Clang versions

### DIFF
--- a/dockerfiles/ubuntu-14.04/Dockerfile
+++ b/dockerfiles/ubuntu-14.04/Dockerfile
@@ -6,10 +6,11 @@ RUN apt-get update \
         bash \
         build-essential \
         ccache \
-        clang \
+        clang-3.4 \
         curl \
         elfutils \
-        gcc-multilib \
+        g++-multilib \
+        ninja-build \
         wget \
         xsltproc \
  && rm -rf /var/lib/apt/lists/*

--- a/test/suites/modules.bash
+++ b/test/suites/modules.bash
@@ -1,7 +1,9 @@
 SUITE_modules_PROBE() {
     if ! $COMPILER_TYPE_CLANG; then
         echo "-fmodules/-fcxx-modules not supported by compiler"
-        return
+    else
+        touch test.c
+        $COMPILER -fmodules test.c -S || echo "Clang 3.4 does not support modules"
     fi
 }
 

--- a/test/suites/modules.bash
+++ b/test/suites/modules.bash
@@ -3,7 +3,7 @@ SUITE_modules_PROBE() {
         echo "-fmodules/-fcxx-modules not supported by compiler"
     else
         touch test.c
-        $COMPILER -fmodules test.c -S || echo "Clang 3.4 does not support modules"
+        $COMPILER -fmodules test.c -S || echo "compiler does not support modules"
     fi
 }
 

--- a/test/suites/profiling.bash
+++ b/test/suites/profiling.bash
@@ -4,7 +4,7 @@ SUITE_profiling_PROBE() {
         echo "compiler does not support profiling"
     fi
     if ! $COMPILER -fprofile-generate=data -c test.c 2>/dev/null; then
-        echo "compiler does not support profiling with assignment"
+        echo "compiler does not support -fprofile-generate=path"
     fi
     if $COMPILER_TYPE_CLANG && ! command -v llvm-profdata$CLANG_VERSION_SUFFIX >/dev/null; then
         echo "llvm-profdata$CLANG_VERSION_SUFFIX tool not found"

--- a/test/suites/profiling.bash
+++ b/test/suites/profiling.bash
@@ -3,6 +3,9 @@ SUITE_profiling_PROBE() {
     if ! $COMPILER -fprofile-generate -c test.c 2>/dev/null; then
         echo "compiler does not support profiling"
     fi
+    if ! $COMPILER -fprofile-generate=data -c test.c 2>/dev/null; then
+        echo "compiler does not support profiling with assignment"
+    fi
     if $COMPILER_TYPE_CLANG && ! command -v llvm-profdata$CLANG_VERSION_SUFFIX >/dev/null; then
         echo "llvm-profdata$CLANG_VERSION_SUFFIX tool not found"
     fi

--- a/test/suites/profiling_clang.bash
+++ b/test/suites/profiling_clang.bash
@@ -3,6 +3,10 @@ SUITE_profiling_clang_PROBE() {
         echo "compiler is not Clang"
     elif ! command -v llvm-profdata$CLANG_VERSION_SUFFIX >/dev/null; then
         echo "llvm-profdata$CLANG_VERSION_SUFFIX tool not found"
+    elif ! $COMPILER -fdebug-prefix-map -c test.c 2>/dev/null; then
+        echo "compiler does not support -fdebug-prefix-map"
+    elif ! $COMPILER -fprofile-sample-accurate -c test.c 2>/dev/null; then
+        echo "compiler does not support -fdebug-prefix-map"
     fi
 }
 

--- a/test/suites/profiling_clang.bash
+++ b/test/suites/profiling_clang.bash
@@ -3,10 +3,10 @@ SUITE_profiling_clang_PROBE() {
         echo "compiler is not Clang"
     elif ! command -v llvm-profdata$CLANG_VERSION_SUFFIX >/dev/null; then
         echo "llvm-profdata$CLANG_VERSION_SUFFIX tool not found"
-    elif ! $COMPILER -fdebug-prefix-map -c test.c 2>/dev/null; then
+    elif ! $COMPILER -fdebug-prefix-map=x=y -c test.c 2>/dev/null; then
         echo "compiler does not support -fdebug-prefix-map"
     elif ! $COMPILER -fprofile-sample-accurate -c test.c 2>/dev/null; then
-        echo "compiler does not support -fdebug-prefix-map"
+        echo "compiler does not support -fprofile-sample-accurate"
     fi
 }
 

--- a/test/suites/profiling_hip_clang.bash
+++ b/test/suites/profiling_hip_clang.bash
@@ -1,7 +1,7 @@
 SUITE_profiling_hip_clang_PROBE() {
     if ! $COMPILER_TYPE_CLANG; then
         echo "compiler is not Clang"
-    elif ! echo | $COMPILER -x hip --cuda-gpu-arch=gfx900 -nogpulib -c - > /dev/null; then
+    elif ! echo | $COMPILER -x hip --cuda-gpu-arch=gfx900 -nogpulib -c - 2> /dev/null; then
         echo "Hip not supported"
     fi
 }

--- a/test/suites/sanitize_blacklist.bash
+++ b/test/suites/sanitize_blacklist.bash
@@ -43,7 +43,8 @@ SUITE_sanitize_blacklist() {
     expect_stat 'files in cache' 4
 
     # -------------------------------------------------------------------------
-    TEST "Compile failed"
+    # Not "failed" as it triggers regex 'fail' detection on some older setups.
+    TEST "Compile fai-led"
 
     if $REAL_COMPILER -c -fsanitize-blacklist=nosuchfile.txt test1.c 2>expected.stderr; then
         test_failed "Expected an error compiling test1.c"

--- a/test/suites/sanitize_blacklist.bash
+++ b/test/suites/sanitize_blacklist.bash
@@ -43,8 +43,7 @@ SUITE_sanitize_blacklist() {
     expect_stat 'files in cache' 4
 
     # -------------------------------------------------------------------------
-    # Not "failed" as it triggers regex 'fail' detection on some older setups.
-    TEST "Compile fai-led"
+    TEST "Unsuccessful compilation"
 
     if $REAL_COMPILER -c -fsanitize-blacklist=nosuchfile.txt test1.c 2>expected.stderr; then
         test_failed "Expected an error compiling test1.c"

--- a/test/suites/serialize_diagnostics.bash
+++ b/test/suites/serialize_diagnostics.bash
@@ -31,8 +31,7 @@ SUITE_serialize_diagnostics() {
     expect_equal_content expected.dia test.dia
 
     # -------------------------------------------------------------------------
-    # Not "failed" as it triggers regex 'fail' detection on some older setups.
-    TEST "Compile fai-led"
+    TEST "Unsuccessful compilation"
 
     echo "bad source" >error.c
     if $REAL_COMPILER -c --serialize-diagnostics expected.dia error.c 2>expected.stderr; then

--- a/test/suites/serialize_diagnostics.bash
+++ b/test/suites/serialize_diagnostics.bash
@@ -31,7 +31,8 @@ SUITE_serialize_diagnostics() {
     expect_equal_content expected.dia test.dia
 
     # -------------------------------------------------------------------------
-    TEST "Compile failed"
+    # Not "failed" as it triggers regex 'fail' detection on some older setups.
+    TEST "Compile fai-led"
 
     echo "bad source" >error.c
     if $REAL_COMPILER -c --serialize-diagnostics expected.dia error.c 2>expected.stderr; then

--- a/test/suites/split_dwarf.bash
+++ b/test/suites/split_dwarf.bash
@@ -2,6 +2,8 @@ SUITE_split_dwarf_PROBE() {
     touch test.c
     if ! $REAL_COMPILER -c -gsplit-dwarf test.c 2>/dev/null || [ ! -e test.dwo ]; then
         echo "-gsplit-dwarf not supported by compiler"
+    elif ! $COMPILER -fdebug-prefix-map=a=b -c test.c 2>/dev/null; then
+        echo "-fdebug-prefix-map not supported by compiler"
     fi
 }
 


### PR DESCRIPTION
We need to disable/fix some tests on clang 3.
Unfortunately clang 5 is also affected.

(Currently not tested with clang 4)

This is definitely not pretty and I would appreciate a better fix!

Discovered in #690 and probably relevant for #689 since the old MacOS versions are using AppleClang based on clang 3.4.