### PR TITLE
Use BLAKE3 machinery for detecting AVX2 support

### DIFF
--- a/cmake/GenerateConfigurationFile.cmake
+++ b/cmake/GenerateConfigurationFile.cmake
@@ -53,7 +53,16 @@ check_struct_has_member("struct statfs" f_fstypename sys/mount.h
                         HAVE_STRUCT_STATFS_F_FSTYPENAME)
 
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag(-mavx2 HAVE_AVX2)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0")
+  # Old GCC versions don't have the required header support.
+  message(STATUS "Detected unsupported compiler for HAVE_AVX2 - disabled")
+  set(HAVE_AVX2 FALSE)
+else()
+  check_cxx_compiler_flag(-mavx2 HAVE_AVX2)
+endif()
+
 
 list(APPEND CMAKE_REQUIRED_LIBRARIES ws2_32)
 list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES ws2_32)

--- a/src/hashutil.cpp
+++ b/src/hashutil.cpp
@@ -28,27 +28,14 @@
 #include "execute.hpp"
 #include "macroskip.hpp"
 
+#include "third_party/blake3/blake3_cpu_supports_avx2.h"
+
 #ifdef INODE_CACHE_SUPPORTED
 #  include "InodeCache.hpp"
 #endif
 
 #ifdef _WIN32
 #  include "Win32Util.hpp"
-#endif
-
-// With older GCC (libgcc), __builtin_cpu_supports("avx2) returns true if AVX2
-// is supported by the CPU but disabled by the OS. This was fixed in GCC 8, 7.4
-// and 6.5 (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85100).
-//
-// For Clang it seems to be correct if compiler-rt is used as -rtlib, at least
-// as of 3.9 (see https://bugs.llvm.org/show_bug.cgi?id=25510). But if libgcc is
-// used we have the same problem as mentioned above. Unfortunately there doesn't
-// seem to be a way to detect which one is used, or the version of libgcc when
-// used by Clang, so assume that it works with Clang >= 3.9.
-#if !(__GNUC__ >= 8 || (__GNUC__ == 7 && __GNUC_MINOR__ >= 4)                  \
-      || (__GNUC__ == 6 && __GNUC_MINOR__ >= 5) || __clang_major__ > 3         \
-      || (__clang_major__ == 3 && __clang_minor__ >= 9))
-#  undef HAVE_AVX2
 #endif
 
 #ifdef HAVE_AVX2
@@ -221,7 +208,7 @@ int
 check_for_temporal_macros(string_view str)
 {
 #ifdef HAVE_AVX2
-  if (__builtin_cpu_supports("avx2")) {
+  if (blake3_cpu_supports_avx2()) {
     return check_for_temporal_macros_avx2(str);
   }
 #endif

--- a/src/third_party/blake3/CMakeLists.txt
+++ b/src/third_party/blake3/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(blake3 STATIC blake3.c blake3_dispatch.c blake3_portable.c)
+add_library(blake3 STATIC blake3.c blake3_dispatch_ccache.c blake3_portable.c)
 
 target_link_libraries(blake3 PRIVATE standard_settings)
 

--- a/src/third_party/blake3/blake3_cpu_supports_avx2.h
+++ b/src/third_party/blake3/blake3_cpu_supports_avx2.h
@@ -1,0 +1,18 @@
+#ifndef BLAKE3_CPU_SUPPORTS_AVX2_H
+#define BLAKE3_CPU_SUPPORTS_AVX2_H
+
+// This file is a ccache modification to BLAKE3
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool blake3_cpu_supports_avx2();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/third_party/blake3/blake3_dispatch_ccache.c
+++ b/src/third_party/blake3/blake3_dispatch_ccache.c
@@ -1,0 +1,10 @@
+// This file is a ccache modification to BLAKE3
+
+#include "blake3_dispatch.c"
+
+#include "blake3_cpu_supports_avx2.h"
+
+bool blake3_cpu_supports_avx2()
+{
+  return get_cpu_features() & AVX2;
+}


### PR DESCRIPTION
Instead of relying on the sometimes broken __builtin_cpu_support. This hopefully also fixes the build error on Mac OSX 10.11 reported in a comment in #689.

This exposes an internal detail of BLAKE3, but it's hopefully a small change that shouldn't cause problems when upgrading BLAKE3.