### PR TITLE
Fix order of commands in third_party cmake

### DIFF
--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -1,13 +1,10 @@
-set(third_party_source_files base32hex.c format.cpp xxhash.c)
-
+add_library(third_party_lib STATIC base32hex.c format.cpp xxhash.c)
 if(NOT MSVC)
-  list(APPEND third_party_source_files getopt_long.c)
+  target_sources(third_party_lib PRIVATE getopt_long.c)
 else()
-  list(APPEND third_party_source_files win32/getopt.c)
+  target_sources(third_party_lib PRIVATE win32/getopt.c)
   target_compile_definitions(third_party_lib PUBLIC -DSTATIC_GETOPT)
 endif()
-
-add_library(third_party_lib STATIC ${third_party_source_files})
 
 if(ENABLE_TRACING)
   target_sources(third_party_lib PRIVATE minitrace.c)


### PR DESCRIPTION
Fix order of commands in third_party cmake
fixes #697

@mumpitzstuff can you try whether this resolves your issue? Unfortunately I cannot try MSVC myself right now. I assume you have the problem with MSVC.