### PR TITLE
Ignore -ivfsoverlay parameter

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -272,7 +272,9 @@ parse_sloppiness(const std::string& value)
       result |= SLOPPY_LOCALE;
     } else if (token == "modules") {
       result |= SLOPPY_MODULES;
-    } // else: ignore unknown value for forward compatibility
+    } else if (token == "ivfsoverlay") {
+      result |= SLOPPY_IVFOVERLAY;
+    }// else: ignore unknown value for forward compatibility
     start = value.find_first_not_of(", ", end);
   }
   return result;
@@ -311,6 +313,9 @@ format_sloppiness(uint32_t sloppiness)
   }
   if (sloppiness & SLOPPY_MODULES) {
     result += "modules, ";
+  }
+  if (sloppiness & SLOPPY_IVFOVERLAY) {
+    result += "ivfsoverlay, ";
   }
   if (!result.empty()) {
     // Strip last ", ".

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -274,7 +274,7 @@ parse_sloppiness(const std::string& value)
       result |= SLOPPY_MODULES;
     } else if (token == "ivfsoverlay") {
       result |= SLOPPY_IVFOVERLAY;
-    }// else: ignore unknown value for forward compatibility
+    } // else: ignore unknown value for forward compatibility
     start = value.find_first_not_of(", ", end);
   }
   return result;

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -230,6 +230,17 @@ process_arg(Context& ctx,
     return nullopt;
   }
 
+  // Ignore Xcode -ivfsoverlay <path to yaml file> to not detect multiple input files
+  if (args[i] == "-ivfsoverlay") {
+    i++;
+    if (i == args.size()) {
+      log("-ivfsoverlay lacks an argument");
+      return Statistic::bad_compiler_arguments;
+    }
+    state.common_args.push_back(args[i]);
+    return nullopt;
+  }
+
   // Special case for -E.
   if (args[i] == "-E") {
     return Statistic::called_for_preprocessing;

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -230,11 +230,18 @@ process_arg(Context& ctx,
     return nullopt;
   }
 
-  // Ignore Xcode -ivfsoverlay <path to yaml file> to not detect multiple input files
+  // Ignore Xcode -ivfsoverlay <path to yaml file>
+  // to not detect multiple input files.
   if (args[i] == "-ivfsoverlay") {
+    if (!(config.sloppiness() & SLOPPY_IVFOVERLAY)) {
+      LOG_RAW(
+        "You have to specify \"ivfsoverlay\" sloppiness when using"
+        " -ivfsoverlay to get hits");
+      return Statistic::bad_compiler_arguments;
+    }
     i++;
     if (i == args.size()) {
-      log("-ivfsoverlay lacks an argument");
+      LOG_RAW("-ivfsoverlay lacks an argument");
       return Statistic::bad_compiler_arguments;
     }
     state.common_args.push_back(args[i]);

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -51,6 +51,8 @@ const uint32_t SLOPPY_CLANG_INDEX_STORE = 1 << 7;
 const uint32_t SLOPPY_LOCALE = 1 << 8;
 // Allow caching even if -fmodules is used.
 const uint32_t SLOPPY_MODULES = 1 << 9;
+// Ignore virtual file system (VFS) overlay file.
+const uint32_t SLOPPY_IVFOVERLAY = 1 << 10;
 
 using FindExecutableFunction =
   std::function<std::string(const Context& ctx,


### PR DESCRIPTION
Ignores `-ivfsoverlay <filepath>` parameter that is used in Xcode with an optional new `ivfsoverlay` sloppiness parameter.

First of, congrats to ccache v4 release, it's amazing! I'm excited that `-fmodules` is supported and this will greatly speed up our compilation. I tried to enable everything and noticed that there's a different error, ccache detects multiple source files as input.

```
[2020-10-22T13:28:08.137445 43404] Hostname: steipete-mbp-i9.local
[2020-10-22T13:28:08.137484 43404] Working directory: /Users/steipete/Projects/PSPDFKit/iOS/PSPDFKit
[2020-10-22T13:28:08.137910 43404] Set profile directory to .
[2020-10-22T13:28:08.137983 43404] /Users/steipete/Builds/PSPDFKit-apwojecgwxmuoieabhwzqzmecixq/Index/DataStore is not a regular file, not considering as input file
[2020-10-22T13:28:08.138633 43404] Multiple input files: /Users/steipete/Builds/PSPDFKit-apwojecgwxmuoieabhwzqzmecixq/Build/Intermediates.noindex/PSPDFKit.build/Debug-iphonesimulator/PSPDFKit.framework.build/all-product-headers.yaml and /Users/steipete/Projects/PSPDFKit/iOS/PSPDFKit/Glyphs/PSPDFTextBlock.m
[2020-10-22T13:28:08.138868 43404] Failed; falling back to running the real compiler
[2020-10-22T13:28:08.139051 43404] Executing /usr/bin/clang -x objective-c -target x86_64-apple-ios12.0-simulator -fmessage-length=0 -fdiagnostics-show-note-include-stack (...) -ivfsoverlay /Users/steipete/Builds/PSPDFKit-apwojecgwxmuoieabhwzqzmecixq/Build/Intermediates.noindex/PSPDFKit.build/Debug-iphonesimulator/PSPDFKit.framework.build/all-product-headers.yaml -MMD -MT dependencies -MF /Users/steipete/Builds/PSPDFKit-apwojecgwxmuoieabhwzqzmecixq/Build/Intermediates.noindex/PSPDFKit.build/Debug-iphonesimulator/PSPDFKit.framework.build/Objects-normal/x86_64/PSPDFTextBlock.d --serialize-diagnostics /Users/steipete/Builds/PSPDFKit-apwojecgwxmuoieabhwzqzmecixq/Build/Intermediates.noindex/PSPDFKit.build/Debug-iphonesimulator/PSPDFKit.framework.build/Objects-normal/x86_64/PSPDFTextBlock.dia -c /Users/steipete/Projects/PSPDFKit/iOS/PSPDFKit/Glyphs/PSPDFTextBlock.m -o /Users/steipete/Builds/PSPDFKit-apwojecgwxmuoieabhwzqzmecixq/Build/Intermediates.noindex/PSPDFKit.build/Debug-iphonesimulator/PSPDFKit.framework.build/Objects-normal/x86_64/PSPDFTextBlock.o
[2020-10-22T13:28:08.139143 43404] Result: multiple source files
```

(I removed most parameters that are not relevant for this to improve readability)

The `all-product-headers.yaml` file contains following content:

```
{"case-sensitive":"false","roots":[{"contents":[{"external-contents":"/Users/steipete/Projects/PSPDFKit/iOS/PSPDFKit/Encryption/PSPDFAESCryptoDataProvider.h","name":"PSPDFAESCryptoDataProvider.h","type":"file"},{"external-contents":"/Users/steipete/Projects/PSPDFKit/iOS/PSPDFKit/Encryption/PSPDFAESCryptoDataSink.h","name":"PSPDFAESCryptoDataSink.h","type":"file"},{"exte
```

The ivsoverlay feature seems to be used when combining Objective-C and Swift code, to provide a virtual file system overlay. I'm not 100% certain in what way this affects caching, but ignoring the property works great and and produces correct results with cached content.

This is my first contribution, I read the guideline, but happy to change things or provide more info to help with this project.