### PR TITLE
Fail gracefully on ancient compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,29 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 #
+#
+# Minimum compiler requirements
+# (Fail gracefully instead of cryptic C++ error messages)
+#
+#
+
+# Clang 3.4 and AppleClang 6.0 do not compile doctest.
+# Gcc 4.8.5 has been the minimum version for quite a while.
+if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)
+OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8.5)
+OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0))
+  message(FATAL_ERROR "The compiler you are using is too old, sorry.\nYou need one listed here: https://ccache.dev/platform-compiler-language-support.html")
+endif()
+
+# All Clang problems / special handling ccache has is because of 3.5.
+# All gcc problems / special handling ccache has is because of 4.8.5.
+if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6)
+OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0))
+  message(WARNING "The compiler you are using is rather old.\nIf anything goes wrong you might be better of with one listed here: https://ccache.dev/platform-compiler-language-support.html")
+endif()
+
+
+#
 # Settings
 #
 include(StandardSettings)


### PR DESCRIPTION
As suggested in #695 by @ryandesign ccache compilation should fail with a human readable error in case of unsupported compilers.

This would technically close #695.