### PR TITLE
Fall back to version "unknown" when Git is not installed

### DIFF
--- a/cmake/CcacheVersion.cmake
+++ b/cmake/CcacheVersion.cmake
@@ -12,8 +12,7 @@
 #    configuration.
 # 3. Building from a Git repository. In this case the version will be a proper
 #    version if building a tagged commit, otherwise "branch.hash(+dirty)". In
-#    case where git is not available, version will be 'unknown' (e.g. mounting
-#    your source directory into docker without installing git).
+#    case Git is not available, the version will be "unknown".
 
 set(version_info "$Format:%H %D$")
 

--- a/cmake/CcacheVersion.cmake
+++ b/cmake/CcacheVersion.cmake
@@ -11,7 +11,9 @@
 #    version_info has not been substituted). In this case we fail the
 #    configuration.
 # 3. Building from a Git repository. In this case the version will be a proper
-#    version if building a tagged commit, otherwise "branch.hash(+dirty)".
+#    version if building a tagged commit, otherwise "branch.hash(+dirty)". In
+#    case where git is not available, version will be 'unknown' (e.g. mounting
+#    your source directory into docker without installing git).
 
 set(version_info "$Format:%H %D$")
 
@@ -30,7 +32,8 @@ elseif(EXISTS "${CMAKE_SOURCE_DIR}/.git")
   # Scenario 3.
   find_package(Git QUIET)
   if(NOT GIT_FOUND)
-    message(SEND_ERROR "Could not find git")
+    set(VERSION "unknown")
+    message(WARNING "Could not find git")
   endif()
 
   macro(git)

--- a/cmake/CcacheVersion.cmake
+++ b/cmake/CcacheVersion.cmake
@@ -33,31 +33,31 @@ elseif(EXISTS "${CMAKE_SOURCE_DIR}/.git")
   if(NOT GIT_FOUND)
     set(VERSION "unknown")
     message(WARNING "Could not find git")
+  else()
+    macro(git)
+      execute_process(
+        COMMAND "${GIT_EXECUTABLE}" ${ARGN}
+        OUTPUT_VARIABLE git_stdout OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_VARIABLE git_stderr ERROR_STRIP_TRAILING_WHITESPACE)
+    endmacro()
+
+    git(describe --abbrev=8 --dirty)
+    if(git_stdout MATCHES "^v([^-]+)(-dirty)?$")
+      set(VERSION "${CMAKE_MATCH_1}")
+      if(NOT "${CMAKE_MATCH_2}" STREQUAL "")
+        set(VERSION "${VERSION}+dirty")
+      endif()
+    elseif(git_stdout MATCHES "^v[^-]+-[0-9]+-g([0-9a-f]+)(-dirty)?$")
+      set(hash "${CMAKE_MATCH_1}")
+      set(dirty "${CMAKE_MATCH_2}")
+      string(REPLACE "-" "+" dirty "${dirty}")
+
+      git(rev-parse --abbrev-ref HEAD)
+      set(branch "${git_stdout}")
+
+      set(VERSION "${branch}.${hash}${dirty}")
+    endif() # else: fail below
   endif()
-
-  macro(git)
-    execute_process(
-      COMMAND "${GIT_EXECUTABLE}" ${ARGN}
-      OUTPUT_VARIABLE git_stdout OUTPUT_STRIP_TRAILING_WHITESPACE
-      ERROR_VARIABLE git_stderr ERROR_STRIP_TRAILING_WHITESPACE)
-  endmacro()
-
-  git(describe --abbrev=8 --dirty)
-  if(git_stdout MATCHES "^v([^-]+)(-dirty)?$")
-    set(VERSION "${CMAKE_MATCH_1}")
-    if(NOT "${CMAKE_MATCH_2}" STREQUAL "")
-      set(VERSION "${VERSION}+dirty")
-    endif()
-  elseif(git_stdout MATCHES "^v[^-]+-[0-9]+-g([0-9a-f]+)(-dirty)?$")
-    set(hash "${CMAKE_MATCH_1}")
-    set(dirty "${CMAKE_MATCH_2}")
-    string(REPLACE "-" "+" dirty "${dirty}")
-
-    git(rev-parse --abbrev-ref HEAD)
-    set(branch "${git_stdout}")
-
-    set(VERSION "${branch}.${hash}${dirty}")
-  endif() # else: fail below
 endif()
 
 if(VERSION STREQUAL "")


### PR DESCRIPTION
I was just looking into clang 3.4 and noticed the following strange behavior: cmake command failed due to missing git.

How to reproduce:
1) change ubuntu-14.04/Dockerfile from clang to clang-3.4
2) `CC=clang CXX=clang++ CMAKE_PARAMS="-DZSTD_FROM_INTERNET=ON" misc/build-in-docker ubuntu-14.04`

It fails since git is not installed into the docker image. Why should it? I'm quite fine with not knowing the git hash within docker.