### PR TITLE
Support compilation on Clang 3.4

### DIFF
--- a/src/third_party/doctest.h
+++ b/src/third_party/doctest.h
@@ -301,11 +301,15 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
 #define DOCTEST_NOINLINE __declspec(noinline)
 #define DOCTEST_UNUSED
 #define DOCTEST_ALIGNMENT(x)
-#else // MSVC
+#elif DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 5, 0)
+#define DOCTEST_NOINLINE
+#define DOCTEST_UNUSED
+#define DOCTEST_ALIGNMENT(x)
+#else
 #define DOCTEST_NOINLINE __attribute__((noinline))
 #define DOCTEST_UNUSED __attribute__((unused))
 #define DOCTEST_ALIGNMENT(x) __attribute__((aligned(x)))
-#endif // MSVC
+#endif
 
 #ifndef DOCTEST_NORETURN
 #define DOCTEST_NORETURN [[noreturn]]


### PR DESCRIPTION
While the compiler is rather old it seems trivial enough to support clang 3.4 as it requires only a trivial change.
Reported to doctest at https://github.com/onqtam/doctest/pull/428

Note: it's also possible to add clang-3.4 to GitHub Actions. I'll do that once all the puzzle pieces that are required (#704, #693, #690 etc) are merged.
It's something like:
```
            if [ "${{ matrix.config.version }}" = "3.4" ]; then
              echo "CC=clang" >> $GITHUB_ENV
              echo "CXX=clang++" >> $GITHUB_ENV
              echo "CXXFLAGS=-stdlib=libc++" >> $GITHUB_ENV

              # clang-3.4 is available from trusty
              sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ trusty main"
              sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ trusty universe"
            fi
```

Note: this will need some small adjustment for AppleClang. But I simply want to get clang 3.4 completely working first.