### PR TITLE
MinGW: Fix path normalization issues

### DIFF
--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -501,4 +501,10 @@ void write_file(const std::string& path,
                 const std::string& data,
                 std::ios_base::openmode open_mode = std::ios::binary);
 
+// Replaces `from` with `to` in `str` in-place
+void
+str_replace(std::string &str,
+            const std::string &from,
+            const std::string &to);
+
 } // namespace Util

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -653,6 +653,13 @@ process_preprocessed_file(Context& ctx,
       }
       // p and q span the include file path.
       std::string inc_path(p, q - p);
+#ifdef _WIN32
+      // gcc-E [file.c] -g adds CWD with double forward slashes
+      // like:
+      // # 1 "C:\\msys64\\home\\user\\test//"
+      // double forward slashes should be replaced with simple slashes
+      Util::str_replace(inc_path, "\\\\", "\\");
+#endif
       if (!ctx.has_absolute_include_headers) {
         ctx.has_absolute_include_headers = Util::is_absolute_path(inc_path);
       }


### PR DESCRIPTION
Based on MSYS2 patch with some improvements

For example, if base_dir is D:\mydir and the input is D:/mydir/foo it
wasn't transformed to a relative path.