### PR TITLE
Fix result_name_from_depfile by parsing depfile in Makefile syntax

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -687,10 +687,9 @@ use_relative_paths_in_depfile(const Context& ctx)
 }
 
 static inline bool
-is_blank(std::string s)
+is_blank(const std::string& s)
 {
-  return s.empty()
-         || all_of(s.begin(), s.end(), [](char c) { return isspace(c); });
+  return std::all_of(s.begin(), s.end(), [](char c) { return isspace(c); });
 }
 
 std::vector<std::string>

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -694,7 +694,7 @@ is_blank(std::string s)
 }
 
 std::vector<std::string>
-parse_depfile(string_view input)
+parse_depfile(string_view file_content)
 {
   std::vector<std::string> result;
 
@@ -702,13 +702,13 @@ parse_depfile(string_view input)
   // This is not perfect parser, however, compilers don't generate a depfile
   // that contains a complex syntax such as single or double quoted string,
   // therefore, this is enough for parsing a depfile.
-  const size_t length = input.size();
+  const size_t length = file_content.size();
   std::string token;
   size_t p{0};
   while (p < length) {
     // Each token is separated by the space.
-    if (isspace(input[p])) {
-      while (p < length && isspace(input[p])) {
+    if (isspace(file_content[p])) {
+      while (p < length && isspace(file_content[p])) {
         p++;
       }
       if (!is_blank(token)) {
@@ -718,24 +718,24 @@ parse_depfile(string_view input)
       continue;
     }
 
-    char c{input[p]};
+    char c{file_content[p]};
 
     // Characters can be escaped by the backslash.
     if (c == '\\') {
       p++;
       if (p < length) {
         // Backslash/newline is ignored.
-        if (input[p] == '\n') {
+        if (file_content[p] == '\n') {
           p++;
           if (p < length) {
             // The following leading prefix which is tab is ignored.
-            if (input[p] == '\t') {
+            if (file_content[p] == '\t') {
               p++;
             }
           }
           continue;
         }
-        c = input[p];
+        c = file_content[p];
       } else {
         continue;
       }

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -703,7 +703,7 @@ parse_depfile(string_view file_content)
   std::string token;
   size_t p{0};
   while (p < length) {
-    // Each token is separated by a space.
+    // Each token is separated by spaces.
     if (isspace(file_content[p])) {
       while (p < length && isspace(file_content[p])) {
         p++;
@@ -730,7 +730,7 @@ parse_depfile(string_view file_content)
           c = next;
           p++;
           break;
-        // For this parser, it can treat backslash-newline as just a space.
+        // For this parser, it can treat a backslash-newline as just a space.
         // Therefore simply skip a backslash.
         case '\n':
           p++;
@@ -742,7 +742,7 @@ parse_depfile(string_view file_content)
       if (p + 1 < length) {
         const char next{file_content[p + 1]};
         switch (next) {
-        // A dollar sign can be followed by a dollar sign and lave it as-is.
+        // A dollar sign can be followed by a dollar sign and leave it as-is.
         case '$':
           c = next;
           p++;

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -26,6 +26,7 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 class Context;
 

--- a/src/ccache.hpp
+++ b/src/ccache.hpp
@@ -22,6 +22,7 @@
 #include "system.hpp"
 
 #include "third_party/nonstd/optional.hpp"
+#include "third_party/nonstd/string_view.hpp"
 
 #include <functional>
 #include <string>
@@ -62,3 +63,4 @@ void find_compiler(Context& ctx,
                    const FindExecutableFunction& find_executable_function);
 nonstd::optional<std::string>
 rewrite_dep_file_paths(const Context& ctx, const std::string& file_content);
+std::vector<std::string> parse_depfile(nonstd::string_view file_content);

--- a/unittest/test_ccache.cpp
+++ b/unittest/test_ccache.cpp
@@ -202,40 +202,78 @@ TEST_CASE("parse_depfile")
   SUBCASE("Parse simple depfile")
   {
     std::vector<std::string> result = parse_depfile("cat.o: meow meow purr");
-    CHECK(result.size() == 4);
+    REQUIRE(result.size() == 4);
     CHECK(result[0] == "cat.o:");
     CHECK(result[1] == "meow");
     CHECK(result[2] == "meow");
     CHECK(result[3] == "purr");
   }
 
+  SUBCASE("Parse depfile with a dollar sign followed by a dollar sign")
+  {
+    std::vector<std::string> result = parse_depfile("cat.o: meow$$");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow$");
+  }
+
+  SUBCASE("Parse depfile with a dollar sign followed by an alphabet")
+  {
+    std::vector<std::string> result = parse_depfile("cat.o: meow$w");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow$w");
+  }
+
+  SUBCASE("Parse depfile with a backslash followed by a number sign or a colon")
+  {
+    std::vector<std::string> result = parse_depfile("cat.o: meow\\# meow\\:");
+    REQUIRE(result.size() == 3);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow#");
+    CHECK(result[2] == "meow:");
+  }
+
+  SUBCASE("Parse depfile with a backslash followed by an alphabet")
+  {
+    std::vector<std::string> result = parse_depfile("cat.o: meow\\w purr\\r");
+    REQUIRE(result.size() == 3);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow\\w");
+    CHECK(result[2] == "purr\\r");
+  }
+
+  SUBCASE("Parse depfile with a backslash followed by a space or a tab")
+  {
+    std::vector<std::string> result =
+      parse_depfile("cat.o: meow\\ meow purr\\\tpurr");
+    REQUIRE(result.size() == 3);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow meow");
+    CHECK(result[2] == "purr\tpurr");
+  }
+
+  SUBCASE("Parse depfile with backslashes followed by a space or a tab")
+  {
+    std::vector<std::string> result =
+      parse_depfile("cat.o: meow\\\\\\ meow purr\\\\ purr");
+    REQUIRE(result.size() == 4);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow\\ meow");
+    CHECK(result[2] == "purr\\");
+    CHECK(result[3] == "purr");
+  }
+
   SUBCASE("Parse depfile with a backslash newline")
   {
     std::vector<std::string> result =
-      parse_depfile("cat.o: meow\\\nmeow\\\n purr");
-    CHECK(result.size() == 3);
+      parse_depfile("cat.o: meow\\\nmeow\\\n purr\\\n\tpurr");
+    REQUIRE(result.size() == 5);
     CHECK(result[0] == "cat.o:");
-    CHECK(result[1] == "meowmeow");
-    CHECK(result[2] == "purr");
-  }
-
-  SUBCASE("Parse depfile with a backslash newline with a leading prefix")
-  {
-    std::vector<std::string> result =
-      parse_depfile("cat.o: meow\\\n\tmeow\\\n\t purr");
-    CHECK(result.size() == 3);
-    CHECK(result[0] == "cat.o:");
-    CHECK(result[1] == "meowmeow");
-    CHECK(result[2] == "purr");
-  }
-
-  SUBCASE("Parse depfile with an escaped character")
-  {
-    std::vector<std::string> result = parse_depfile("cat.o: meow\\ meow purr");
-    CHECK(result.size() == 3);
-    CHECK(result[0] == "cat.o:");
-    CHECK(result[1] == "meow meow");
-    CHECK(result[2] == "purr");
+    CHECK(result[1] == "meow");
+    CHECK(result[2] == "meow");
+    CHECK(result[3] == "purr");
+    CHECK(result[4] == "purr");
   }
 
   SUBCASE("Parse depfile with a new line")
@@ -245,25 +283,33 @@ TEST_CASE("parse_depfile")
     // However, parse_depfile is parsing it to each token, which is expected.
     std::vector<std::string> result =
       parse_depfile("cat.o: meow\nmeow\npurr\n");
-    CHECK(result.size() == 4);
+    REQUIRE(result.size() == 4);
     CHECK(result[0] == "cat.o:");
     CHECK(result[1] == "meow");
     CHECK(result[2] == "meow");
     CHECK(result[3] == "purr");
   }
 
-  SUBCASE("Parse depfile with an incomplete escaped character")
+  SUBCASE("Parse depfile with a trailing dollar sign")
+  {
+    std::vector<std::string> result = parse_depfile("cat.o: meow$");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow$");
+  }
+
+  SUBCASE("Parse depfile with a trailing backslash")
   {
     std::vector<std::string> result = parse_depfile("cat.o: meow\\");
-    CHECK(result.size() == 2);
+    REQUIRE(result.size() == 2);
     CHECK(result[0] == "cat.o:");
-    CHECK(result[1] == "meow");
+    CHECK(result[1] == "meow\\");
   }
 
   SUBCASE("Parse depfile with a trailing backslash newline")
   {
     std::vector<std::string> result = parse_depfile("cat.o: meow\\\n");
-    CHECK(result.size() == 2);
+    REQUIRE(result.size() == 2);
     CHECK(result[0] == "cat.o:");
     CHECK(result[1] == "meow");
   }


### PR DESCRIPTION
**Problems**

`result_name_from_depfile` is simply split depfile content with a space
which breaks the file path contains a space, which is often happening
on Apple platform developments such as iOS application.

Currently if users are using `ccache` with a file located in a path with a space like
`path/with/a/space may/fail`, the log may contains following errors:
```
[2020-11-04T10:08:41.118646 54991] Disabling direct mode
[2020-11-04T10:08:41.118667 54991] Failed to stat path/with/a/space\: No such file or directory
[2020-11-04T10:08:41.118679 54991] Failed to stat may/fail: No such file or directory
...
```

**Solution**

Parse depfile by taking care of escaped characters.

A depfile that compilers generate is in Makefile format which may
contain escaped characters by the backslash, backslash newline and
leading prefix character, which should be ignored.

It could have more complex syntax such as single or double quoted
string, however, compilers don't generate such complex format,
taking care of escaped characters is sufficient.