### PR TITLE
Link with libatomic when needed

### DIFF
--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -47,6 +47,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^GNU|(Apple)?Clang$")
       INTERFACE -fsanitize=${SANITIZER})
   endforeach()
 
+  include(StdAtomic)
+
 elseif(MSVC)
   target_compile_options(standard_settings INTERFACE /std:c++latest /Zc:preprocessor /Zc:__cplusplus /D_CRT_SECURE_NO_WARNINGS)
 endif()

--- a/cmake/StdAtomic.cmake
+++ b/cmake/StdAtomic.cmake
@@ -1,0 +1,31 @@
+# Check if std::atomic needs -latomic
+
+include(CheckCXXSourceCompiles)
+
+set(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX11_STANDARD_COMPILE_OPTION})
+set(
+  check_std_atomic_source_code
+  [=[
+    #include <atomic>
+    int main()
+    {
+      std::atomic<long long> x;
+      (void)x.load();
+      return 0;
+    }
+  ]=])
+
+check_cxx_source_compiles("${check_std_atomic_source_code}" std_atomic_without_libatomic)
+
+if(NOT std_atomic_without_libatomic)
+  set(CMAKE_REQUIRED_LIBRARIES atomic)
+  check_cxx_source_compiles("${check_std_atomic_source_code}" std_atomic_with_libatomic)
+  set(CMAKE_REQUIRED_LIBRARIES)
+  if(NOT std_atomic_with_libatomic)
+    message(FATAL_ERROR "Toolchain doesn't support std::atomic with nor without -latomic")
+  else()
+    target_link_libraries(standard_settings INTERFACE atomic)
+  endif()
+endif()
+
+set(CMAKE_REQUIRED_FLAGS)


### PR DESCRIPTION
Linking with libatomic is apparently needed when using `<atomic>` functionality with GCC on ARM and PowerPC.

Fixes #720 and fixes #721.