### PR TITLE
MinGW: Default to static linking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -192,7 +192,7 @@ jobs:
             CC: x86_64-w64-mingw32-gcc-posix
             CXX: x86_64-w64-mingw32-g++-posix
             ENABLE_CACHE_CLEANUP_TESTS: 1
-            CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DCMAKE_SYSTEM_NAME=Windows -DZSTD_FROM_INTERNET=ON -DSTATIC_LINK=ON
+            CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DCMAKE_SYSTEM_NAME=Windows -DZSTD_FROM_INTERNET=ON
             RUN_TESTS: unittest-in-wine
             apt_get: elfutils mingw-w64 wine
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -261,7 +261,7 @@ jobs:
 
       - name: Run apt-get
         if: matrix.config.apt_get != ''
-        run: sudo apt-get install ${{ matrix.config.apt_get }}
+        run: sudo apt-get update && sudo apt-get install ${{ matrix.config.apt_get }}
 
       - name: Build and test
         env:
@@ -314,7 +314,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install codespell
-        run: sudo apt-get install codespell
+        run: sudo apt-get update && sudo apt-get install codespell
 
       - name: Run codespell
         run: codespell -q 7 -S ".git,LICENSE.adoc,./src/third_party/*" -I misc/codespell-allowlist.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ include(CodeAnalysis)
 option(ENABLE_TRACING "Enable possibility to use internal ccache tracing" OFF)
 
 if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  option(STATIC_LINK "Link statically with system libraries" OFF)
+  option(STATIC_LINK "Link statically with system libraries" ON)
 endif()
 
 #


### PR DESCRIPTION
The release contains only the executable without the dll dependencies.

It is easier to deploy a single self-contained executable anyway.

Fixes #729