### PR TITLE
Make TemporaryFile generate unique file names on Windows

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -638,6 +638,30 @@ The full license text can be found in LGPL-3.0.txt and at
 https://www.gnu.org/licenses/lgpl-3.0.html.
 
 
+src/third_party/win32/mktemp.*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This implementation of `mkstemp()` for Win32 was adapted from
+<https://github.com/openbsd/src/blob/99b791d14c0f1858d87a0c33b55880fb9b00be66/lib/libc/stdio/mktemp.c>
+and has the folowing license text:
+
+-------------------------------------------------------------------------------
+Copyright (c) 1996-1998, 2008 Theo de Raadt
+Copyright (c) 1997, 2008-2009 Todd C. Miller
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+-------------------------------------------------------------------------------
+
 src/third_party/xxh*
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -6,6 +6,10 @@ else()
   target_compile_definitions(third_party_lib PUBLIC -DSTATIC_GETOPT)
 endif()
 
+if (WIN32)
+    target_sources(third_party_lib PRIVATE win32/mktemp.c)
+endif ()
+
 if(ENABLE_TRACING)
   target_sources(third_party_lib PRIVATE minitrace.c)
 endif()

--- a/src/third_party/win32/mktemp.c
+++ b/src/third_party/win32/mktemp.c
@@ -1,0 +1,260 @@
+/*	$OpenBSD: mktemp.c,v 1.39 2017/11/28 06:55:49 tb Exp $ */
+/*
+ * Copyright (c) 1996-1998, 2008 Theo de Raadt
+ * Copyright (c) 1997, 2008-2009 Todd C. Miller
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifdef _WIN32
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600 // _WIN32_WINNT_VISTA
+#endif
+
+#ifndef _CRT_NONSTDC_NO_DEPRECATE
+#define _CRT_NONSTDC_NO_DEPRECATE
+#endif
+
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+#endif
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#include <io.h>
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX 1
+#define WIN32_NO_STATUS
+#include <windows.h>
+#undef WIN32_NO_STATUS
+#include <ntstatus.h>
+
+// Work-around wrong calling convention for RtlGenRandom in old mingw-w64
+#define SystemFunction036 __stdcall SystemFunction036
+#include <ntsecapi.h>
+#undef SystemFunction036
+#endif
+
+#ifdef _MSC_VER
+#define S_IRUSR	(_S_IREAD)
+#define S_IWUSR	(_S_IWRITE)
+#endif
+
+#define MKTEMP_NAME	0
+#define MKTEMP_FILE	1
+#define MKTEMP_DIR	2
+
+#define TEMPCHARS	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+#define NUM_CHARS	(sizeof(TEMPCHARS) - 1)
+#define MIN_X		6
+
+#ifdef _WIN32
+#define MKOTEMP_FLAGS		(_O_APPEND|_O_NOINHERIT|_O_BINARY|_O_TEXT| \
+				 _O_U16TEXT|_O_U8TEXT|_O_WTEXT)
+#define MKTEMP_FLAGS_DEFAULT	(_O_BINARY)
+#else
+#define MKOTEMP_FLAGS		(O_APPEND|O_CLOEXEC|O_DSYNC|O_RSYNC|O_SYNC)
+#define MKTEMP_FLAGS_DEFAULT	(0)
+#endif
+
+#ifndef nitems
+#define nitems(_a)	(sizeof((_a)) / sizeof((_a)[0]))
+#endif
+
+#ifdef _WIN32
+static BOOL CALLBACK
+lookup_ntdll_function_once(
+    PINIT_ONCE init_once, PVOID parameter, PVOID *context)
+{
+	(void)init_once;
+	*context = (PVOID)GetProcAddress(
+	    GetModuleHandleA("ntdll.dll"), parameter);
+	return(TRUE);
+}
+
+static NTSTATUS
+GetLastNtStatus()
+{
+	static INIT_ONCE init_once = INIT_ONCE_STATIC_INIT;
+	typedef NTSTATUS(NTAPI * RtlGetLastNtStatus_t)(void);
+	RtlGetLastNtStatus_t get_last_nt_status = NULL;
+	InitOnceExecuteOnce(&init_once, lookup_ntdll_function_once,
+	    "RtlGetLastNtStatus", (LPVOID *)&get_last_nt_status);
+	return(get_last_nt_status());
+}
+
+static int
+normalize_msvcrt_errno(int ret)
+{
+	if (ret == -1 && errno == EACCES && _doserrno == ERROR_ACCESS_DENIED) {
+		/*
+		 * Win32 APIs return ERROR_ACCESS_DENIED for many distinct
+		 * NTSTATUS codes, even when it's arguably inappropriate to do
+		 * so, e.g. if you attempt to open a directory, or open a file
+		 * that's in the "pending delete" state. These are mapped to
+		 * EACCESS in the C runtime. We instead map these to EEXIST.
+		 */
+		NTSTATUS nt_err = GetLastNtStatus();
+		if (nt_err == STATUS_FILE_IS_A_DIRECTORY ||
+		    nt_err == STATUS_DELETE_PENDING) {
+			errno = EEXIST;
+		}
+	}
+	return(ret);
+}
+
+#define open(...)		(normalize_msvcrt_errno(open(__VA_ARGS__)))
+#define mkdir(path, mode)	(normalize_msvcrt_errno(mkdir(path)))
+#define lstat(path, sb)		(normalize_msvcrt_errno(stat(path, sb)))
+
+static void (*_bsd_mkstemp_random_source)(void *buf, size_t n);
+
+void
+bsd_mkstemp_set_random_source(void (*f)(void *buf, size_t n))
+{
+	_bsd_mkstemp_random_source = f;
+}
+
+static void
+arc4random_buf(void *buf, size_t nbytes)
+{
+	if (_bsd_mkstemp_random_source != NULL) {
+		_bsd_mkstemp_random_source(buf, nbytes);
+	} else {
+		RtlGenRandom(buf, (ULONG)nbytes);
+	}
+}
+#endif
+
+static int
+mktemp_internal(char *path, int slen, int mode, int flags)
+{
+	char *start, *cp, *ep;
+	const char tempchars[] = TEMPCHARS;
+	unsigned int tries;
+	struct stat sb;
+	size_t len;
+	int fd;
+
+	len = strlen(path);
+	if (len < MIN_X || slen < 0 || (size_t)slen > len - MIN_X) {
+		errno = EINVAL;
+		return(-1);
+	}
+	ep = path + len - slen;
+
+	for (start = ep; start > path && start[-1] == 'X'; start--)
+		;
+	if (ep - start < MIN_X) {
+		errno = EINVAL;
+		return(-1);
+	}
+
+	if (flags & ~MKOTEMP_FLAGS) {
+		errno = EINVAL;
+		return(-1);
+	}
+	flags |= O_CREAT|O_EXCL|O_RDWR;
+
+	tries = INT_MAX;
+	do {
+		cp = start;
+		do {
+			unsigned short rbuf[16];
+			unsigned int i;
+
+			/*
+			 * Avoid lots of arc4random() calls by using
+			 * a buffer sized for up to 16 Xs at a time.
+			 */
+			arc4random_buf(rbuf, sizeof(rbuf));
+			for (i = 0; i < nitems(rbuf) && cp != ep; i++)
+				*cp++ = tempchars[rbuf[i] % NUM_CHARS];
+		} while (cp != ep);
+
+		switch (mode) {
+		case MKTEMP_NAME:
+			if (lstat(path, &sb) != 0)
+				return(errno == ENOENT ? 0 : -1);
+			break;
+		case MKTEMP_FILE:
+			fd = open(path, flags, S_IRUSR|S_IWUSR);
+			if (fd != -1 || errno != EEXIST)
+				return(fd);
+			break;
+		case MKTEMP_DIR:
+			if (mkdir(path, S_IRUSR|S_IWUSR|S_IXUSR) == 0)
+				return(0);
+			if (errno != EEXIST)
+				return(-1);
+			break;
+		}
+	} while (--tries);
+
+	errno = EEXIST;
+	return(-1);
+}
+
+char *
+bsd_mktemp(char *path)
+{
+	if (mktemp_internal(path, 0, MKTEMP_NAME, MKTEMP_FLAGS_DEFAULT) == -1)
+		return(NULL);
+	return(path);
+}
+
+int
+bsd_mkostemps(char *path, int slen, int flags)
+{
+	return(mktemp_internal(path, slen, MKTEMP_FILE, flags));
+}
+
+int
+bsd_mkstemp(char *path)
+{
+	return(mktemp_internal(path, 0, MKTEMP_FILE, MKTEMP_FLAGS_DEFAULT));
+}
+
+int
+bsd_mkostemp(char *path, int flags)
+{
+	return(mktemp_internal(path, 0, MKTEMP_FILE, flags));
+}
+
+int
+bsd_mkstemps(char *path, int slen)
+{
+	return(mktemp_internal(path, slen, MKTEMP_FILE, MKTEMP_FLAGS_DEFAULT));
+}
+
+char *
+bsd_mkdtemp(char *path)
+{
+	int error;
+
+	error = mktemp_internal(path, 0, MKTEMP_DIR, 0);
+	return(error ? NULL : path);
+}

--- a/src/third_party/win32/mktemp.h
+++ b/src/third_party/win32/mktemp.h
@@ -1,0 +1,18 @@
+#ifndef CCACHE_THIRD_PARTY_WIN32_MKTEMP_H_
+#define CCACHE_THIRD_PARTY_WIN32_MKTEMP_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int bsd_mkstemp(char *);
+
+// Exposed for testing.
+void bsd_mkstemp_set_random_source(void (*)(void *buf, size_t n));
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -27,7 +27,9 @@ if(INODE_CACHE_SUPPORTED)
 endif()
 
 if(WIN32)
-  list(APPEND source_files test_Win32Util.cpp)
+  list(APPEND source_files
+    test_bsdmkstemp.cpp
+    test_Win32Util.cpp)
 endif()
 
 add_executable(unittest ${source_files})

--- a/unittest/test_bsdmkstemp.cpp
+++ b/unittest/test_bsdmkstemp.cpp
@@ -1,0 +1,193 @@
+#include "../src/Fd.hpp"
+#include "TestUtil.hpp"
+
+#include "third_party/doctest.h"
+#include "third_party/win32/mktemp.h"
+
+#include <algorithm>
+#include <memory>
+#include <ostream>
+#include <sddl.h>
+#include <utility>
+
+using TestUtil::TestContext;
+
+namespace {
+
+class ScopedHANDLE
+{
+public:
+  ScopedHANDLE() = default;
+
+  explicit ScopedHANDLE(HANDLE h) : h_(h)
+  {
+  }
+
+  ScopedHANDLE(ScopedHANDLE&& other) : ScopedHANDLE(other.release())
+  {
+  }
+
+  ~ScopedHANDLE()
+  {
+    if (h_ != INVALID_HANDLE_VALUE) {
+      CloseHandle(h_);
+    }
+  }
+
+  ScopedHANDLE&
+  operator=(ScopedHANDLE rhs)
+  {
+    std::swap(h_, rhs.h_);
+    return *this;
+  }
+
+  explicit operator bool() const
+  {
+    return h_ != INVALID_HANDLE_VALUE;
+  }
+
+  HANDLE
+  get() const
+  {
+    return h_;
+  }
+
+  HANDLE
+  release()
+  {
+    HANDLE h = h_;
+    h_ = INVALID_HANDLE_VALUE;
+    return h;
+  }
+
+private:
+  HANDLE h_ = INVALID_HANDLE_VALUE;
+};
+
+} // namespace
+
+TEST_SUITE_BEGIN("thirdparty");
+
+TEST_CASE("thirdparty::bsd_mkstemp")
+{
+  TestContext test_context;
+
+  static int rand_iter;
+  rand_iter = 0;
+
+  bsd_mkstemp_set_random_source([](void* buf, size_t nbytes) {
+    std::fill_n(
+      static_cast<uint16_t*>(buf), nbytes / sizeof(uint16_t), rand_iter);
+    rand_iter++;
+  });
+
+  struct Cleanup
+  {
+    ~Cleanup()
+    {
+      bsd_mkstemp_set_random_source(nullptr);
+    }
+  } cleanup;
+
+  SUBCASE("successful")
+  {
+    std::string path("XXXXXX");
+    CHECK_MESSAGE(Fd(bsd_mkstemp(&path[0])), "errno=" << errno);
+    CHECK(path == "AAAAAA");
+  }
+
+  SUBCASE("existing_file")
+  {
+    CHECK_MESSAGE(ScopedHANDLE(CreateFileA("AAAAAA",
+                                           GENERIC_READ | GENERIC_WRITE,
+                                           0,
+                                           nullptr,
+                                           CREATE_NEW,
+                                           FILE_ATTRIBUTE_NORMAL,
+                                           nullptr)),
+                  "errno=" << errno);
+
+    std::string path("XXXXXX");
+    CHECK_MESSAGE(Fd(bsd_mkstemp(&path[0])), "errno=" << errno);
+    CHECK(path == "BBBBBB");
+  }
+
+  SUBCASE("existing_file_pending_delete")
+  {
+    ScopedHANDLE h;
+    CHECK_MESSAGE(
+      (h = ScopedHANDLE(CreateFileA("AAAAAA",
+                                    GENERIC_READ | GENERIC_WRITE | DELETE,
+                                    0,
+                                    nullptr,
+                                    CREATE_NEW,
+                                    FILE_ATTRIBUTE_NORMAL,
+                                    nullptr))),
+      "errno=" << errno);
+
+    // Mark file as deleted. This puts it into a "pending delete" state that
+    // will persist until the handle is closed.
+    FILE_DISPOSITION_INFO info{};
+    info.DeleteFile = TRUE;
+    CHECK_MESSAGE(SetFileInformationByHandle(
+                    h.get(), FileDispositionInfo, &info, sizeof(info)),
+                  "errno=" << errno);
+
+    std::string path("XXXXXX");
+    CHECK_MESSAGE(Fd(bsd_mkstemp(&path[0])), "errno=" << errno);
+    CHECK(path == "BBBBBB");
+  }
+
+  SUBCASE("existing_dir")
+  {
+    CHECK_MESSAGE(CreateDirectoryA("AAAAAA", nullptr), "errno=" << errno);
+
+    std::string path("XXXXXX");
+    CHECK_MESSAGE(Fd(bsd_mkstemp(&path[0])), "errno=" << errno);
+    CHECK(path == "BBBBBB");
+  }
+
+  SUBCASE("permission denied")
+  {
+    auto makeACL = [](const char* aclString) {
+      PSECURITY_DESCRIPTOR desc = nullptr;
+      ConvertStringSecurityDescriptorToSecurityDescriptorA(
+        aclString, SDDL_REVISION_1, &desc, nullptr);
+      return std::shared_ptr<SECURITY_DESCRIPTOR>(
+        static_cast<SECURITY_DESCRIPTOR*>(desc), &LocalFree);
+    };
+
+    // Create a directory with a contrived ACL that denies creation of new
+    // files and directories to the "Everybody" (WD) group.
+    std::shared_ptr<SECURITY_DESCRIPTOR> desc;
+    CHECK_MESSAGE((desc = makeACL("D:(D;;DCLCRPCR;;;WD)(A;;FA;;;WD)")),
+                  "errno=" << errno);
+
+    SECURITY_ATTRIBUTES attrs{};
+    attrs.nLength = sizeof(attrs);
+    attrs.lpSecurityDescriptor = desc.get();
+    CHECK_MESSAGE(CreateDirectoryA("my_readonly_dir", &attrs),
+                  "errno=" << errno);
+
+    // Sanity check that we cannot write to this directory. (E.g. Wine
+    // doesn't appear to emulate Windows ACLs properly when run under root.)
+    bool broken_acls = static_cast<bool>(ScopedHANDLE(
+      CreateFileA("my_readonly_dir/.writable",
+                  GENERIC_WRITE,
+                  0,
+                  nullptr,
+                  CREATE_ALWAYS,
+                  FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE,
+                  nullptr)));
+
+    if (!broken_acls) {
+      std::string path("my_readonly_dir/XXXXXX");
+      CHECK(!Fd(bsd_mkstemp(&path[0])));
+      CHECK(errno == EACCES);
+    } else {
+      MESSAGE("ACLs do not appear to function properly on this filesystem");
+    }
+  }
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
On Windows, multiple ccache process can race each other to create, rename and delete temporary files, because they would attempt to generate the same sequence of temporary file names (`tmp.cpp_stdout.iG2Kb7`, `tmp.cpp_stdout.P1kAlM`, `tmp.cpp_stdout.FzP5tM`, ...). I observed this behaviour in [Process Monitor](https://docs.microsoft.com/en-us/sysinternals/downloads/procmon) when running a multithreaded build of a C++ project.

Root cause appears to be that the offical Windows ccache builds use mingw-w64's [implementation of `mkstemp()`][1], which uses `rand()` to generate temporary file names.

This PR replaces `mkstemp()` with a safer implementation that uses the CRT's `rand_s()` function to generate temporary file names that are more likely to be unique. `rand_s()` uses `RtlGenRandom()` under the hood, which is basically the Windows equivalent of `/dev/urandom`.

See: #703

Example errors:

- Some ccache process is in the process of deleting a temporary file:

      ccache: error: Failed to create temporary file for C:\Users\someuser/.ccache/tmp/tmp.cpp_stdout.FzP5tM: Access is denied.

- Some ccache process has destination file open, so it can't be overwritten:
          
      ccache: error: failed to rename C:\Users\someuser/.ccache/tmp/tmp.cpp_stdout.iG2Kb7 to C:\Users\someuser/.ccache/tmp/tmp.cpp_stdout.iG2Kb7.ii: Access is denied.

- Source file has been deleted by some other ccache process:
      
      ccache: error: failed to rename C:\Users\someuser/.ccache/tmp/tmp.cpp_stdout.P1kAlM to C:\Users\someuser/.ccache/tmp/tmp.cpp_stdout.P1kAlM.ii: The system cannot find the file specified.

[1]: https://github.com/mirror/mingw-w64/blob/v8.0.0/mingw-w64-crt/misc/mkstemp.c

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
