### PR TITLE
Disable -Wthread-safety-analysis on FreeBSD currently

### DIFF
--- a/cmake/DevModeWarnings.cmake
+++ b/cmake/DevModeWarnings.cmake
@@ -107,6 +107,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     CCACHE_COMPILER_WARNINGS "-Wno-undefined-func-template")
   add_compile_flag_if_supported(
     CCACHE_COMPILER_WARNINGS "-Wno-return-std-move-in-c++11")
+
+  # -Wthread-safety-analysis (on FreeBSD when dev mode is enabled) gives false
+  # positive results currently. See PR #730.
+  if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    add_compile_flag_if_supported(
+      CCACHE_COMPILER_WARNINGS "-Wno-thread-safety-analysis")
+  endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   list(
     APPEND


### PR DESCRIPTION
This option is enabled on FreeBSD when -Werror and -Weverything are
enabled. However, it gives false-positive results. As a workaround
it is disabled on FreeBSD as of writing this commit message.

See PR #730: https://github.com/ccache/ccache/pull/730

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
