### PR TITLE
Adapt used XCode versions to GitHub changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,11 +82,11 @@ jobs:
 
           - os: macOS-latest
             compiler: xcode
-            version: "11.0.0"
+            version: "11.7"
 
           - os: macOS-latest
             compiler: xcode
-            version: "12.2"
+            version: "12.3"
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Apparently GitHub has changes available XCode versions. 11.0.0 is no longer available. Surely we need a better concept. This is a quick fix.