### PR TITLE
Add option to link statically with zstd from system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ if(MSVC AND NOT CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg|conan")
 endif()
 
 option(ZSTD_FROM_INTERNET "Download and use libzstd from the Internet" ${ZSTD_FROM_INTERNET_DEFAULT})
+option(ZSTD_SYSTEM_STATIC "Link statically if using libzstd from system" OFF)
 find_package(zstd 1.1.2 REQUIRED)
 
 #

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -41,7 +41,13 @@ if(ZSTD_FROM_INTERNET)
 
   set(zstd_FOUND TRUE)
 else()
-  find_library(ZSTD_LIBRARY zstd)
+  set(zstd_library_name zstd)
+  if (ZSTD_SYSTEM_STATIC)
+    string(CONCAT zstd_library_name
+      ${CMAKE_STATIC_LIBRARY_PREFIX} zstd ${CMAKE_STATIC_LIBRARY_SUFFIX})
+  endif()
+  message(STATUS ${zstd_library_name})
+  find_library(ZSTD_LIBRARY ${zstd_library_name})
   find_path(ZSTD_INCLUDE_DIR zstd.h)
 
   include(FindPackageHandleStandardArgs)

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -46,7 +46,6 @@ else()
     string(CONCAT zstd_library_name
       ${CMAKE_STATIC_LIBRARY_PREFIX} zstd ${CMAKE_STATIC_LIBRARY_SUFFIX})
   endif()
-  message(STATUS ${zstd_library_name})
   find_library(ZSTD_LIBRARY ${zstd_library_name})
   find_path(ZSTD_INCLUDE_DIR zstd.h)
 


### PR DESCRIPTION
ZSTD_SYSTEM_STATIC is added as an CMake option to let libzstd from system being linked statically.

The inspiration was to allow ccache to be linked with a static library version of zstd to prevent a potential chicken-and-egg problem, since ccache binary depends on libzstd.so automatically if not using downloaded version of libzstd.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
