### PR TITLE
Ignore SOURCE_DATE_EPOCH under time_macros sloppiness

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -826,7 +826,8 @@ still has to do _some_ preprocessing (like macros).
     hash but not add the system header files to the list of include files.
 *time_macros*::
     Ignore `__DATE__`, `__TIME__` and `__TIMESTAMP__` being present in the
-    source code.
+    source code. It will also ignore `SOURCE_DATE_EPOCH`
+    https://gcc.gnu.org/onlinedocs/gcc/Environment-Variables.html[environment variable]
 --
 +
 See the discussion under _<<_troubleshooting,Troubleshooting>>_ for more

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1272,17 +1272,24 @@ hash_common_info(const Context& ctx,
   hash.hash(Util::base_name(args[0]));
 
   // Hash variables that may affect the compilation.
-  const char* always_hash_env_vars[] = {
+  struct
+  {
+    const char* name;
+    uint32_t sloppiness;
+  } hash_env_vars[] = {
     // From <https://gcc.gnu.org/onlinedocs/gcc/Environment-Variables.html>:
-    "COMPILER_PATH",
-    "GCC_COMPARE_DEBUG",
-    "GCC_EXEC_PREFIX",
-    "SOURCE_DATE_EPOCH",
+    {"COMPILER_PATH", 0},
+    {"GCC_COMPARE_DEBUG", 0},
+    {"GCC_EXEC_PREFIX", 0},
+    {"SOURCE_DATE_EPOCH", SLOPPY_TIME_MACROS},
   };
-  for (const char* name : always_hash_env_vars) {
-    const char* value = getenv(name);
+  for (const auto& env : hash_env_vars) {
+    if (env.sloppiness && (ctx.config.sloppiness() & env.sloppiness)) {
+      continue;
+    }
+    const char* value = getenv(env.name);
     if (value) {
-      hash.hash_delimiter(name);
+      hash.hash_delimiter(env.name);
       hash.hash(value);
     }
   }

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -293,6 +293,24 @@ base_tests() {
     expect_stat 'files in cache' 1
 
     # -------------------------------------------------------------------------
+    TEST "SOURCE_DATE_EPOCH with time_macros sloppiness"
+
+    CCACHE_SLOPPINESS=time_macros SOURCE_DATE_EPOCH=1 $CCACHE_COMPILE -c test1.c
+    expect_stat 'cache hit (preprocessed)' 0
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+
+    CCACHE_SLOPPINESS=time_macros SOURCE_DATE_EPOCH=2 $CCACHE_COMPILE -c test1.c
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 1
+    expect_stat 'files in cache' 1
+
+    SOURCE_DATE_EPOCH=1 $CCACHE_COMPILE -c test1.c
+    expect_stat 'cache hit (preprocessed)' 1
+    expect_stat 'cache miss' 2
+    expect_stat 'files in cache' 2
+
+    # -------------------------------------------------------------------------
     TEST "Result file is compressed"
 
     $CCACHE_COMPILE -c test1.c


### PR DESCRIPTION
SOURCE_DATE_EPOCH will be passed from debhelpers, by extracting last
entry from d/changelog (or current time if there is entries)
And this will not allow to use cache.