### PR TITLE
Fix running tests on macOS

### DIFF
--- a/misc/format-files
+++ b/misc/format-files
@@ -46,7 +46,7 @@ for file in "$@"; do
         echo "Error: $file not formatted with Clang-Format"
         echo 'Run "make format" or apply this diff:'
         git diff $cf_color --no-index "$file" "$tmp_file" \
-            | sed -r -e "s!^---.*!--- a/$file!" \
+            | sed -E -e "s!^---.*!--- a/$file!" \
                      -e "s!^\+\+\+.*!+++ b/$file!" \
                      -e "/diff --/d" -e "/index /d" \
                      -e "s/.[0-9]*.clang-format.tmp//"

--- a/test/run
+++ b/test/run
@@ -485,6 +485,7 @@ if $HOST_OS_APPLE; then
         echo "Error: xcrun --show-sdk-path failure"
         exit 1
     fi
+    export SDKROOT
 
     SYSROOT="-isysroot `echo \"$SDKROOT\" | sed 's/ /\\ /g'`"
 else
@@ -493,7 +494,7 @@ fi
 
 # ---------------------------------------
 
-all_suites="$(sed -rn 's/^addtest\((.*)\)$/\1/p' $(dirname $0)/CMakeLists.txt)"
+all_suites="$(sed -En 's/^addtest\((.*)\)$/\1/p' $(dirname $0)/CMakeLists.txt)"
 
 for suite in $all_suites; do
     . $(dirname $0)/suites/$suite.bash

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -788,7 +788,7 @@ EOF
     chmod +x gcc
 
     CCACHE_DEBUG=1 $CCACHE ./gcc -c test1.c
-    compiler_type=$(sed -rn 's/.*Compiler type: (.*)/\1/p' test1.o.ccache-log)
+    compiler_type=$(sed -En 's/.*Compiler type: (.*)/\1/p' test1.o.ccache-log)
     if [ "$compiler_type" != gcc ]; then
         test_failed "Compiler type $compiler_type != gcc"
     fi
@@ -796,7 +796,7 @@ EOF
     rm test1.o.ccache-log
 
     CCACHE_COMPILERTYPE=clang CCACHE_DEBUG=1 $CCACHE ./gcc -c test1.c
-    compiler_type=$(sed -rn 's/.*Compiler type: (.*)/\1/p' test1.o.ccache-log)
+    compiler_type=$(sed -En 's/.*Compiler type: (.*)/\1/p' test1.o.ccache-log)
     if [ "$compiler_type" != clang ]; then
         test_failed "Compiler type $compiler_type != clang"
     fi

--- a/test/suites/cache_levels.bash
+++ b/test/suites/cache_levels.bash
@@ -11,7 +11,7 @@ expect_on_level() {
     local expected_level="$2"
 
     slashes=$(find $CCACHE_DIR -name "*$type" \
-                  | sed -r -e 's!.*\.ccache/!!' -e 's![^/]*$!!' -e 's![^/]!!g')
+                  | sed -E -e 's!.*\.ccache/!!' -e 's![^/]*$!!' -e 's![^/]!!g')
     actual_level=$(echo -n "$slashes" | wc -c)
     if [ "$actual_level" -ne "$expected_level" ]; then
         test_failed "$type file on level $actual_level, expected level $expected_level"


### PR DESCRIPTION
Bash tests were not actually being run on the macOS CI agents because the version of sed installed there does not understand the `-r` flag:

    sed: illegal option -- r
    usage: sed script [-Ealn] [-i extension] [file ...]
           sed [-Ealn] [-i extension] [-e script] ... [-f script_file] ... [file ...]

The PR:
- fixes scripts to use `sed -E` instead of `sed -r` as the latter isn't supported by BSD sed.

- exports `SDKROOT` in `test/run`. Otherwise it appears at least some some Apple toolchains (e.g. Xcode 10.3) will pick the _latest_ SDK installed on the host (e.g. `/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk`) instead of using the SDK bundled with the toolchain (e.g. `/Applications/Xcode_10.3.app/.../MacOSX10.14.sdk`).

  The 10.15 SDK is not compatible with Xcode 10.3:

      ld: unsupported tapi file type '!tapi-tbd' in YAML file '/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/lib/libSystem.tbd' for architecture x86_64
      clang: error: linker command failed with exit code 1

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
