### PR TITLE
Always use 64bit to print time_t

### DIFF
--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -88,7 +88,10 @@ do_log(string_view message, bool bulk)
     if (tm) {
       strftime(timestamp, sizeof(timestamp), "%Y-%m-%dT%H:%M:%S", &*tm);
     } else {
-      snprintf(timestamp, sizeof(timestamp), "%lu", tv.tv_sec);
+      snprintf(timestamp,
+               sizeof(timestamp),
+               "%llu",
+               (long long unsigned int)tv.tv_sec);
     }
     snprintf(prefix,
              sizeof(prefix),


### PR DESCRIPTION
some 32bit architectures e.g. RISCV32 use 64bit time_t from beginning
which does not fit into long int size on LP32 systems

Upstream-Status: Pending

Signed-off-by: Khem Raj <raj.khem@gmail.com>

