### PR TITLE
CI: Fix testdir upload file name in case of failed tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,7 +134,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.config.os }}-${{ matrix.config.compiler }}-{{ matrix.config.version }}-testdir.tar.xz
+          name: ${{ matrix.config.os }}-${{ matrix.config.compiler }}-${{ matrix.config.version }}-testdir.tar.xz
           path: testdir.tar.xz
 
   specific_tests:


### PR DESCRIPTION
As randomly discovered in #751 the testdir.tar filenames contain `{{ matrix.config.version }}` which looks rather strange. A dollar sign was missing.