### PR TITLE
Cache CMakeFiles even when compilation failed

### DIFF
--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -101,11 +101,11 @@ base_tests() {
     TEST "don't cache non compiling file (preprocessor error)"
     # Otherwise ccache would cache every single incorrect iteration which will never happen again.
 
-    echo '#error This triggers a compiler error' >error_dont_cache.c
+    echo '#error This triggers a preprocessor error' >error_dont_cache.c
     
     $REAL_COMPILER -c -o reference.o error_dont_cache.c -o error.o 2> reference_stderr.txt
     expect_contains reference_stderr.txt "error:"
-    expect_contains reference_stderr.txt "This triggers a compiler error"
+    expect_contains reference_stderr.txt "This triggers a preprocessor error"
 
     $CCACHE $COMPILER -c error_dont_cache.c -o error.o 2> stderr_cached.txt
     expect_equal_text_content reference_stderr.txt stderr_cached.txt
@@ -118,17 +118,17 @@ base_tests() {
     unset CCACHE_NODIRECT
 
     mkdir -p "CMakeFiles/CMakeTmp"
-    echo '#error This triggers a compiler error' >CMakeFiles/CMakeTmp/error.c
+    echo '#error This triggers a preprocessor error' >CMakeFiles/CMakeTmp/error.c
 
     $CCACHE $COMPILER -c CMakeFiles/CMakeTmp/error.c -o error.o 2> reference_stderr.txt
     expect_contains reference_stderr.txt "error:"
-    expect_contains reference_stderr.txt "This triggers a compiler error"
+    expect_contains reference_stderr.txt "This triggers a preprocessor error"
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2 # direct + preprocessed
 
     $CCACHE $COMPILER -c CMakeFiles/CMakeTmp/error.c -o error.o 2> cached_stderr.txt
     expect_equal_text_content reference_stderr.txt cached_stderr.txt
-    expect_stat 'cache hit (direct)' 1 # FIXME: Not sure why this is not preprocessed!
+    expect_stat 'cache hit (direct)' 1
     expect_stat 'files in cache' 2
 
     # -------------------------------------------------------------------------
@@ -138,17 +138,17 @@ base_tests() {
     mkdir -p "CMakeFiles/CMakeTmp"
     cd "CMakeFiles/CMakeTmp"
 
-    echo '#error This triggers a compiler error' >error.c
+    echo '#error This triggers a preprocessor error' >error.c
 
     $CCACHE $COMPILER -c error.c -o error.o 2> reference_stderr.txt
     expect_contains reference_stderr.txt "error:"
-    expect_contains reference_stderr.txt "This triggers a compiler error"
+    expect_contains reference_stderr.txt "This triggers a preprocessor error"
     expect_stat 'cache miss' 1
     expect_stat 'files in cache' 2
 
     $CCACHE $COMPILER -c error.c -o error.o 2> cached_stderr.txt
     expect_equal_text_content reference_stderr.txt cached_stderr.txt
-    expect_stat 'cache hit (direct)' 1 # FIXME: Not sure why this is not preprocessed!
+    expect_stat 'cache hit (direct)' 1
     expect_stat 'files in cache' 2
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
When running CMake through ccache (e.g. via creating links for gcc -> ccache within PATH or by patching CMake itself), the results are far from 100% cached as detailed below. This patch makes sure everything is cached. Unfortunately the speed improvement is not what I originally expected.

The biggest improvement of this patch is not even the speed (although every bit matters), but the nice round 100% :-)

Note: whether it's a good idea to run cmake via ccache is out of scope of this change. This just improves behavior in case you do so.

### Some measurements

#### Running CMake through CMake without ccache
45.5s, 44.9s

#### Running CMake through CMake with ccache 4.1
empty ccache: 49s, 48.8s
cached: 41.7s, 40.7s

cache hit (direct)                   291
cache hit (preprocessed)               1
cache miss                             0
cache hit rate                    100.00 %
compile failed                       103
preprocessor error                    51
cache size                           2.8 MB


#### Running CMake through CMake with this patch
empty cold: as before

cached: 39.2s

cache hit (direct)                   446
cache hit (preprocessed)               0
cache miss                             0
cache hit rate                    100.00 %
files in cache                       803
cache size                           3.8 MB


Note: cache hit rate is not increasing, see #765