### PR TITLE
Fix Lockfile on Windows when parent directories do not exist

### DIFF
--- a/src/Lockfile.cpp
+++ b/src/Lockfile.cpp
@@ -160,7 +160,7 @@ do_acquire_win32(const std::string& lockfile, uint32_t staleness_limit)
         error);
     if (error == ERROR_PATH_NOT_FOUND) {
       // Directory doesn't exist?
-      if (Util::create_dir(Util::dir_name(lockfile)) == 0) {
+      if (Util::create_dir(Util::dir_name(lockfile))) {
         // OK. Retry.
         continue;
       }

--- a/unittest/test_Lockfile.cpp
+++ b/unittest/test_Lockfile.cpp
@@ -45,6 +45,15 @@ TEST_CASE("Lockfile acquire and release")
   CHECK(!Stat::lstat("test.lock"));
 }
 
+TEST_CASE("Lockfile creates missing directories")
+{
+  TestContext test_context;
+
+  Lockfile lock("a/b/c/test", 1000);
+  CHECK(lock.acquired());
+  CHECK(Stat::lstat("a/b/c/test.lock"));
+}
+
 #ifndef _WIN32
 TEST_CASE("Lockfile breaking")
 {


### PR DESCRIPTION
Fix flipped condition test that meant the file lock wouldn't be acquired if parent directories needed to be created first.

I noticed this when looking at some of the Windows test failures, as stats files wouldn't be updated.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
