### PR TITLE
File

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(
   CacheEntryReader.cpp
   CacheEntryWriter.cpp
   CacheFile.cpp
+  FileInfo.cpp
   Compression.cpp
   Compressor.cpp
   Config.cpp

--- a/src/CacheFile.cpp
+++ b/src/CacheFile.cpp
@@ -22,22 +22,12 @@
 #include "Result.hpp"
 #include "Util.hpp"
 
-const Stat&
-CacheFile::lstat() const
-{
-  if (!m_stat) {
-    m_stat = Stat::lstat(m_path);
-  }
-
-  return *m_stat;
-}
-
 CacheFile::Type
 CacheFile::type() const
 {
-  if (Util::ends_with(m_path, Manifest::k_file_suffix)) {
+  if (Util::ends_with(path(), Manifest::k_file_suffix)) {
     return Type::manifest;
-  } else if (Util::ends_with(m_path, Result::k_file_suffix)) {
+  } else if (Util::ends_with(path(), Result::k_file_suffix)) {
     return Type::result;
   } else {
     return Type::unknown;

--- a/src/CacheFile.hpp
+++ b/src/CacheFile.hpp
@@ -20,38 +20,22 @@
 
 #include "system.hpp"
 
-#include "Stat.hpp"
-#include "exceptions.hpp"
+#include "FileInfo.hpp"
 
 #include "third_party/nonstd/optional.hpp"
 
 #include <string>
 
-class CacheFile
+class CacheFile : public FileInfo
 {
 public:
   enum class Type { result, manifest, unknown };
 
   explicit CacheFile(const std::string& path);
 
-  CacheFile(const CacheFile&) = delete;
-  CacheFile& operator=(const CacheFile&) = delete;
-
-  const Stat& lstat() const;
-  const std::string& path() const;
   Type type() const;
-
-private:
-  const std::string m_path;
-  mutable nonstd::optional<Stat> m_stat;
 };
 
-inline CacheFile::CacheFile(const std::string& path) : m_path(path)
+inline CacheFile::CacheFile(const std::string& path) : FileInfo(path)
 {
-}
-
-inline const std::string&
-CacheFile::path() const
-{
-  return m_path;
 }

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "FileInfo.hpp"
+
+#include "Util.hpp"
+
+const Stat&
+FileInfo::lstat() const
+{
+  if (!m_stat) {
+    m_stat = Stat::lstat(m_path);
+  }
+
+  return *m_stat;
+}

--- a/src/FileInfo.hpp
+++ b/src/FileInfo.hpp
@@ -32,10 +32,18 @@ class FileInfo
 public:
   explicit FileInfo(const std::string& path);
 
-  const Stat& lstat() const;
   const std::string& path() const;
 
+  bool exists() const;
+  bool is_directory() const;
+  bool is_regular() const;
+  uint64_t size_on_disk() const;
+  uint64_t size() const;
+  time_t mtime() const;
+
 private:
+  const Stat& lstat() const;
+
   std::string m_path;
   mutable nonstd::optional<Stat> m_stat;
 };
@@ -48,4 +56,40 @@ inline const std::string&
 FileInfo::path() const
 {
   return m_path;
+}
+
+inline bool
+FileInfo::exists() const
+{
+  return lstat();
+}
+
+inline bool
+FileInfo::is_directory() const
+{
+  return lstat() && lstat().is_directory();
+}
+
+inline bool
+FileInfo::is_regular() const
+{
+  return lstat() && lstat().is_regular();
+}
+
+inline uint64_t
+FileInfo::size_on_disk() const
+{
+  return lstat().size_on_disk();
+}
+
+inline uint64_t
+FileInfo::size() const
+{
+  return lstat().size();
+}
+
+inline time_t
+FileInfo::mtime() const
+{
+  return lstat().mtime();
 }

--- a/src/FileInfo.hpp
+++ b/src/FileInfo.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2021 Joel Rosdahl and other contributors
+//
+// See doc/AUTHORS.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#pragma once
+
+#include "system.hpp"
+
+#include "Stat.hpp"
+
+#include "third_party/nonstd/optional.hpp"
+
+#include <string>
+
+// file path and cached lstat
+class FileInfo
+{
+public:
+  explicit FileInfo(const std::string& path);
+
+  const Stat& lstat() const;
+  const std::string& path() const;
+
+private:
+  std::string m_path;
+  mutable nonstd::optional<Stat> m_stat;
+};
+
+inline FileInfo::FileInfo(const std::string& path) : m_path(path)
+{
+}
+
+inline const std::string&
+FileInfo::path() const
+{
+  return m_path;
+}

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -654,13 +654,14 @@ get_extension(string_view path)
   }
 }
 
-void
+std::vector<FileInfo>
 get_level_1_files(const std::string& dir,
-                  const ProgressReceiver& progress_receiver,
-                  std::vector<std::shared_ptr<CacheFile>>& files)
+                  const ProgressReceiver& progress_receiver)
 {
+  std::vector<FileInfo> files;
+
   if (!Stat::stat(dir)) {
-    return;
+    return files;
   }
 
   size_t level_2_directories = 0;
@@ -672,7 +673,7 @@ get_level_1_files(const std::string& dir,
     }
 
     if (!is_dir) {
-      files.push_back(std::make_shared<CacheFile>(path));
+      files.push_back(FileInfo{path});
     } else if (path != dir
                && path.find('/', dir.size() + 1) == std::string::npos) {
       ++level_2_directories;
@@ -681,6 +682,8 @@ get_level_1_files(const std::string& dir,
   });
 
   progress_receiver(1.0);
+
+  return files;
 }
 
 std::string

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -673,7 +673,7 @@ get_level_1_files(const std::string& dir,
     }
 
     if (!is_dir) {
-      files.push_back(FileInfo{path});
+      files.emplace_back(path);
     } else if (path != dir
                && path.find('/', dir.size() + 1) == std::string::npos) {
       ++level_2_directories;

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -21,6 +21,7 @@
 #include "system.hpp"
 
 #include "CacheFile.hpp"
+#include "FileInfo.hpp"
 
 #include "third_party/nonstd/optional.hpp"
 #include "third_party/nonstd/string_view.hpp"
@@ -208,10 +209,9 @@ nonstd::string_view get_extension(nonstd::string_view path);
 // Parameters:
 // - dir: The directory to traverse recursively.
 // - progress_receiver: Function that will be called for progress updates.
-// - files: Found files.
-void get_level_1_files(const std::string& dir,
-                       const ProgressReceiver& progress_receiver,
-                       std::vector<std::shared_ptr<CacheFile>>& files);
+std::vector<FileInfo>
+get_level_1_files(const std::string& dir,
+                  const ProgressReceiver& progress_receiver);
 
 // Return the current user's home directory, or throw `Fatal` if it can't
 // be determined.

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -20,7 +20,6 @@
 
 #include "system.hpp"
 
-#include "CacheFile.hpp"
 #include "FileInfo.hpp"
 
 #include "third_party/nonstd/optional.hpp"

--- a/src/cleanup.cpp
+++ b/src/cleanup.cpp
@@ -90,9 +90,8 @@ clean_up_dir(const std::string& subdir,
 {
   LOG("Cleaning up cache directory {}", subdir);
 
-  std::vector<std::shared_ptr<CacheFile>> files;
-  Util::get_level_1_files(
-    subdir, [&](double progress) { progress_receiver(progress / 3); }, files);
+  std::vector<FileInfo> files = Util::get_level_1_files(
+    subdir, [&](double progress) { progress_receiver(progress / 3); });
 
   uint64_t cache_size = 0;
   uint64_t files_in_cache = 0;
@@ -102,29 +101,27 @@ clean_up_dir(const std::string& subdir,
        ++i, progress_receiver(1.0 / 3 + 1.0 * i / files.size() / 3)) {
     const auto& file = files[i];
 
-    if (!file->lstat().is_regular()) {
+    if (!file.lstat().is_regular()) {
       // Not a file or missing file.
       continue;
     }
 
     // Delete any tmp files older than 1 hour right away.
-    if (file->lstat().mtime() + 3600 < current_time
-        && Util::base_name(file->path()).find(".tmp.") != std::string::npos) {
-      Util::unlink_tmp(file->path());
+    if (file.lstat().mtime() + 3600 < current_time
+        && Util::base_name(file.path()).find(".tmp.") != std::string::npos) {
+      Util::unlink_tmp(file.path());
       continue;
     }
 
-    cache_size += file->lstat().size_on_disk();
+    cache_size += file.lstat().size_on_disk();
     files_in_cache += 1;
   }
 
   // Sort according to modification time, oldest first.
-  std::sort(files.begin(),
-            files.end(),
-            [](const std::shared_ptr<CacheFile>& f1,
-               const std::shared_ptr<CacheFile>& f2) {
-              return f1->lstat().mtime() < f2->lstat().mtime();
-            });
+  std::sort(
+    files.begin(), files.end(), [](const FileInfo& f1, const FileInfo& f2) {
+      return f1.lstat().mtime() < f2.lstat().mtime();
+    });
 
   LOG("Before cleanup: {:.0f} KiB, {:.0f} files",
       static_cast<double>(cache_size) / 1024,
@@ -135,27 +132,26 @@ clean_up_dir(const std::string& subdir,
        ++i, progress_receiver(2.0 / 3 + 1.0 * i / files.size() / 3)) {
     const auto& file = files[i];
 
-    if (!file->lstat() || file->lstat().is_directory()) {
+    if (!file.lstat() || file.lstat().is_directory()) {
       continue;
     }
 
     if ((max_size == 0 || cache_size <= max_size)
         && (max_files == 0 || files_in_cache <= max_files)
         && (max_age == 0
-            || file->lstat().mtime()
+            || file.lstat().mtime()
                  > (current_time - static_cast<int64_t>(max_age)))) {
       break;
     }
 
-    if (Util::ends_with(file->path(), ".stderr")) {
+    if (Util::ends_with(file.path(), ".stderr")) {
       // In order to be nice to legacy ccache versions, make sure that the .o
       // file is deleted before .stderr, because if the ccache process gets
       // killed after deleting the .stderr but before deleting the .o, the
       // cached result will be inconsistent. (.stderr is the only file that is
       // optional for legacy ccache versions; any other file missing from the
       // cache will be detected.)
-      std::string o_file =
-        file->path().substr(0, file->path().size() - 6) + "o";
+      std::string o_file = file.path().substr(0, file.path().size() - 6) + "o";
 
       // Don't subtract this extra deletion from the cache size; that
       // bookkeeping will be done when the loop reaches the .o file. If the
@@ -167,7 +163,7 @@ clean_up_dir(const std::string& subdir,
     }
 
     delete_file(
-      file->path(), file->lstat().size_on_disk(), &cache_size, &files_in_cache);
+      file.path(), file.lstat().size_on_disk(), &cache_size, &files_in_cache);
     cleaned = true;
   }
 
@@ -207,12 +203,11 @@ wipe_dir(const std::string& subdir,
 {
   LOG("Clearing out cache directory {}", subdir);
 
-  std::vector<std::shared_ptr<CacheFile>> files;
-  Util::get_level_1_files(
-    subdir, [&](double progress) { progress_receiver(progress / 2); }, files);
+  std::vector<FileInfo> files = Util::get_level_1_files(
+    subdir, [&](double progress) { progress_receiver(progress / 2); });
 
   for (size_t i = 0; i < files.size(); ++i) {
-    Util::unlink_safe(files[i]->path());
+    Util::unlink_safe(files[i].path());
     progress_receiver(0.5 + 0.5 * i / files.size());
   }
 

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -223,15 +223,15 @@ compress_stats(const Config& config,
 
       for (size_t i = 0; i < files.size(); ++i) {
         const auto& cache_file = files[i];
-        on_disk_size += cache_file.lstat().size_on_disk();
+        on_disk_size += cache_file.size_on_disk();
 
         try {
           auto file = open_file(cache_file.path(), "rb");
           auto reader = create_reader(CacheFile(cache_file.path()), file.get());
-          compr_size += cache_file.lstat().size();
+          compr_size += cache_file.size();
           content_size += reader->content_size();
         } catch (Error&) {
-          incompr_size += cache_file.lstat().size();
+          incompr_size += cache_file.size();
         }
 
         sub_progress_receiver(1.0 / 2 + 1.0 * i / files.size() / 2);
@@ -305,7 +305,7 @@ compress_recompress(Context& ctx,
             }
           });
         } else {
-          statistics.update(0, 0, 0, file.lstat().size());
+          statistics.update(0, 0, 0, file.size());
         }
 
         sub_progress_receiver(0.1 + 0.9 * i / files.size());

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -21,6 +21,7 @@
 #include "AtomicFile.hpp"
 #include "CacheEntryReader.hpp"
 #include "CacheEntryWriter.hpp"
+#include "CacheFile.hpp"
 #include "Context.hpp"
 #include "File.hpp"
 #include "Logging.hpp"

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -403,13 +403,13 @@ TEST_CASE("Util::get_level_1_files")
       });
 
     CHECK(files[0].path() == os_path("0/1/file_b"));
-    CHECK(files[0].lstat().size() == 1);
+    CHECK(files[0].size() == 1);
     CHECK(files[1].path() == os_path("0/1/file_c"));
-    CHECK(files[1].lstat().size() == 2);
+    CHECK(files[1].size() == 2);
     CHECK(files[2].path() == os_path("0/f/c/file_d"));
-    CHECK(files[2].lstat().size() == 3);
+    CHECK(files[2].size() == 3);
     CHECK(files[3].path() == os_path("0/file_a"));
-    CHECK(files[3].lstat().size() == 0);
+    CHECK(files[3].size() == 0);
   }
 }
 

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -376,43 +376,40 @@ TEST_CASE("Util::get_level_1_files")
   Util::write_file("0/1/file_c", "12");
   Util::write_file("0/f/c/file_d", "123");
 
-  std::vector<std::shared_ptr<CacheFile>> files;
   auto null_receiver = [](double) {};
 
   SUBCASE("nonexistent subdirectory")
   {
-    Util::get_level_1_files("2", null_receiver, files);
+    const auto files = Util::get_level_1_files("2", null_receiver);
     CHECK(files.empty());
   }
 
   SUBCASE("empty subdirectory")
   {
-    Util::get_level_1_files("e", null_receiver, files);
+    const auto files = Util::get_level_1_files("e", null_receiver);
     CHECK(files.empty());
   }
 
   SUBCASE("simple case")
   {
-    Util::get_level_1_files("0", null_receiver, files);
+    auto files = Util::get_level_1_files("0", null_receiver);
     REQUIRE(files.size() == 4);
 
     // Files within a level are in arbitrary order, sort them to be able to
     // verify them.
-    std::sort(files.begin(),
-              files.end(),
-              [](const std::shared_ptr<CacheFile>& f1,
-                 const std::shared_ptr<CacheFile>& f2) {
-                return f1->path() < f2->path();
-              });
+    std::sort(
+      files.begin(), files.end(), [](const FileInfo& f1, const FileInfo& f2) {
+        return f1.path() < f2.path();
+      });
 
-    CHECK(files[0]->path() == os_path("0/1/file_b"));
-    CHECK(files[0]->lstat().size() == 1);
-    CHECK(files[1]->path() == os_path("0/1/file_c"));
-    CHECK(files[1]->lstat().size() == 2);
-    CHECK(files[2]->path() == os_path("0/f/c/file_d"));
-    CHECK(files[2]->lstat().size() == 3);
-    CHECK(files[3]->path() == os_path("0/file_a"));
-    CHECK(files[3]->lstat().size() == 0);
+    CHECK(files[0].path() == os_path("0/1/file_b"));
+    CHECK(files[0].lstat().size() == 1);
+    CHECK(files[1].path() == os_path("0/1/file_c"));
+    CHECK(files[1].lstat().size() == 2);
+    CHECK(files[2].path() == os_path("0/f/c/file_d"));
+    CHECK(files[2].lstat().size() == 3);
+    CHECK(files[3].path() == os_path("0/file_a"));
+    CHECK(files[3].lstat().size() == 0);
   }
 }
 


### PR DESCRIPTION
Idea: pretty much every occurrence of any path is sooner or later checked for exists() or size() or similar.
This is done either via Stat or via CacheFile.
But it seems reasonable to provide a generic helpful class which is not dependent on one specific cache backend.

Much of the current functionality in CacheFile is not really "cache file" dependent. This removes some dependencies and provides a reusable FileInfo class.

Therefore functions which use std::string path or CacheFile can now instead use the light weight FileInfo class, which should make usage of these functions way more readable.


Review commit by commit should be trivial.