### PR TITLE
Fix fast linker selection for old gcc versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,10 +91,12 @@ jobs:
           if [ "${{ runner.os }}" = "Linux" ]; then
             sudo apt-get update
 
+            # Install ld.gold (binutils) and ld.lld on different runs.
+            # Binding to Ubuntu 20 has no special meaning.
             if [ "${{ matrix.config.os }}" = "ubuntu-20.04" ]; then
-              sudo apt-get install -y ninja-build elfutils libzstd-dev
+              sudo apt-get install -y ninja-build elfutils libzstd-dev lld
             else
-              sudo apt-get install -y ninja-build elfutils libzstd1-dev
+              sudo apt-get install -y ninja-build elfutils libzstd1-dev binutils
             fi
 
             if [ "${{ matrix.config.compiler }}" = "gcc" ]; then


### PR DESCRIPTION
Turns out it would have been a good idea to add that to CI in the first place.
Current master fails to compile if ld.gold / lld are installed with gcc <9.