### PR TITLE
Tests: improve COFF object file comparison

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -204,8 +204,7 @@ jobs:
             ENABLE_CACHE_CLEANUP_TESTS: 1
             CMAKE_GENERATOR: Ninja
             CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DZSTD_FROM_INTERNET=ON
-            # -mno-incremental-linker-compatible: reproducible object files
-            TEST_CC: clang -target i686-pc-windows-msvc -mno-incremental-linker-compatible
+            TEST_CC: clang -target i686-pc-windows-msvc
 
           - name: Windows VS2019 64-bit
             os: windows-2019
@@ -216,8 +215,7 @@ jobs:
             ENABLE_CACHE_CLEANUP_TESTS: 1
             CMAKE_GENERATOR: Ninja
             CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DZSTD_FROM_INTERNET=ON
-            # -mno-incremental-linker-compatible: reproducible object files
-            TEST_CC: clang -target x86_64-pc-windows-msvc -mno-incremental-linker-compatible
+            TEST_CC: clang -target x86_64-pc-windows-msvc
 
           - name: Clang address & UB sanitizer
             os: ubuntu-20.04

--- a/test/run
+++ b/test/run
@@ -226,6 +226,22 @@ is_equal_object_files() {
         elfdump -a -w "$2".dump "$2"
         # these were the elfdump fields that seemed to differ (empirically)
         diff -I e_shoff -I sh_size -I st_name "$1".dump "$2".dump > /dev/null
+    elif $HOST_OS_WINDOWS && command -v dumpbin.exe >/dev/null; then
+        # Filter out fields that are affected by compilation time or source
+        # filename.
+        local awk_filter='
+            skip {--skip; next}
+
+            /Dump of file/ {next}                 # dumbin header
+            /time date stamp/ {next}              # incremental linker timestamp
+            /number of symbols/ {next}            # symbol count
+            /Filename *\| \.file$/ {skip=1; next} # .file symbol
+
+            {print}
+        '
+        dumpbin.exe -all -nologo "$1" | awk "$awk_filter" > "$1".dump
+        dumpbin.exe -all -nologo "$2" | awk "$awk_filter" > "$2".dump
+        cmp -s "$1".dump "$2".dump
     else
         cmp -s "$1" "$2"
     fi


### PR DESCRIPTION
Make `is_equal_object_files` more lenient when comparing COFF object files.

COFF object files contain the original source file name, which was breaking the cpp1 test. They often contain a timestamp used by the incremental linker, unless this is explicitly disabled via `/Brepro` (MSVC) or `-mno-incremental-linker-compatible` (clang).