### PR TITLE
CI: skip homebrew update/cleanup on macOS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,7 +109,9 @@ jobs:
               sudo apt install -y clang-${{ matrix.config.version }} g++-multilib
             fi
           elif [ "${{ runner.os }}" = "macOS" ]; then
-            brew install ninja
+            HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 \
+              brew install ninja
+
             if [ "${{ matrix.config.compiler }}" = "gcc" ]; then
               brew install gcc@${{ matrix.config.version }}
               echo "CC=gcc-${{ matrix.config.version }}" >> $GITHUB_ENV


### PR DESCRIPTION
The auto cleanup step that runs after `brew install` can can often add a few minutes to each macOS CI run.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
