### PR TITLE
disable inode cache on OS without pthread_mutexattr_setpshared()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ include(GNUInstallDirs)
 include(GenerateConfigurationFile)
 include(GenerateVersionFile)
 
-if(HAVE_SYS_MMAN_H)
+if(HAVE_SYS_MMAN_H AND HAVE_MUTEXATTR_SETPSHARED)
   set(INODE_CACHE_SUPPORTED 1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ include(GNUInstallDirs)
 include(GenerateConfigurationFile)
 include(GenerateVersionFile)
 
-if(HAVE_SYS_MMAN_H AND HAVE_MUTEXATTR_SETPSHARED)
+if(HAVE_SYS_MMAN_H AND HAVE_PTHREAD_MUTEXATTR_SETPSHARED)
   set(INODE_CACHE_SUPPORTED 1)
 endif()
 

--- a/cmake/GenerateConfigurationFile.cmake
+++ b/cmake/GenerateConfigurationFile.cmake
@@ -31,6 +31,7 @@ set(functions
     getpwuid
     gettimeofday
     posix_fallocate
+    pthread_mutexattr_setpshared
     realpath
     setenv
     strndup

--- a/cmake/GenerateConfigurationFile.cmake
+++ b/cmake/GenerateConfigurationFile.cmake
@@ -31,7 +31,6 @@ set(functions
     getpwuid
     gettimeofday
     posix_fallocate
-    pthread_mutexattr_setpshared
     realpath
     setenv
     strndup
@@ -57,6 +56,7 @@ check_c_source_compiles(
     }
   ]=]
   HAVE_PTHREAD_MUTEX_ROBUST)
+check_function_exists(pthread_mutexattr_setpshared HAVE_PTHREAD_MUTEXATTR_SETPSHARED)
 set(CMAKE_REQUIRED_LINK_OPTIONS)
 
 include(CheckStructHasMember)

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -88,6 +88,9 @@
 // Define if you have the "posix_fallocate.
 #cmakedefine HAVE_POSIX_FALLOCATE
 
+// Define if you have the "pthread_mutexattr_setpshared" function.
+#cmakedefine HAVE_PTHREAD_MUTEXATTR_SETPSHARED
+
 // Define if you have the <pwd.h> header file.
 #cmakedefine HAVE_PWD_H
 

--- a/src/system.hpp
+++ b/src/system.hpp
@@ -171,7 +171,7 @@ DLLIMPORT extern char** environ;
 #  define O_BINARY 0
 #endif
 
-#ifdef HAVE_SYS_MMAN_H
+#if defined(HAVE_SYS_MMAN_H) && defined(HAVE_PTHREAD_MUTEXATTR_SETPSHARED)
 #  define INODE_CACHE_SUPPORTED
 #endif
 


### PR DESCRIPTION
The inode cache requires pthread_mutexattr_setpshared() and build fails on OS with sys/mman.h that do not have this function. Here's my attempt at checking for this in the CMake files and disabling the feature if needed.