### PR TITLE
StdAtomic.cmake: probe atomic increment as well

### DIFF
--- a/cmake/StdAtomic.cmake
+++ b/cmake/StdAtomic.cmake
@@ -10,6 +10,7 @@ set(
     int main()
     {
       std::atomic<long long> x;
+      ++x;
       (void)x.load();
       return 0;
     }


### PR DESCRIPTION
On sparc there are 8-byte atomic loads and stores available in ISA
but not atomic increments. As a result linking fails as:

```
ld: src/libccache_lib.a(InodeCache.cpp.o):
    undefined reference to symbol '__atomic_fetch_add_8@@LIBATOMIC_1.0'
ld: sparc-unknown-linux-gnu/8.2.0/libatomic.so.1:
    error adding symbols: DSO missing from command line
```

The fix is to add increment into libatomic test.
tested on `sparc-unknown-linux-gnu` target.