### PR TITLE
Support -fcolor-diagnostics passed to cc1 with -Xclang

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -700,6 +700,14 @@ process_arg(Context& ctx,
     return Statistic::unsupported_compiler_option;
   }
 
+  // In the "-Xclang -fcolor-diagnostics" form, -Xclang is skipped and the
+  // -fcolor-diagnostics argument which is passed to cc1 is handled below.
+  if (args[i] == "-Xclang" && i < args.size() - 1
+      && args[i + 1] == "-fcolor-diagnostics") {
+    state.compiler_only_args_no_hash.push_back(args[i]);
+    ++i;
+  }
+
   if (args[i] == "-fcolor-diagnostics" || args[i] == "-fdiagnostics-color"
       || args[i] == "-fdiagnostics-color=always") {
     state.color_diagnostics = ColorDiagnostics::always;

--- a/test/suites/color_diagnostics.bash
+++ b/test/suites/color_diagnostics.bash
@@ -137,6 +137,15 @@ color_diagnostics_test() {
         fi
     fi
 
+    if $COMPILER_TYPE_CLANG; then
+        # ---------------------------------------------------------------------
+        TEST "-fcolor-diagnostics works when passed to cc1 with -Xclang"
+
+        color_diagnostics_generate_code test1.c
+        $CCACHE_COMPILE -Xclang -fcolor-diagnostics -Wreturn-type -c -o test1.o test1.c 2>test1.stderr
+        color_diagnostics_expect_color test1.stderr
+    fi
+
     while read -r case; do
         # ---------------------------------------------------------------------
         TEST "Cache object shared across ${case} (run_second_cpp=$run_second_cpp)"

--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -570,6 +570,8 @@ TEST_CASE("-Xclang")
     "-Xclang -fno-pch-timestamp"
     " -Xclang unsupported";
 
+  const std::string color_diag = "-Xclang -fcolor-diagnostics";
+
   const std::string extra_args =
     "-Xclang -emit-pch"
     " -Xclang -emit-pth";
@@ -580,8 +582,9 @@ TEST_CASE("-Xclang")
     " -Xclang -include-pth pth_path1"
     " -Xclang -include-pth -Xclang pth_path2";
 
-  ctx.orig_args = Args::from_string("gcc -c foo.c " + common_args + " "
-                                    + extra_args + " " + pch_pth_variants);
+  ctx.orig_args =
+    Args::from_string("gcc -c foo.c " + common_args + " " + color_diag + " "
+                      + extra_args + " " + pch_pth_variants);
   Util::write_file("foo.c", "");
 
   const ProcessArgsResult result = process_args(ctx);
@@ -589,8 +592,8 @@ TEST_CASE("-Xclang")
         == "gcc " + common_args + " " + pch_pth_variants);
   CHECK(result.extra_args_to_hash.to_string() == extra_args);
   CHECK(result.compiler_args.to_string()
-        == "gcc " + common_args + " " + extra_args + " " + pch_pth_variants
-             + " -c");
+        == "gcc " + common_args + " " + color_diag + " " + extra_args + " "
+             + pch_pth_variants + " -c");
 }
 
 TEST_CASE("-x")


### PR DESCRIPTION
Before this change `clang++ -Xclang -fcolor-diagnostics -c foo.cc`
would result in diagnostics without color if stderr was not a TTY.

Fixes #801.