### PR TITLE
Build ccache with xlclang++ on AIX72

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -34,6 +34,9 @@
 #  define _XOPEN_SOURCE 500
 #elif defined(__FreeBSD__)
 #  define _XOPEN_SOURCE 700
+#elif defined(__ibmxl__) && defined(__clang__) // Compiler xlclang
+#  define _XOPEN_SOURCE 600
+#  define _ALL_SOURCE 1
 #elif !defined(__SunOS_5_11) && !defined(__APPLE__)
 #  define _XOPEN_SOURCE
 #endif
@@ -165,3 +168,9 @@
 
 // Define if you have the "PTHREAD_MUTEX_ROBUST" constant.
 #cmakedefine HAVE_PTHREAD_MUTEX_ROBUST
+
+#if defined(__ibmxl__) && defined(__clang__) // Compiler xlclang
+#  undef HAVE_VARARGS_H // varargs.h would hide macros of stdarg.h
+#  undef HAVE_STRUCT_STAT_ST_CTIM
+#  undef HAVE_STRUCT_STAT_ST_MTIM
+#endif

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -64,9 +64,9 @@
 #elif defined(_WIN32)
 #  include "third_party/win32/getopt.h"
 #else
-  extern "C" {
-#    include "third_party/getopt_long.h"
-  }
+extern "C" {
+#  include "third_party/getopt_long.h"
+}
 #endif
 
 #ifdef _WIN32

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -64,7 +64,9 @@
 #elif defined(_WIN32)
 #  include "third_party/win32/getopt.h"
 #else
-#  include "third_party/getopt_long.h"
+  extern "C" {
+#    include "third_party/getopt_long.h"
+  }
 #endif
 
 #ifdef _WIN32

--- a/src/system.hpp
+++ b/src/system.hpp
@@ -80,7 +80,7 @@
 // function is available in libc.a. This extern define ensures that it is
 // usable within the ccache code base.
 #ifdef _AIX
-extern int usleep(useconds_t);
+extern "C" int usleep(useconds_t);
 #endif
 
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -1080,6 +1080,8 @@ TEST_CASE("Util::wipe_path")
   {
 #ifdef _WIN32
     const char error[] = "failed to rmdir .: Permission denied";
+#elif defined(_AIX)
+    const char error[] = "failed to rmdir .: Device busy";
 #else
     const char error[] = "failed to rmdir .: Invalid argument";
 #endif


### PR DESCRIPTION
- Update of config.h.in to build with xlclang++ on AIX72
- Little fixes in code chunks never built on usual platforms
