### PR TITLE
Fix "Debug option" test

### DIFF
--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -64,7 +64,7 @@ base_tests() {
     expect_stat 'cache miss' 1
 
     $REAL_COMPILER -c -o reference_test1.o test1.c -g
-    expect_equal_object_files reference_test1.o reference_test1.o
+    expect_equal_object_files reference_test1.o test1.o
 
     # -------------------------------------------------------------------------
     TEST "Output option"


### PR DESCRIPTION
Trivial fix for 'debug option' test from base testsuite.
Previously `reference_test1.o` was compared to itself, therefore not really testing anything.
Now it properly compares `reference_test1.o` to `test1.o` to check that CCACHE produces the same output as real compiler.