### PR TITLE
Fix Util::read_file returning truncated results if size_hint is an underestimate

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1180,7 +1180,7 @@ read_file(const std::string& path, size_t size_hint)
   result.resize(size_hint);
 
   while (true) {
-    if (pos > result.size()) {
+    if (pos == result.size()) {
       result.resize(2 * result.size());
     }
     const size_t max_read = result.size() - pos;

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -820,6 +820,10 @@ TEST_CASE("Util::read_file and Util::write_file")
 #else
   CHECK(data == "carpet\n\n");
 #endif
+
+  Util::write_file("size_hint_test", std::string(8192, '\0'));
+  CHECK(Util::read_file("size_hint_test", 4096 /*size_hint*/).size() == 8192);
+
   CHECK_THROWS_WITH(Util::read_file("does/not/exist"),
                     "No such file or directory");
 


### PR DESCRIPTION
If the size_hint passed to `Util::read_file()` was an underestimate, or the platform's `stat()` implementation gives an inaccurate file size (e.g. MinGW) then `Util::read_file()` would only issue a single `read()` call instead of reading the entire file.

Fixes #803.
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
