### PR TITLE
test: print line number of failing assert

### DIFF
--- a/test/run
+++ b/test/run
@@ -43,11 +43,15 @@ bold() {
     printf "$ansi_bold%s$ansi_reset\n" "$*"
 }
 
-test_failed() {
+test_failed_internal() {
+    # called from functions inside this file, so skip the first caller:
+    line="$(caller 1)"
+    line=" (line ${line%% *})"
+
     echo
     red FAILED
     echo
-    echo "Test suite:     $(bold $CURRENT_SUITE)"
+    echo "Test suite:     $(bold $CURRENT_SUITE)$line"
     echo "Test case:      $(bold $CURRENT_TEST)"
     echo "Failure reason: $(red "$1")"
     echo
@@ -57,6 +61,11 @@ test_failed() {
     echo "Test data and log file have been left in $TESTDIR / $TEST_FAILED_SYMLINK"
     symlink_testdir_on_failure
     exit 1
+}
+
+# indirection so the line returned by `caller` is correct
+test_failed() {
+    test_failed_internal "$@"
 }
 
 find_compiler() {
@@ -163,62 +172,62 @@ expect_stat() {
     done < <($CCACHE -s)
 
     if [ "$expected_value" != "$value" ]; then
-        test_failed "Expected \"$stat\" to be $expected_value, actual $value"
+        test_failed_internal "Expected \"$stat\" to be $expected_value, actual $value"
     fi
 }
 
 expect_exists() {
     if [ ! -e "$1" ]; then
-        test_failed "Expected $1 to exist, but it's missing"
+        test_failed_internal "Expected $1 to exist, but it's missing"
     fi
 }
 
 expect_missing() {
     if [ -e "$1" ]; then
-        test_failed "Expected $1 to be missing, but it exists"
+        test_failed_internal "Expected $1 to be missing, but it exists"
     fi
 }
 
 expect_equal_content() {
     if [ ! -e "$1" ]; then
-        test_failed "expect_equal_content: $1 missing"
+        test_failed_internal "expect_equal_content: $1 missing"
     fi
     if [ ! -e "$2" ]; then
-        test_failed "expect_equal_content: $2 missing"
+        test_failed_internal "expect_equal_content: $2 missing"
     fi
     if ! cmp -s "$1" "$2"; then
-        test_failed "$1 and $2 differ"
+        test_failed_internal "$1 and $2 differ"
     fi
 }
 
 expect_equal_text_content() {
     if [ ! -e "$1" ]; then
-        test_failed "expect_equal_text_content: $1 missing"
+        test_failed_internal "expect_equal_text_content: $1 missing"
     fi
     if [ ! -e "$2" ]; then
-        test_failed "expect_equal_text_content: $2 missing"
+        test_failed_internal "expect_equal_text_content: $2 missing"
     fi
     if ! cmp -s "$1" "$2"; then
-        test_failed "$1 and $2 differ: $(echo; diff -u "$1" "$2")"
+        test_failed_internal "$1 and $2 differ: $(echo; diff -u "$1" "$2")"
     fi
 }
 
 expect_different_content() {
     if [ ! -e "$1" ]; then
-        test_failed "expect_different_content: $1 missing"
+        test_failed_internal "expect_different_content: $1 missing"
     fi
     if [ ! -e "$2" ]; then
-        test_failed "expect_different_content: $2 missing"
+        test_failed_internal "expect_different_content: $2 missing"
     fi
     if cmp -s "$1" "$2"; then
-        test_failed "$1 and $2 are identical"
+        test_failed_internal "$1 and $2 are identical"
     fi
 }
 
 is_equal_object_files() {
     if $HOST_OS_LINUX && $COMPILER_TYPE_CLANG; then
         if ! command -v eu-elfcmp >/dev/null; then
-            test_failed "Please install elfutils to get eu-elfcmp"
+            test_failed_internal "Please install elfutils to get eu-elfcmp"
         fi
         eu-elfcmp -q "$1" "$2"
     elif $HOST_OS_FREEBSD && $COMPILER_TYPE_CLANG; then
@@ -250,7 +259,7 @@ is_equal_object_files() {
 expect_equal_object_files() {
     is_equal_object_files "$1" "$2"
     if [ $? -ne 0 ]; then
-        test_failed "Objects differ: $1 != $2"
+        test_failed_internal "Objects differ: $1 != $2"
     fi
 }
 
@@ -259,10 +268,10 @@ expect_content() {
     local content="$2"
 
     if [ ! -e "$file" ]; then
-        test_failed "$file not found"
+        test_failed_internal "$file not found"
     fi
     if [ "$(cat $file)" != "$content" ]; then
-        test_failed "Bad content of $file.\nExpected: $content\nActual: $(cat $file)"
+        test_failed_internal "Bad content of $file.\nExpected: $content\nActual: $(cat $file)"
     fi
 }
 
@@ -271,10 +280,10 @@ expect_contains() {
     local string="$2"
 
     if [ ! -e "$file" ]; then
-        test_failed "$file not found"
+        test_failed_internal "$file not found"
     fi
-    if ! fgrep -q "$string" "$file"; then
-        test_failed "File $file does not contain \"$string\"\nActual content: $(cat $file)"
+    if ! fgrep -q -- "$string" "$file"; then
+        test_failed_internal "File $file does not contain \"$string\"\nActual content: $(cat $file)"
     fi
 }
 
@@ -283,10 +292,10 @@ expect_not_contains() {
     local string="$2"
 
     if [ ! -e "$file" ]; then
-        test_failed "$file not found"
+        test_failed_internal "$file not found"
     fi
-    if fgrep -q "$string" "$file"; then
-        test_failed "File $file contains \"$string\"\nActual content: $(cat $file)"
+    if fgrep -q -- "$string" "$file"; then
+        test_failed_internal "File $file contains \"$string\"\nActual content: $(cat $file)"
     fi
 }
 
@@ -295,7 +304,7 @@ expect_objdump_contains() {
     local string="$2"
 
     if ! objdump_cmd "$file" | objdump_grep_cmd "$string"; then
-        test_failed "File $file does not contain \"$string\""
+        test_failed_internal "File $file does not contain \"$string\""
     fi
 }
 
@@ -304,7 +313,7 @@ expect_objdump_not_contains() {
     local string="$2"
 
     if objdump_cmd "$file" | objdump_grep_cmd "$string"; then
-        test_failed "File $file contains \"$string\""
+        test_failed_internal "File $file contains \"$string\""
     fi
 }
 
@@ -314,7 +323,7 @@ expect_file_count() {
     local dir=$3
     local actual=`find $dir -type f -name "$pattern" | wc -l`
     if [ $actual -ne $expected ]; then
-        test_failed "Found $actual (expected $expected) $pattern files in $dir"
+        test_failed_internal "Found $actual (expected $expected) $pattern files in $dir"
     fi
 }
 
@@ -323,7 +332,7 @@ expect_newer_than() {
     local newer_file=$1
     local older_file=$2
     if [ "$newer_file" -ot "$older_file" ]; then
-        test_failed "$newer_file is older than $older_file"
+        test_failed_internal "$newer_file is older than $older_file"
     fi
 }
 
@@ -332,7 +341,7 @@ expect_perm() {
     local expected_perm="$2"
     local actual_perm=$(ls -ld "$path" | awk '{print substr($1, 1, 10)}')
     if [ "$expected_perm" != "$actual_perm" ]; then
-        test_failed "Expected permissions for $path to be $expected_perm, actual $actual_perm"
+        test_failed_internal "Expected permissions for $path to be $expected_perm, actual $actual_perm"
     fi
 }
 


### PR DESCRIPTION
The line is printed with "Test suite:" as line numbers are counted relative to the start of that file, and to avoid adding another line to the output:

```
Running test suite base.
FAILED

Test suite:     base (line 11)
Test case:      Base case
Failure reason: Objects differ: reference_test1.o != test1.o
```

