### PR TITLE
Fix win32execute

### DIFF
--- a/src/Win32Util.cpp
+++ b/src/Win32Util.cpp
@@ -67,8 +67,8 @@ argv_to_string(const char* const* argv, const std::string& prefix)
     for (size_t j = 0; arg[j]; ++j) {
       switch (arg[j]) {
       case '\\':
-        ++bs;
-        break;
+        //++bs;
+        //break;
       // Fallthrough.
       case '"':
         bs = (bs << 1) + 1;

--- a/src/Win32Util.cpp
+++ b/src/Win32Util.cpp
@@ -55,7 +55,7 @@ error_message(DWORD error_code)
 }
 
 std::string
-argv_to_string(const char* const* argv, const std::string& prefix)
+argv_to_string(const char* const* argv, const std::string& prefix, bool escape_backslashes)
 {
   std::string result;
   size_t i = 0;
@@ -67,9 +67,11 @@ argv_to_string(const char* const* argv, const std::string& prefix)
     for (size_t j = 0; arg[j]; ++j) {
       switch (arg[j]) {
       case '\\':
-        //++bs;
-        // break;
-      // Fallthrough.
+    	if (!escape_backslashes) {
+          ++bs;
+          break;
+    	}
+        // Fallthrough.
       case '"':
         bs = (bs << 1) + 1;
       // Fallthrough.

--- a/src/Win32Util.cpp
+++ b/src/Win32Util.cpp
@@ -68,7 +68,7 @@ argv_to_string(const char* const* argv, const std::string& prefix)
       switch (arg[j]) {
       case '\\':
         //++bs;
-        //break;
+        // break;
       // Fallthrough.
       case '"':
         bs = (bs << 1) + 1;

--- a/src/Win32Util.cpp
+++ b/src/Win32Util.cpp
@@ -55,7 +55,9 @@ error_message(DWORD error_code)
 }
 
 std::string
-argv_to_string(const char* const* argv, const std::string& prefix, bool escape_backslashes)
+argv_to_string(const char* const* argv,
+               const std::string& prefix,
+               bool escape_backslashes)
 {
   std::string result;
   size_t i = 0;
@@ -67,10 +69,10 @@ argv_to_string(const char* const* argv, const std::string& prefix, bool escape_b
     for (size_t j = 0; arg[j]; ++j) {
       switch (arg[j]) {
       case '\\':
-    	if (!escape_backslashes) {
+        if (!escape_backslashes) {
           ++bs;
           break;
-    	}
+        }
         // Fallthrough.
       case '"':
         bs = (bs << 1) + 1;

--- a/src/Win32Util.hpp
+++ b/src/Win32Util.hpp
@@ -30,7 +30,7 @@ std::string add_exe_suffix(const std::string& program);
 
 // Recreate a Windows command line string based on `argv`. If `prefix` is
 // non-empty, add it as the first argument.
-std::string argv_to_string(const char* const* argv, const std::string& prefix);
+std::string argv_to_string(const char* const* argv, const std::string& prefix, bool escape_backslashes = false);
 
 // Return the error message corresponding to `error_code`.
 std::string error_message(DWORD error_code);

--- a/src/Win32Util.hpp
+++ b/src/Win32Util.hpp
@@ -30,6 +30,8 @@ std::string add_exe_suffix(const std::string& program);
 
 // Recreate a Windows command line string based on `argv`. If `prefix` is
 // non-empty, add it as the first argument.
+// If escape_backslashes is true, emit additional backslash for each backslash
+// which is not preceding '"' and is not at the end of argv[i] either.
 std::string argv_to_string(const char* const* argv,
                            const std::string& prefix,
                            bool escape_backslashes = false);

--- a/src/Win32Util.hpp
+++ b/src/Win32Util.hpp
@@ -30,7 +30,9 @@ std::string add_exe_suffix(const std::string& program);
 
 // Recreate a Windows command line string based on `argv`. If `prefix` is
 // non-empty, add it as the first argument.
-std::string argv_to_string(const char* const* argv, const std::string& prefix, bool escape_backslashes = false);
+std::string argv_to_string(const char* const* argv,
+                           const std::string& prefix,
+                           bool escape_backslashes = false);
 
 // Return the error message corresponding to `error_code`.
 std::string error_message(DWORD error_code);

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2326,7 +2326,7 @@ cache_compilation(int argc, const char* const* argv)
       saved_orig_args = std::move(ctx.orig_args);
       auto execv_argv = saved_orig_args.to_argv();
       LOG("Executing {}", Util::format_argv_for_logging(execv_argv.data()));
-      // Run execv below after ctx and finalizer have been destructed.
+      // Run execute_noreturn below after ctx and finalizer have been destructed.
     }
   }
 
@@ -2335,8 +2335,8 @@ cache_compilation(int argc, const char* const* argv)
       umask(*original_umask);
     }
     auto execv_argv = saved_orig_args.to_argv();
-    execv(execv_argv[0], const_cast<char* const*>(execv_argv.data()));
-    throw Fatal("execv of {} failed: {}", execv_argv[0], strerror(errno));
+    execute_noreturn(const_cast<char* const*>(execv_argv.data()), saved_temp_dir);
+    throw Fatal("execute_noreturn of {} failed: {}", execv_argv[0], strerror(errno));
   }
 
   return EXIT_SUCCESS;

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2326,7 +2326,8 @@ cache_compilation(int argc, const char* const* argv)
       saved_orig_args = std::move(ctx.orig_args);
       auto execv_argv = saved_orig_args.to_argv();
       LOG("Executing {}", Util::format_argv_for_logging(execv_argv.data()));
-      // Run execute_noreturn below after ctx and finalizer have been destructed.
+      // Run execute_noreturn below after ctx and finalizer have been
+      // destructed.
     }
   }
 
@@ -2335,8 +2336,10 @@ cache_compilation(int argc, const char* const* argv)
       umask(*original_umask);
     }
     auto execv_argv = saved_orig_args.to_argv();
-    execute_noreturn(const_cast<char* const*>(execv_argv.data()), saved_temp_dir);
-    throw Fatal("execute_noreturn of {} failed: {}", execv_argv[0], strerror(errno));
+    execute_noreturn(const_cast<char* const*>(execv_argv.data()),
+                     saved_temp_dir);
+    throw Fatal(
+      "execute_noreturn of {} failed: {}", execv_argv[0], strerror(errno));
   }
 
   return EXIT_SUCCESS;

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -235,7 +235,7 @@ execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
 }
 
 void
-execute_noreturn(const char* const* argv, const std::string& temp_dir)
+execute_noreturn(const char* const* argv, const std::string& /* unused */)
 {
   execv(argv[0], const_cast<char* const*>(argv));
 }

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -112,11 +112,11 @@ win32execute(const char* path,
   const char* lpAppName = full_path.c_str();
   if (args.length() > 8192) {
     TemporaryFile tmp_file(FMT("{}/cmd_args", temp_dir));
+    args = Win32Util::argv_to_string(argv+1, sh);
     Util::write_fd(*tmp_file.fd, args.data(), args.length());
-    args = FMT("@{}", tmp_file.path);
+    args = FMT("{} @{}", lpAppName, tmp_file.path);
     tmp_file_path = tmp_file.path;
-    lpAppName = NULL;
-    LOG("args from file option is {}", args);
+    LOG("args from file {}", tmp_file.path);
   }
   BOOL ret = CreateProcess(lpAppName,
                            const_cast<char*>(args.c_str()),

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -170,7 +170,7 @@ execute(const Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
 
   {
     SignalHandlerBlocker signal_handler_blocker;
-    *ctx.compiler_pid = fork();
+    ctx.compiler_pid = fork();
   }
 
   if (*pid == -1) {

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -36,6 +36,14 @@
 using nonstd::string_view;
 
 #ifdef _WIN32
+static int
+win32execute(const char* path,
+             const char* const* argv,
+             int doreturn,
+             int fd_stdout,
+             int fd_stderr,
+             const std::string& temp_dir);
+
 int
 execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
 {
@@ -45,6 +53,17 @@ execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
                       fd_out.release(),
                       fd_err.release(),
                       ctx.config.temporary_dir());
+}
+
+void
+execute_noreturn(const char* const* argv, const std::string& temp_dir)
+{
+  win32execute(argv[0],
+                      argv,
+                      0,
+                      -1,
+                      -1,
+                      temp_dir);
 }
 
 std::string
@@ -213,6 +232,12 @@ execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
   }
 
   return WEXITSTATUS(status);
+}
+
+void
+execute_noreturn(const char* const* argv, const std::string& temp_dir)
+{
+  execv(argv[0], argv);
 }
 #endif
 

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -39,7 +39,12 @@ using nonstd::string_view;
 int
 execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
 {
-  return win32execute(argv[0], argv, 1, fd_out.release(), fd_err.release(), ctx.config.temporary_dir());
+  return win32execute(argv[0],
+                      argv,
+                      1,
+                      fd_out.release(),
+                      fd_err.release(),
+                      ctx.config.temporary_dir());
 }
 
 std::string
@@ -112,7 +117,7 @@ win32execute(const char* path,
   const char* lpAppName = full_path.c_str();
   if (args.length() > 8192) {
     TemporaryFile tmp_file(FMT("{}/cmd_args", temp_dir));
-    args = Win32Util::argv_to_string(argv+1, sh);
+    args = Win32Util::argv_to_string(argv + 1, sh);
     Util::write_fd(*tmp_file.fd, args.data(), args.length());
     args = FMT("{} @{}", lpAppName, tmp_file.path);
     tmp_file_path = tmp_file.path;

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -37,7 +37,7 @@ using nonstd::string_view;
 
 #ifdef _WIN32
 int
-execute(const Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
+execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
 {
   return win32execute(argv[0], argv, 1, fd_out.release(), fd_err.release(), ctx.config.temporary_dir());
 }
@@ -164,7 +164,7 @@ win32execute(const char* path,
 // Execute a compiler backend, capturing all output to the given paths the full
 // path to the compiler to run is in argv[0].
 int
-execute(const Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
+execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
 {
   LOG("Executing {}", Util::format_argv_for_logging(argv));
 
@@ -173,11 +173,11 @@ execute(const Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
     ctx.compiler_pid = fork();
   }
 
-  if (*pid == -1) {
+  if (ctx.compiler_pid == -1) {
     throw Fatal("Failed to fork: {}", strerror(errno));
   }
 
-  if (*pid == 0) {
+  if (ctx.compiler_pid == 0) {
     // Child.
     dup2(*fd_out, STDOUT_FILENO);
     fd_out.close();

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -117,7 +117,7 @@ win32execute(const char* path,
   const char* lpAppName = full_path.c_str();
   if (args.length() > 8192) {
     TemporaryFile tmp_file(FMT("{}/cmd_args", temp_dir));
-    args = Win32Util::argv_to_string(argv + 1, sh);
+    args = Win32Util::argv_to_string(argv + 1, sh, true);
     Util::write_fd(*tmp_file.fd, args.data(), args.length());
     args = FMT("{} @{}", lpAppName, tmp_file.path);
     tmp_file_path = tmp_file.path;

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -114,16 +114,15 @@ win32execute(const char* path,
   std::string args = Win32Util::argv_to_string(argv, sh);
   std::string full_path = Win32Util::add_exe_suffix(path);
   std::string tmp_file_path;
-  const char* lpAppName = full_path.c_str();
   if (args.length() > 8192) {
     TemporaryFile tmp_file(FMT("{}/cmd_args", temp_dir));
     args = Win32Util::argv_to_string(argv + 1, sh, true);
     Util::write_fd(*tmp_file.fd, args.data(), args.length());
-    args = FMT("{} @{}", lpAppName, tmp_file.path);
+    args = FMT("{} @{}", full_path, tmp_file.path);
     tmp_file_path = tmp_file.path;
     LOG("args from file {}", tmp_file.path);
   }
-  BOOL ret = CreateProcess(lpAppName,
+  BOOL ret = CreateProcess(full_path.c_str(),
                            const_cast<char*>(args.c_str()),
                            nullptr,
                            nullptr,

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -237,7 +237,7 @@ execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
 void
 execute_noreturn(const char* const* argv, const std::string& temp_dir)
 {
-  execv(argv[0], argv);
+  execv(argv[0], const_cast<char* const*>(argv));
 }
 #endif
 

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -192,7 +192,7 @@ execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
   int status;
   int result;
 
-  while ((result = waitpid(*pid, &status, 0)) != *pid) {
+  while ((result = waitpid(ctx.compiler_pid, &status, 0)) != ctx.compiler_pid) {
     if (result == -1 && errno == EINTR) {
       continue;
     }
@@ -201,7 +201,7 @@ execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
 
   {
     SignalHandlerBlocker signal_handler_blocker;
-    *pid = 0;
+    ctx.compiler_pid = 0;
   }
 
   if (WEXITSTATUS(status) == 0 && WIFSIGNALED(status)) {

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -36,13 +36,12 @@
 using nonstd::string_view;
 
 #ifdef _WIN32
-static int
-win32execute(const char* path,
-             const char* const* argv,
-             int doreturn,
-             int fd_stdout,
-             int fd_stderr,
-             const std::string& temp_dir);
+static int win32execute(const char* path,
+                        const char* const* argv,
+                        int doreturn,
+                        int fd_stdout,
+                        int fd_stderr,
+                        const std::string& temp_dir);
 
 int
 execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
@@ -58,12 +57,7 @@ execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err)
 void
 execute_noreturn(const char* const* argv, const std::string& temp_dir)
 {
-  win32execute(argv[0],
-                      argv,
-                      0,
-                      -1,
-                      -1,
-                      temp_dir);
+  win32execute(argv[0], argv, 0, -1, -1, temp_dir);
 }
 
 std::string

--- a/src/execute.hpp
+++ b/src/execute.hpp
@@ -26,7 +26,7 @@
 
 class Context;
 
-int execute(const char* const* argv, Fd&& fd_out, Fd&& fd_err, pid_t* pid);
+int execute(const Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err);
 
 // Find an executable named `name` in `$PATH`. Exclude any executables that are
 // links to `exclude_name`.
@@ -44,5 +44,6 @@ int win32execute(const char* path,
                  const char* const* argv,
                  int doreturn,
                  int fd_stdout,
-                 int fd_stderr);
+                 int fd_stderr,
+                 const std::string& temp_dir);
 #endif

--- a/src/execute.hpp
+++ b/src/execute.hpp
@@ -28,6 +28,8 @@ class Context;
 
 int execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err);
 
+void execute_noreturn(const char* const* argv, const std::string& temp_dir);
+
 // Find an executable named `name` in `$PATH`. Exclude any executables that are
 // links to `exclude_name`.
 std::string find_executable(const Context& ctx,
@@ -40,10 +42,4 @@ std::string find_executable_in_path(const std::string& name,
 
 #ifdef _WIN32
 std::string win32getshell(const std::string& path);
-int win32execute(const char* path,
-                 const char* const* argv,
-                 int doreturn,
-                 int fd_stdout,
-                 int fd_stderr,
-                 const std::string& temp_dir);
 #endif

--- a/src/execute.hpp
+++ b/src/execute.hpp
@@ -26,7 +26,7 @@
 
 class Context;
 
-int execute(const Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err);
+int execute(Context& ctx, const char* const* argv, Fd&& fd_out, Fd&& fd_err);
 
 // Find an executable named `name` in `$PATH`. Exclude any executables that are
 // links to `exclude_name`.

--- a/src/system.hpp
+++ b/src/system.hpp
@@ -139,7 +139,9 @@ const mode_t S_IWUSR = mode_t(_S_IWRITE);
 #  define NOMINMAX 1
 #  include <windows.h>
 #  define mkdir(a, b) _mkdir(a)
-#  define execv(a, b) do_not_call_execv_on_windows // to protect against incidental use of MinGW execv
+#  define execv(a, b)                                                          \
+    do_not_call_execv_on_windows // to protect against incidental use of MinGW
+                                 // execv
 #  define strncasecmp _strnicmp
 #  define strcasecmp _stricmp
 

--- a/src/system.hpp
+++ b/src/system.hpp
@@ -139,7 +139,7 @@ const mode_t S_IWUSR = mode_t(_S_IWRITE);
 #  define NOMINMAX 1
 #  include <windows.h>
 #  define mkdir(a, b) _mkdir(a)
-#  define execv(a, b) win32execute(a, b, 0, -1, -1, saved_temp_dir)
+#  define execv(a, b) do_not_call_execv_on_windows // to protect against incidental use of MinGW execv
 #  define strncasecmp _strnicmp
 #  define strcasecmp _stricmp
 

--- a/src/system.hpp
+++ b/src/system.hpp
@@ -139,7 +139,7 @@ const mode_t S_IWUSR = mode_t(_S_IWRITE);
 #  define NOMINMAX 1
 #  include <windows.h>
 #  define mkdir(a, b) _mkdir(a)
-#  define execv(a, b) win32execute(a, b, 0, -1, -1)
+#  define execv(a, b) win32execute(a, b, 0, -1, -1, saved_temp_dir)
 #  define strncasecmp _strnicmp
 #  define strcasecmp _stricmp
 

--- a/unittest/test_Win32Util.cpp
+++ b/unittest/test_Win32Util.cpp
@@ -38,6 +38,14 @@ TEST_CASE("Win32Util::argv_to_string")
     CHECK(Win32Util::argv_to_string(argv, "")
           == R"("a" "b c" "\"d\"" "'e'" "\\\"h")");
   }
+  {
+    const char* const argv[] = {"a\\b\\c", nullptr};
+    CHECK(Win32Util::argv_to_string(argv, "") == R"("a\b\c")");
+  }
+  {
+    const char* const argv[] = {"a\\b\\c", nullptr};
+    CHECK(Win32Util::argv_to_string(argv, "", true) == R"("a\\b\\c")");
+  }
 }
 
 TEST_SUITE_END();

--- a/unittest/test_Win32Util.cpp
+++ b/unittest/test_Win32Util.cpp
@@ -51,8 +51,9 @@ TEST_CASE("Win32Util::argv_to_string")
     CHECK(Win32Util::argv_to_string(argv, "") == R"("a\b \\\"c\\\" \\")");
   }
   {
-	const char* const argv[] = {R"(a\b \"c\" \)", nullptr};
-	CHECK(Win32Util::argv_to_string(argv, "", true) == R"("a\\b \\\"c\\\" \\")");
+    const char* const argv[] = {R"(a\b \"c\" \)", nullptr};
+    CHECK(Win32Util::argv_to_string(argv, "", true)
+          == R"("a\\b \\\"c\\\" \\")");
   }
 }
 

--- a/unittest/test_Win32Util.cpp
+++ b/unittest/test_Win32Util.cpp
@@ -46,6 +46,14 @@ TEST_CASE("Win32Util::argv_to_string")
     const char* const argv[] = {"a\\b\\c", nullptr};
     CHECK(Win32Util::argv_to_string(argv, "", true) == R"("a\\b\\c")");
   }
+  {
+    const char* const argv[] = {R"(a\b \"c\" \)", nullptr};
+    CHECK(Win32Util::argv_to_string(argv, "") == R"("a\b \\\"c\\\" \\")");
+  }
+  {
+	const char* const argv[] = {R"(a\b \"c\" \)", nullptr};
+	CHECK(Win32Util::argv_to_string(argv, "", true) == R"("a\\b \\\"c\\\" \\")");
+  }
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
I'm trying to make Ccache work (again) on Windows. What is broken: handling of "execute" with long command parameters (see win32execute).

In more details:
- parameter lpCommandLine was formatted incorrectly (it has to contain app name too)
- temporary file with parameters to the compiler was formatted incorrectly (it should NOT contain app name; if it contains backslashes, then these backslashes need to be escaped as double-backslashes)
- wrong location (directory) of temporary files in win32execute
- premature deletion of temporary files in win32execute
