### PR TITLE
Changed zstd url back to http

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -11,7 +11,7 @@ To build ccache you need:
   languages](https://ccache.dev/platform-compiler-language-support.html) for
   details.
 - A C99 compiler.
-- [libzstd](https://www.zstd.net). If you don't have libzstd installed and
+- [libzstd](http://www.zstd.net). If you don't have libzstd installed and
   can't or don't want to install it in a standard system location, there are
   two options:
     1. Install zstd in a custom path and set `CMAKE_PREFIX_PATH` to it, e.g.


### PR DESCRIPTION
 It looks like https://zstd.net isn't working anymore, however, http://zstd.net works and simply redirects to https://facebook.github.io/zstd/ which is served through https.

This change essentially reverts a single change from commit a0f32f161f1b8b9c5d287ca8abe88e3fd1e940a2: where the `zstd` url was changed from `http` to `https`.