### PR TITLE
Stat: treat pending deletes as missing files on Windows 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -267,11 +267,11 @@ jobs:
 
           - name: Clang-Tidy
             os: ubuntu-18.04
-            CC: clang
-            CXX: clang++
+            CC: clang-9
+            CXX: clang++-9
             RUN_TESTS: none
-            CMAKE_PARAMS: -DENABLE_CLANG_TIDY=ON
-            apt_get: libzstd-dev clang-tidy
+            CMAKE_PARAMS: -DENABLE_CLANG_TIDY=ON -DCLANGTIDY=/usr/bin/clang-tidy-9
+            apt_get: libzstd-dev clang-9 clang-tidy-9
 
     steps:
       - name: Get source

--- a/src/Win32Util.hpp
+++ b/src/Win32Util.hpp
@@ -39,4 +39,8 @@ std::string argv_to_string(const char* const* argv,
 // Return the error message corresponding to `error_code`.
 std::string error_message(DWORD error_code);
 
+// Returns the last NTSTATUS code. (These can be more specific than the
+// corresponding Win32 error code.)
+NTSTATUS get_last_ntstatus();
+
 } // namespace Win32Util

--- a/src/system.hpp
+++ b/src/system.hpp
@@ -158,7 +158,10 @@ const mode_t S_IWUSR = mode_t(_S_IWRITE);
 #  include <io.h>
 #  include <process.h>
 #  define NOMINMAX 1
+#  define WIN32_NO_STATUS
 #  include <windows.h>
+#  undef WIN32_NO_STATUS
+#  include <ntstatus.h>
 #  define mkdir(a, b) _mkdir(a)
 #  define execv(a, b)                                                          \
     do_not_call_execv_on_windows // to protect against incidental use of MinGW

--- a/unittest/test_Stat.cpp
+++ b/unittest/test_Stat.cpp
@@ -579,7 +579,7 @@ TEST_CASE("Win32 Pending Delete" * doctest::skip(running_under_wine()))
   // will persist until the handle is closed. Until the file is closed, new
   // handles cannot be created to the file; attempts to do so fail with
   // ERROR_ACCESS_DENIED/STATUS_DELETE_PENDING. Our stat implementation maps
-  // these to EACCES. (Should this be ENOENT?)
+  // these to ENOENT.
   FILE_DISPOSITION_INFO info{};
   info.DeleteFile = TRUE;
   REQUIRE_MESSAGE(SetFileInformationByHandle(
@@ -590,14 +590,14 @@ TEST_CASE("Win32 Pending Delete" * doctest::skip(running_under_wine()))
   {
     auto st = Stat::stat("file");
     CHECK(!st);
-    CHECK(st.error_number() == EACCES);
+    CHECK(st.error_number() == ENOENT);
   }
 
   SUBCASE("lstat file pending delete")
   {
     auto st = Stat::lstat("file");
     CHECK(!st);
-    CHECK(st.error_number() == EACCES);
+    CHECK(st.error_number() == ENOENT);
   }
 }
 


### PR DESCRIPTION
Win32 functions like `CreateFile` return `ERROR_ACCESS_DENIED` when a file is in the process of being deleted, which gets mapped to an errno of `EACCES`. For the purposes of `Stat::stat` and `Stat::lstat`, it's more useful to treat this as a missing file and map this to an errno of `ENOENT`.

Speculative fix for issue noted by @brechtsanders in https://github.com/ccache/ccache/issues/831#issuecomment-811029194

> [...]  I got an error building gstreamer 1.18.4 in one of my MinGW-w64 environments:
> ```
> ccache: error: failed to lstat D:\Prog\winlibs64-10.2.1\home/ccache/tmp/tmp.cpp_stdout.pBIXIw.i: Permission denied
> ```

Also: fix clang-tidy job following GitHub changing default clang version in their Ubuntu 18.04 runners. https://github.com/actions/virtual-environments/issues/2950