### PR TITLE
test: Use `env` instead of `compgen -e`

### DIFF
--- a/test/run
+++ b/test/run
@@ -346,11 +346,11 @@ expect_perm() {
 }
 
 reset_environment() {
-    while IFS= read -r name; do
+    while IFS='=' read -r name value; do
         if [[ $name =~ ^CCACHE_[A-Z0-9_]*$ ]]; then
             unset $name
         fi
-    done < <(compgen -e)
+    done < <(env)
 
     unset GCC_COLORS
     unset TERM


### PR DESCRIPTION
`compgen` isn't available in non-interactive bash, so this change just updates `test/run` to use `env` instead.