### PR TITLE
Fix performance impact from 'Canonicalize path for comparison; Clang …

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -398,14 +398,14 @@ do_remember_include_file(Context& ctx,
     return true;
   }
 
-  if (ctx.included_files.find(path) != ctx.included_files.end()) {
-    // Already known include file.
-    return true;
-  }
-
   // Canonicalize path for comparison; Clang uses ./header.h.
   if (Util::starts_with(path, "./")) {
     path.erase(0, 2);
+  }
+
+  if (ctx.included_files.find(path) != ctx.included_files.end()) {
+    // Already known include file.
+    return true;
   }
 
 #ifdef _WIN32


### PR DESCRIPTION
…uses ./header.h'

Problem Summary and RCA:
The 'ctx.included_files.find(path)' was done before 'Canonicalize path for comparison; Clang uses ./header.h' which using './header.h'.
The following operation, such as 'ctx.included_files.emplace(path, d)' all after 'Canonicalize path' which using 'header.h'.
This mismatch will cause './header.h' being added over and over which leading to performance hit.

Fix summary:
Using 'Canonicalize path' in 'ctx.included_files.find(path)'.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
