### PR TITLE
Fix detection of pthread features

### DIFF
--- a/cmake/GenerateConfigurationFile.cmake
+++ b/cmake/GenerateConfigurationFile.cmake
@@ -44,7 +44,7 @@ foreach(func IN ITEMS ${functions})
 endforeach()
 
 include(CheckCSourceCompiles)
-set(CMAKE_REQUIRED_LINK_OPTIONS -pthread)
+set(CMAKE_REQUIRED_FLAGS -pthread)
 check_c_source_compiles(
   [=[
     #include <pthread.h>
@@ -57,7 +57,7 @@ check_c_source_compiles(
   ]=]
   HAVE_PTHREAD_MUTEX_ROBUST)
 check_function_exists(pthread_mutexattr_setpshared HAVE_PTHREAD_MUTEXATTR_SETPSHARED)
-set(CMAKE_REQUIRED_LINK_OPTIONS)
+set(CMAKE_REQUIRED_FLAGS)
 
 include(CheckStructHasMember)
 check_struct_has_member("struct stat" st_ctim sys/stat.h


### PR DESCRIPTION
Add the -pthread flag to the compiler when building the test
program. Otherwise the compiler will build with wrong defines.

Fixes failing unit tests in ubuntu 18.04.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
