### PR TITLE
CMake: make build of documentation optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,10 @@ target_link_libraries(ccache PRIVATE standard_settings standard_warnings ccache_
 #
 # Documentation
 #
-add_subdirectory(doc)
+option(ENABLE_DOCUMENTATION "Enable documentation" ON)
+if(ENABLE_DOCUMENTATION)
+  add_subdirectory(doc)
+endif()
 
 #
 # Installation


### PR DESCRIPTION
So we don't need to support corner cases as for example one fixed in
commit f6202db308e3 ("doc/MANUAL.adoc: Don't use non-ASCII quotes
(#761)") when the documentation is actually not needed at all as ccache
is used as a build tool only.

Signed-off-by: Petr Štetiar <ynezz@true.cz>