### PR TITLE
Add support for clang's --config option

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1657,7 +1657,8 @@ calculate_result_name(Context& ctx,
 
     if (Util::starts_with(args[i], "-specs=")
         || Util::starts_with(args[i], "--specs=")
-        || (args[i] == "-specs" || args[i] == "--specs")) {
+        || (args[i] == "-specs" || args[i] == "--specs")
+        || args[i] == "--config") {
       std::string path;
       size_t eq_pos = args[i].find('=');
       if (eq_pos == std::string::npos) {

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -55,6 +55,7 @@ const CompOpt compopts[] = {
   {"--Werror", TAKES_ARG},                            // nvcc
   {"--analyze", TOO_HARD},                            // Clang
   {"--compiler-bindir", AFFECTS_CPP | TAKES_ARG},     // nvcc
+  {"--config", TAKES_ARG},                            // Clang
   {"--libdevice-directory", AFFECTS_CPP | TAKES_ARG}, // nvcc
   {"--output-directory", AFFECTS_CPP | TAKES_ARG},    // nvcc
   {"--param", TAKES_ARG},


### PR DESCRIPTION
This is more or less equivalent to gcc's --specs option except that the
contents of the file have different syntaxes.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->


