### PR TITLE
Enable minitrace tracing and stop it from crashing

### DIFF
--- a/src/MiniTrace.cpp
+++ b/src/MiniTrace.cpp
@@ -72,7 +72,8 @@ MiniTrace::MiniTrace(const ArgsInfo& args_info)
   m_tmp_trace_file = tmp_file.path;
 
   mtr_init(m_tmp_trace_file.c_str());
-  MTR_INSTANT_C("", "", "time", FMT("{:f}", time_seconds()).c_str());
+  m_start_time = FMT("{:f}", time_seconds());
+  MTR_INSTANT_C("", "", "time", m_start_time.c_str());
   MTR_META_PROCESS_NAME("ccache");
   MTR_START("program", "ccache", m_trace_id);
 }

--- a/src/MiniTrace.hpp
+++ b/src/MiniTrace.hpp
@@ -38,6 +38,7 @@ private:
   const ArgsInfo& m_args_info;
   const void* const m_trace_id;
   std::string m_tmp_trace_file;
+  std::string m_start_time;
 };
 
 #endif

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -12,6 +12,7 @@ endif ()
 
 if(ENABLE_TRACING)
   target_sources(third_party_lib PRIVATE minitrace.c)
+  set_source_files_properties(minitrace.c PROPERTIES COMPILE_DEFINITIONS "MTR_ENABLED;_POSIX_C_SOURCE=200809L")
 endif()
 
 set(xxhdispatchtest [=[


### PR DESCRIPTION
Need to make sure to pass the -DMTR_ENABLED also when compiling
the library and not only in the ccache internal config.h file.

Also the strings used need to be still around when the destructor
is called, so avoid using local strings and any strdup strings.

Closes #851