### PR TITLE
Add stats log file, logging input file and result

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -153,6 +153,11 @@ compiler's documentation.
     (environment variable, configuration file or compile-time default) in
     human-readable format.
 
+*`--show-log-stats`*::
+
+    Print statistics counters from the stats log in human-readable format.
+    See <<config_stats_log,*stats_log*>>.
+
 *`-s`*, *`--show-stats`*::
 
     Print a summary of configuration and statistics counters in human-readable
@@ -848,6 +853,7 @@ information.
 
     If set to a file path, ccache will write statistics counter updates to the
     specified file. This is useful for getting statistics for individual builds.
+    To show a summary of the current stats log, use: `ccache --show-log-stats`.
 +
 NOTE: Lines in the stats log starting with a hash sign (`#`) are comments.
 

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -844,6 +844,13 @@ information.
     If true, ccache will update the statistics counters on each compilation.
     The default is true.
 
+[[config_stats_log]] *stats_log* (*CCACHE_STATSLOG*)::
+
+    If set to a file path, ccache will write statistics counter updates to the
+    specified file. This is useful for getting statistics for individual builds.
++
+NOTE: Lines in the stats log starting with a hash sign (`#`) are comments.
+
 [[config_temporary_dir]] *temporary_dir* (*CCACHE_TEMPDIR*)::
 
     This option specifies where ccache will put temporary files. The default is

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -78,6 +78,7 @@ enum class ConfigItem {
   run_second_cpp,
   sloppiness,
   stats,
+  stats_log,
   temporary_dir,
   umask,
 };
@@ -119,6 +120,7 @@ const std::unordered_map<std::string, ConfigItem> k_config_key_table = {
   {"run_second_cpp", ConfigItem::run_second_cpp},
   {"sloppiness", ConfigItem::sloppiness},
   {"stats", ConfigItem::stats},
+  {"stats_log", ConfigItem::stats_log},
   {"temporary_dir", ConfigItem::temporary_dir},
   {"umask", ConfigItem::umask},
 };
@@ -161,6 +163,7 @@ const std::unordered_map<std::string, std::string> k_env_variable_table = {
   {"RECACHE", "recache"},
   {"SLOPPINESS", "sloppiness"},
   {"STATS", "stats"},
+  {"STATSLOG", "stats_log"},
   {"TEMPDIR", "temporary_dir"},
   {"UMASK", "umask"},
 };
@@ -632,6 +635,9 @@ Config::get_string_value(const std::string& key) const
   case ConfigItem::stats:
     return format_bool(m_stats);
 
+  case ConfigItem::stats_log:
+    return m_stats_log;
+
   case ConfigItem::temporary_dir:
     return m_temporary_dir;
 
@@ -869,6 +875,10 @@ Config::set_item(const std::string& key,
 
   case ConfigItem::stats:
     m_stats = parse_bool(value, env_var_key, negate);
+    break;
+
+  case ConfigItem::stats_log:
+    m_stats_log = Util::expand_environment_variables(value);
     break;
 
   case ConfigItem::temporary_dir:

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -77,6 +77,7 @@ public:
   bool run_second_cpp() const;
   uint32_t sloppiness() const;
   bool stats() const;
+  const std::string& stats_log() const;
   const std::string& temporary_dir() const;
   uint32_t umask() const;
 
@@ -169,6 +170,7 @@ private:
   bool m_run_second_cpp = true;
   uint32_t m_sloppiness = 0;
   bool m_stats = true;
+  std::string m_stats_log;
   std::string m_temporary_dir;
   uint32_t m_umask = std::numeric_limits<uint32_t>::max(); // Don't set umask
 
@@ -399,6 +401,12 @@ inline bool
 Config::stats() const
 {
   return m_stats;
+}
+
+inline const std::string&
+Config::stats_log() const
+{
+  return m_stats_log;
 }
 
 inline const std::string&

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -88,8 +88,8 @@ for_each_level_1_and_2_stats_file(
   }
 }
 
-static std::pair<Counters, time_t>
-collect_counters(const Config& config)
+std::pair<Counters, time_t>
+Statistics::collect_counters(const Config& config)
 {
   Counters counters;
   uint64_t zero_timestamp = 0;
@@ -274,17 +274,23 @@ zero_all_counters(const Config& config)
 }
 
 std::string
-format_human_readable(const Config& config)
+format_config_header(const Config& config)
 {
-  Counters counters;
-  time_t last_updated;
-  std::tie(counters, last_updated) = collect_counters(config);
   std::string result;
 
   result += FMT("{:36}{}\n", "cache directory", config.cache_dir());
   result += FMT("{:36}{}\n", "primary config", config.primary_config_path());
   result += FMT(
     "{:36}{}\n", "secondary config (readonly)", config.secondary_config_path());
+
+  return result;
+}
+
+std::string
+format_human_readable(const Counters& counters, time_t last_updated)
+{
+  std::string result;
+
   if (last_updated > 0) {
     const auto tm = Util::localtime(last_updated);
     char timestamp[100] = "?";
@@ -320,6 +326,14 @@ format_human_readable(const Config& config)
     }
   }
 
+  return result;
+}
+
+std::string
+format_config_footer(const Config& config)
+{
+  std::string result;
+
   if (config.max_files() != 0) {
     result += FMT("{:32}{:8}\n", "max files", config.max_files());
   }
@@ -332,11 +346,8 @@ format_human_readable(const Config& config)
 }
 
 std::string
-format_machine_readable(const Config& config)
+format_machine_readable(const Counters& counters, time_t last_updated)
 {
-  Counters counters;
-  time_t last_updated;
-  std::tie(counters, last_updated) = collect_counters(config);
   std::string result;
 
   result += FMT("stats_updated_timestamp\t{}\n", last_updated);

--- a/src/Statistics.hpp
+++ b/src/Statistics.hpp
@@ -41,9 +41,18 @@ Counters read(const std::string& path);
 nonstd::optional<Counters> update(const std::string& path,
                                   std::function<void(Counters& counters)>);
 
+// Write input and result to the file in `path`.
+void log_result(const std::string& path,
+                const std::string& input,
+                const std::string& result);
+
 // Return a human-readable string representing the final ccache result, or
 // nullopt if there was no result.
-nonstd::optional<std::string> get_result(const Counters& counters);
+nonstd::optional<std::string> get_result_message(const Counters& counters);
+
+// Return a machine-readable string representing the final ccache result, or
+// nullopt if there was no result.
+nonstd::optional<std::string> get_result_id(const Counters& counters);
 
 // Zero all statistics counters except those tracking cache size and number of
 // files in the cache.

--- a/src/Statistics.hpp
+++ b/src/Statistics.hpp
@@ -26,6 +26,7 @@
 #include "third_party/nonstd/optional.hpp"
 
 #include <functional>
+#include <sstream>
 #include <string>
 
 class Config;
@@ -34,6 +35,9 @@ namespace Statistics {
 
 // Read counters from `path`. No lock is acquired.
 Counters read(const std::string& path);
+
+// Read counters from lines of text in `path`.
+Counters read_log(const std::string& path);
 
 // Acquire a lock, read counters from `path`, call `function` with the counters,
 // write the counters to `path` and release the lock. Returns the resulting
@@ -61,12 +65,16 @@ void zero_all_counters(const Config& config);
 // Collect cache statistics from all statistics counters.
 std::pair<Counters, time_t> collect_counters(const Config& config);
 
+// Format stats log in human-readable format.
+std::string format_stats_log(const Config& config);
+
 // Format config header in human-readable format.
 std::string format_config_header(const Config& config);
 
 // Format cache statistics in human-readable format.
 std::string format_human_readable(const Counters& counters,
-                                  time_t last_updated);
+                                  time_t last_updated,
+                                  bool from_log);
 
 // Format config footer in human-readable format.
 std::string format_config_footer(const Config& config);

--- a/src/Statistics.hpp
+++ b/src/Statistics.hpp
@@ -49,10 +49,21 @@ nonstd::optional<std::string> get_result(const Counters& counters);
 // files in the cache.
 void zero_all_counters(const Config& config);
 
+// Collect cache statistics from all statistics counters.
+std::pair<Counters, time_t> collect_counters(const Config& config);
+
+// Format config header in human-readable format.
+std::string format_config_header(const Config& config);
+
 // Format cache statistics in human-readable format.
-std::string format_human_readable(const Config& config);
+std::string format_human_readable(const Counters& counters,
+                                  time_t last_updated);
+
+// Format config footer in human-readable format.
+std::string format_config_footer(const Config& config);
 
 // Format cache statistics in machine-readable format.
-std::string format_machine_readable(const Config& config);
+std::string format_machine_readable(const Counters& counters,
+                                    time_t last_updated);
 
 } // namespace Statistics

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2691,9 +2691,15 @@ handle_main_options(int argc, const char* const* argv)
       break;
     }
 
-    case PRINT_STATS:
-      PRINT_RAW(stdout, Statistics::format_machine_readable(ctx.config));
+    case PRINT_STATS: {
+      Counters counters;
+      time_t last_updated;
+      std::tie(counters, last_updated) =
+        Statistics::collect_counters(ctx.config);
+      PRINT_RAW(stdout,
+                Statistics::format_machine_readable(counters, last_updated));
       break;
+    }
 
     case 'c': // --cleanup
     {
@@ -2771,9 +2777,17 @@ handle_main_options(int argc, const char* const* argv)
       ctx.config.visit_items(configuration_printer);
       break;
 
-    case 's': // --show-stats
-      PRINT_RAW(stdout, Statistics::format_human_readable(ctx.config));
+    case 's': { // --show-stats
+      PRINT_RAW(stdout, Statistics::format_config_header(ctx.config));
+      Counters counters;
+      time_t last_updated;
+      std::tie(counters, last_updated) =
+        Statistics::collect_counters(ctx.config);
+      PRINT_RAW(stdout,
+                Statistics::format_human_readable(counters, last_updated));
+      PRINT_RAW(stdout, Statistics::format_config_footer(ctx.config));
       break;
+    }
 
     case 'V': // --version
       PRINT(VERSION_TEXT, CCACHE_NAME, CCACHE_VERSION);

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2205,9 +2205,17 @@ finalize_stats_and_trigger_cleanup(Context& ctx)
   }
 
   if (!config.log_file().empty() || config.debug()) {
-    const auto result = Statistics::get_result(ctx.counter_updates);
+    const auto result = Statistics::get_result_message(ctx.counter_updates);
     if (result) {
       LOG("Result: {}", *result);
+    }
+  }
+
+  if (!config.stats_log().empty()) {
+    const auto result_id = Statistics::get_result_id(ctx.counter_updates);
+    if (result_id) {
+      Statistics::log_result(
+        config.stats_log(), ctx.args_info.input_file, *result_id);
     }
   }
 

--- a/unittest/test_Config.cpp
+++ b/unittest/test_Config.cpp
@@ -405,6 +405,7 @@ TEST_CASE("Config::visit_items")
     " file_stat_matches, file_stat_matches_ctime, pch_defines, system_headers,"
     " clang_index_store, ivfsoverlay\n"
     "stats = false\n"
+    "stats_log = sl\n"
     "temporary_dir = td\n"
     "umask = 022\n");
 
@@ -462,6 +463,7 @@ TEST_CASE("Config::visit_items")
     " time_macros, pch_defines, file_stat_matches, file_stat_matches_ctime,"
     " system_headers, clang_index_store, ivfsoverlay",
     "(test.conf) stats = false",
+    "(test.conf) stats_log = sl",
     "(test.conf) temporary_dir = td",
     "(test.conf) umask = 022",
   };


### PR DESCRIPTION
This is a reimplementation of the original feature, 4e2799df1d3b617525235fa43f8ab048397ddbae

It adds an optional stats log, that will log the input files and their results (only)

```
# foo.c
cache_miss
# bar.c
cache_miss
# foo.c
direct_cache_hit
# bar.c
direct_cache_hit
```
_all lines starting with `#` are regarded as comments, and ignored as results_

It also adds a new command `--log-stats`, that will parse and present this file.

```
cache hit (direct)                     2
cache hit (preprocessed)               0
cache miss                             2
cache hit rate                     50.00 %
```


Closes #262