### PR TITLE
Explicitly select C++ when using -fcxx-modules

### DIFF
--- a/test/suites/modules.bash
+++ b/test/suites/modules.bash
@@ -34,10 +34,10 @@ SUITE_modules() {
     # -------------------------------------------------------------------------
     TEST "fall back to real compiler, no sloppiness"
 
-    $CCACHE_COMPILE -fmodules -fcxx-modules -c test1.cpp -MD
+    $CCACHE_COMPILE -x c++ -fmodules -fcxx-modules -c test1.cpp -MD
     expect_stat "can't use modules" 1
 
-    $CCACHE_COMPILE -fmodules -fcxx-modules -c test1.cpp -MD
+    $CCACHE_COMPILE -x c++ -fmodules -fcxx-modules -c test1.cpp -MD
     expect_stat "can't use modules" 2
 
     # -------------------------------------------------------------------------
@@ -45,27 +45,27 @@ SUITE_modules() {
 
     unset CCACHE_DEPEND
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -fmodules -fcxx-modules -c test1.cpp -MD
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -x c++ -fmodules -fcxx-modules -c test1.cpp -MD
     expect_stat "can't use modules" 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -fmodules -fcxx-modules -c test1.cpp -MD
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -x c++ -fmodules -fcxx-modules -c test1.cpp -MD
     expect_stat "can't use modules" 2
 
     # -------------------------------------------------------------------------
     TEST "cache hit"
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -fmodules -fcxx-modules -c test1.cpp -MD
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -x c++ -fmodules -fcxx-modules -c test1.cpp -MD
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -fmodules -fcxx-modules -c test1.cpp -MD
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -x c++ -fmodules -fcxx-modules -c test1.cpp -MD
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache miss' 1
 
     # -------------------------------------------------------------------------
     TEST "cache miss"
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -MD -fmodules -fcxx-modules -c test1.cpp -MD
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -MD -x c++ -fmodules -fcxx-modules -c test1.cpp -MD
     expect_stat 'cache miss' 1
 
     cat <<EOF >test1.h
@@ -74,12 +74,12 @@ void f();
 EOF
     backdate test1.h
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -MD -fmodules -fcxx-modules -c test1.cpp -MD
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -MD -x c++ -fmodules -fcxx-modules -c test1.cpp -MD
     expect_stat 'cache miss' 2
 
     echo >>module.modulemap
     backdate test1.h
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -MD -fmodules -fcxx-modules -c test1.cpp -MD
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS modules" $CCACHE_COMPILE -MD -x c++ -fmodules -fcxx-modules -c test1.cpp -MD
     expect_stat 'cache miss' 3
 }


### PR DESCRIPTION
Typically, clang is able to auto-detect C++ files and switch to C++
mode, even when `argv[0]` is simply `clang` (without the `++`).

However, Nixpkgs provides `clang` as a wrapper script over the
underlying compiler binary, and only enables C++ standard library
include paths when it thinks it's being invoked as a C++ compiler:

https://github.com/NixOS/nixpkgs/blob/961cae37edeb34b5dec8060e49e5abbde3af9c00/pkgs/build-support/cc-wrapper/cc-wrapper.sh#L28

https://github.com/NixOS/nixpkgs/blob/961cae37edeb34b5dec8060e49e5abbde3af9c00/pkgs/build-support/cc-wrapper/cc-wrapper.sh#L54-L55

https://github.com/NixOS/nixpkgs/blob/961cae37edeb34b5dec8060e49e5abbde3af9c00/pkgs/build-support/cc-wrapper/cc-wrapper.sh#L135-L138

So for the benefit of less clever compiler toolchains which
can't always see that these invocations are using C++ mode,
we explicitly specify `-x c++` so they do the right thing.

See also https://github.com/NixOS/nixpkgs/pull/119176#issuecomment-862853452

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
