### PR TITLE
Test suite repair

### DIFF
--- a/test/suites/ivfsoverlay.bash
+++ b/test/suites/ivfsoverlay.bash
@@ -34,11 +34,11 @@ SUITE_ivfsoverlay() {
     # -------------------------------------------------------------------------
     TEST "with sloppy ivfsoverlay"
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS ivfsoverlay" $CCACHE_COMPILE -ivfsoverlay test.yaml -c test.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS include_file_mtime ivfsoverlay" $CCACHE_COMPILE -ivfsoverlay test.yaml -c test.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS ivfsoverlay" $CCACHE_COMPILE -ivfsoverlay test.yaml -c test.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS include_file_mtime ivfsoverlay" $CCACHE_COMPILE -ivfsoverlay test.yaml -c test.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache miss' 1
 }

--- a/test/suites/nvcc_ldir.bash
+++ b/test/suites/nvcc_ldir.bash
@@ -22,6 +22,11 @@ SUITE_nvcc_ldir_PROBE() {
     elif [ ! -d $nvcc_idir ]; then
         echo "include directory $nvcc_idir not found"
     fi
+
+    echo "int main() { return 0; }" | $REAL_NVCC -Wno-deprecated-gpu-targets -ccbin $REAL_COMPILER_BIN -c -x cu - 
+    if [ $? -ne 0 ]; then
+        echo "nvcc of a canary failed; Is CUDA compatible with the host compiler ($REAL_COMPILER_BIN)?"
+    fi
 }
 
 SUITE_nvcc_ldir_SETUP() {

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -590,7 +590,7 @@ TEST_CASE("Util::make_relative_path")
   SUBCASE("Path matches neither actual nor apparent CWD")
   {
 #ifdef _WIN32
-    CHECK(make_relative_path("C:/", "C:/a", "C:/b", "C:/x") == "C:/x");
+    CHECK(make_relative_path("C:/", "C:/a", "C:/b", "C:/x") == "../x");
 #else
     CHECK(make_relative_path("/", "/a", "/b", "/x") == "/x");
 #endif


### PR DESCRIPTION
A set of compatibility fixes for running the tests.

 * Add `CCACHE_SLOPPINESS=include_file_mtime` to ivfsoverlay test. This is possibly due to me using my self-compiled clang since it does not fail with the version of Clang that comes with Ubuntu 20.04.

 * Add detection to `nvcc_ldir` of whether nvcc works with chosen host compiler.  For instance, `nvcc` aborts with
```
#error -- unsupported clang version! clang version must be less than 9 and greater than 3.2
```
if the version of clang or gcc is too new. The test should be skipped in this case.

 * Add treatment of Windows drive letters in paths to additional functions.
 
 * Fix for `make_relative_path`. The result of this depends on the existence of directories in the root folder which is tested with inodes, a concept that does not exist in the Win32 API. The "Linux MinGW 64-bit" test is actually failing, presumably it actually provides inode numbers under the Wine emulation layer.