### PR TITLE
Skip nvcc_ldir test with non-working nvcc.

### DIFF
--- a/test/suites/nvcc_ldir.bash
+++ b/test/suites/nvcc_ldir.bash
@@ -22,6 +22,11 @@ SUITE_nvcc_ldir_PROBE() {
     elif [ ! -d $nvcc_idir ]; then
         echo "include directory $nvcc_idir not found"
     fi
+
+    echo "int main() { return 0; }" | $REAL_NVCC -Wno-deprecated-gpu-targets -ccbin $REAL_COMPILER_BIN -c -x cu - 
+    if [ $? -ne 0 ]; then
+        echo "nvcc of a canary failed; Is CUDA compatible with the host compiler ($REAL_COMPILER_BIN)?"
+    fi
 }
 
 SUITE_nvcc_ldir_SETUP() {


### PR DESCRIPTION
Add detection to nvcc_ldir of whether nvcc works with chosen host
compiler. For instance, nvcc aborts with

    #error -- unsupported clang version! clang version must be less than 9 and greater than 3.2

if the version of clang (or gcc) is too new. The test should be skipped in
this case.