### PR TITLE
Add sloppy include_file_mtime to ivfsoverlay test

### DIFF
--- a/test/suites/ivfsoverlay.bash
+++ b/test/suites/ivfsoverlay.bash
@@ -34,11 +34,11 @@ SUITE_ivfsoverlay() {
     # -------------------------------------------------------------------------
     TEST "with sloppy ivfsoverlay"
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS ivfsoverlay" $CCACHE_COMPILE -ivfsoverlay test.yaml -c test.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS include_file_mtime ivfsoverlay" $CCACHE_COMPILE -ivfsoverlay test.yaml -c test.c
     expect_stat 'cache hit (direct)' 0
     expect_stat 'cache miss' 1
 
-    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS ivfsoverlay" $CCACHE_COMPILE -ivfsoverlay test.yaml -c test.c
+    CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS include_file_mtime ivfsoverlay" $CCACHE_COMPILE -ivfsoverlay test.yaml -c test.c
     expect_stat 'cache hit (direct)' 1
     expect_stat 'cache miss' 1
 }


### PR DESCRIPTION
Add CCACHE_SLOPPINESS=include_file_mtime to ivfsoverlay test. This is
possibly due to me using my self-compiled clang since it does not fail
with the version of Clang that comes with Ubuntu 20.04.