### PR TITLE
Put compile option with args into quotes

### DIFF
--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -52,7 +52,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^GNU|(Apple)?Clang$")
   include(StdAtomic)
 
 elseif(MSVC)
-  target_compile_options(standard_settings INTERFACE /FI ${CMAKE_BINARY_DIR}/config.h)
+  target_compile_options(standard_settings INTERFACE "/FI${CMAKE_BINARY_DIR}/config.h")
 
   target_compile_options(
     standard_settings


### PR DESCRIPTION
According to
https://cmake.org/cmake/help/latest/command/target_compile_options.html,
compile options are de-duplicated individually, presumably leading to
any non-first "/FI" to be removed. Put flag and option into quotes to interpret as a
single option.

Observed with CMake 3.20.3. I don't know why this does not happen with
-include or what the first /FI option could be.