### PR TITLE
fix: AppleClang detection

### DIFF
--- a/test/run
+++ b/test/run
@@ -470,7 +470,7 @@ HOST_OS_FREEBSD=false
 HOST_OS_WINDOWS=false
 HOST_OS_CYGWIN=false
 
-compiler_version="`$COMPILER --version 2>&1 | head -1`"
+compiler_version="`$COMPILER --version 2>/dev/null | head -1`"
 case $compiler_version in
     *gcc*|*g++*|2.95*)
         COMPILER_TYPE_GCC=true
@@ -571,7 +571,7 @@ if [ "$REAL_COMPILER" = "$COMPILER" ]; then
 else
     echo "Compiler:         $COMPILER ($REAL_COMPILER)"
 fi
-echo "Compiler version: $($COMPILER --version | head -n 1)"
+echo "Compiler version: $($COMPILER --version 2>/dev/null | head -n 1)"
 
 REAL_NVCC=$(find_compiler nvcc)
 REAL_CUOBJDUMP=$(find_compiler cuobjdump)

--- a/test/run
+++ b/test/run
@@ -480,8 +480,8 @@ case $compiler_version in
         CLANG_VERSION_SUFFIX=$(echo "${COMPILER%% *}" | sed 's/.*clang//')
         ;;
     *)
-        echo "WARNING: Compiler $COMPILER not supported (version: $compiler_version) -- not running tests" >&2
-        exit 0
+        echo "WARNING: Compiler $COMPILER not supported (version: $compiler_version) -- Skipped running tests" >&2
+        exit $skip_code
         ;;
 esac
 

--- a/test/run
+++ b/test/run
@@ -451,6 +451,8 @@ export PATH
 
 if [ -n "$CC" ]; then
     COMPILER="$CC"
+elif [[ "$OSTYPE" == "darwin"* && -x "$(command -v clang)" ]]; then
+    COMPILER=clang
 else
     COMPILER=gcc
 fi

--- a/test/suites/direct_gcc.bash
+++ b/test/suites/direct_gcc.bash
@@ -1,5 +1,5 @@
 SUITE_direct_gcc_PROBE() {
-    if [[ $REAL_COMPILER != *"gcc"* ]]; then
+    if [[ "${COMPILER_TYPE_GCC}" != "true" ]]; then
         echo "Skipping GCC only test cases"
     fi
 }


### PR DESCRIPTION
Apple Clang, when called via `gcc`, emits a `Configured with` line
on stderr which confuses the compiler detection. As a consequence
lots of tests were skipped.

To work-around default to clang on macOS.