### PR TITLE
Allow dumping stdin by giving - as path

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -182,11 +182,13 @@ compiler's documentation.
 
     Dump manifest file at _PATH_ in text format to standard output. This is
     only useful when debugging ccache and its behavior.
+    A path of `-` means to read from standard input.
 
 *`--dump-result`* _PATH_::
 
     Dump result file at _PATH_ in text format to standard output. This is only
     useful when debugging ccache and its behavior.
+    A path of `-` means to read from standard input.
 
 *`--extract-result`* _PATH_::
 

--- a/src/Manifest.cpp
+++ b/src/Manifest.cpp
@@ -294,12 +294,19 @@ struct FileStats
 std::unique_ptr<ManifestData>
 read_manifest(const std::string& path, FILE* dump_stream = nullptr)
 {
-  File file(path, "rb");
-  if (!file) {
-    return {};
+  FILE* file_stream;
+  File file;
+  if (path == "-") {
+    file_stream = stdin;
+  } else {
+    file = File(path, "rb");
+    if (!file) {
+      return {};
+    }
+    file_stream = file.get();
   }
 
-  CacheEntryReader reader(file.get(), Manifest::k_magic, Manifest::k_version);
+  CacheEntryReader reader(file_stream, Manifest::k_magic, Manifest::k_version);
 
   if (dump_stream) {
     reader.dump_header(dump_stream);

--- a/src/Result.cpp
+++ b/src/Result.cpp
@@ -228,13 +228,20 @@ Result::Reader::read(Consumer& consumer)
 bool
 Reader::read_result(Consumer& consumer)
 {
-  File file(m_result_path, "rb");
-  if (!file) {
-    // Cache miss.
-    return false;
+  FILE* file_stream;
+  File file;
+  if (m_result_path == "-") {
+    file_stream = stdin;
+  } else {
+    file = File(m_result_path, "rb");
+    if (!file) {
+      // Cache miss.
+      return false;
+    }
+    file_stream = file.get();
   }
 
-  CacheEntryReader cache_entry_reader(file.get(), k_magic, k_version);
+  CacheEntryReader cache_entry_reader(file_stream, k_magic, k_version);
 
   consumer.on_header(cache_entry_reader);
 


### PR DESCRIPTION
Similar to other commands, such as tar

Useful when streaming data, for instance:

```console
$ redis-cli get "ccache:b3c3hb1g03rej3p4o4qqm2bkiq3ch47cs" | ./build/ccache --dump-manifest -
Magic: cCmF
Version: 2
Compression type: zstd
Compression level: 1
Content size: 31187
...
$ redis-cli get "ccache:472amgcrp0t7dubsit1mua2lc849lr81q" | ./build/ccache --dump-result -
Magic: cCrS
Version: 1
Compression type: zstd
Compression level: 1
Content size: 1186630
...

```
