### PR TITLE
Add magic file, for identifying ccache files

### DIFF
--- a/misc/ccache.magic
+++ b/misc/ccache.magic
@@ -1,0 +1,7 @@
+# ccache manifest
+0       string          cCmF            ccache manifest
+>4      ubyte           x               \b, version %d
+
+# ccache result
+0       string          cCrS            ccache result
+>4      ubyte           x               \b, version %d


### PR DESCRIPTION
Useful when working with streams from server

```console
$ redis-cli get "ccache:b3c3hb1g03rej3p4o4qqm2bkiq3ch47cs" | file -
/dev/stdin: ccache manifest, version 2
$ redis-cli get "ccache:472amgcrp0t7dubsit1mua2lc849lr81q" | file -
/dev/stdin: ccache result, version 1
```

Installed in regular locations for the `file`  command.

<http://darwinsys.com/file/>