### PR TITLE
Fix CMake feature detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.4.3)
 
+if(POLICY CMP0067)
+  cmake_policy(SET CMP0067 NEW)
+endif()
+
 project(ccache LANGUAGES C CXX)
 if(MSVC)
   enable_language(ASM_MASM)

--- a/cmake/GenerateConfigurationFile.cmake
+++ b/cmake/GenerateConfigurationFile.cmake
@@ -43,9 +43,9 @@ foreach(func IN ITEMS ${functions})
   check_function_exists(${func} ${func_var})
 endforeach()
 
-include(CheckCSourceCompiles)
+include(CheckCXXSourceCompiles)
 set(CMAKE_REQUIRED_FLAGS -pthread)
-check_c_source_compiles(
+check_cxx_source_compiles(
   [=[
     #include <pthread.h>
     int main()
@@ -61,11 +61,11 @@ set(CMAKE_REQUIRED_FLAGS)
 
 include(CheckStructHasMember)
 check_struct_has_member("struct stat" st_ctim sys/stat.h
-                        HAVE_STRUCT_STAT_ST_CTIM)
+                        HAVE_STRUCT_STAT_ST_CTIM LANGUAGE CXX)
 check_struct_has_member("struct stat" st_mtim sys/stat.h
-                        HAVE_STRUCT_STAT_ST_MTIM)
+                        HAVE_STRUCT_STAT_ST_MTIM LANGUAGE CXX)
 check_struct_has_member("struct statfs" f_fstypename sys/mount.h
-                        HAVE_STRUCT_STATFS_F_FSTYPENAME)
+                        HAVE_STRUCT_STATFS_F_FSTYPENAME LANGUAGE CXX)
 
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles(


### PR DESCRIPTION
When enabling CMake policy [CMP0067](https://cmake.org/cmake/help/latest/policy/CMP0067.html) by either enabling it directly or via a `cmake_minimum_required` of `3.8` or later, the `test.inode_cache` test starts to fail.

This happens because this policy slightly changes the `CheckCSourceCompiles` logic by passing-in any configured C-standard. The detection of the following features now report absence:

```diff
--- CMakeCache-old.txt	2021-07-05 15:50:25.698278961 +0200
+++ CMakeCache-new.txt	2021-07-05 15:50:54.626397301 +0200
@@ -657,7 +657,7 @@
 //Have function pthread_mutexattr_setpshared
 HAVE_PTHREAD_MUTEXATTR_SETPSHARED:INTERNAL=1
 //Test HAVE_PTHREAD_MUTEX_ROBUST
-HAVE_PTHREAD_MUTEX_ROBUST:INTERNAL=1
+HAVE_PTHREAD_MUTEX_ROBUST:INTERNAL=
 //Have include pwd.h
 HAVE_PWD_H:INTERNAL=1
 //Have function realpath
@@ -675,9 +675,9 @@
 //Test HAVE_STRUCT_STATFS_F_FSTYPENAME
 HAVE_STRUCT_STATFS_F_FSTYPENAME:INTERNAL=
 //Test HAVE_STRUCT_STAT_ST_CTIM
-HAVE_STRUCT_STAT_ST_CTIM:INTERNAL=1
+HAVE_STRUCT_STAT_ST_CTIM:INTERNAL=
 //Test HAVE_STRUCT_STAT_ST_MTIM
-HAVE_STRUCT_STAT_ST_MTIM:INTERNAL=1
+HAVE_STRUCT_STAT_ST_MTIM:INTERNAL=
 //Have function syslog
 HAVE_SYSLOG:INTERNAL=1
 //Have include syslog.h
```

In case of `HAVE_PTHREAD_MUTEX_ROBUST` the now passed-in `-std=c99` does not enable the required `__USE_XOPEN2K` extension:

```C
#ifdef __USE_XOPEN2K
/* Robust mutex or not flags.  */
enum
{
  PTHREAD_MUTEX_STALLED,
  PTHREAD_MUTEX_STALLED_NP = PTHREAD_MUTEX_STALLED,
  PTHREAD_MUTEX_ROBUST,
  PTHREAD_MUTEX_ROBUST_NP = PTHREAD_MUTEX_ROBUST
};
#endif
```

To remedy the situation CMake now checks for those features within a C++ language context. In C++ those features seem to be available without enabling any extra extensions.

It also makes the check more precise because all of the consumers are C++ (and not C) compilation units.