### PR TITLE
 Disable preprocessor hits for PCHs with clang again

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1707,7 +1707,7 @@ from_cache(Context& ctx, FromCacheCallMode mode, const Digest& result_key)
   if ((ctx.config.compiler_type() == CompilerType::clang
        || ctx.config.compiler_type() == CompilerType::other)
       && ctx.args_info.output_is_precompiled_header
-      && !ctx.args_info.fno_pch_timestamp && mode == FromCacheCallMode::cpp) {
+      && mode == FromCacheCallMode::cpp) {
     LOG_RAW("Not considering cached precompiled header in preprocessor mode");
     return nullopt;
   }


### PR DESCRIPTION
I added this in 3ec58dbcaa1e7903d59dce4c77baff7bc3783269 as I thought clang only saves the timestamps of included files, so as long as they are turned off by -Xclang -fno-pch-timestamp, preprocessed hits should be possible. However, clang also saves the size and possibly a hash of the un-preprocessed source file, so preprocessed hits don't make much sense.

As long as only the timestamp of a PCH source file changed, e.g. through git operations, there should still be direct hits (as long as -Xclang -fno-pch-timestamp is used).