### PR TITLE
build: Link ws2_32 to third_party instead of ccache_framework

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,7 +50,7 @@ target_compile_definitions(
 )
 
 if(WIN32)
-  target_link_libraries(ccache_framework PRIVATE ws2_32 "psapi")
+  target_link_libraries(ccache_framework PRIVATE "psapi")
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     if(STATIC_LINK)

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -46,6 +46,10 @@ target_include_directories(
 target_link_libraries(third_party PRIVATE standard_settings)
 target_link_libraries(third_party INTERFACE blake3)
 
+if(WIN32)
+    target_link_libraries(third_party PRIVATE ws2_32 )
+endif()
+
 # Silence warning from winbase.h due to /Zc:preprocessor.
 if(MSVC)
   target_compile_options(third_party PRIVATE /wd5105)

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(third_party PRIVATE standard_settings)
 target_link_libraries(third_party INTERFACE blake3)
 
 if(WIN32)
-    target_link_libraries(third_party PRIVATE ws2_32 )
+  target_link_libraries(third_party PRIVATE ws2_32)
 endif()
 
 # Silence warning from winbase.h due to /Zc:preprocessor.


### PR DESCRIPTION
The library ws2_32 is used in third_party, but linked against ccache_framework. 
This has the consequence that the symbols cannot be resolved when building with gcc:
```
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::close_socket(unsigned long long)':
ccache/src/third_party/httplib.cpp:371: undefined reference to `__imp_closesocket'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj):ccache/src/third_party/httplib.cpp:410: undefined reference to `__imp_select'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj):ccache/src/third_party/httplib.cpp:438: undefined reference to `__imp_select'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj):ccache/src/third_party/httplib.cpp:478: undefined reference to `__imp_select'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::wait_until_socket_is_ready(unsigned long long, long long, long long)':
ccache/src/third_party/httplib.cpp:481: undefined reference to `__WSAFDIsSet'
.../ld.exe: ccache/src/third_party/httplib.cpp:481: undefined reference to `__WSAFDIsSet'
.../ld.exe: ccache/src/third_party/httplib.cpp:484: undefined reference to `__imp_getsockopt'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::shutdown_socket(unsigned long long)':
ccache/src/third_party/httplib.cpp:601: undefined reference to `__imp_shutdown'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::set_nonblocking(unsigned long long, bool)':
ccache/src/third_party/httplib.cpp:693: undefined reference to `__imp_ioctlsocket'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::is_connection_error()':
ccache/src/third_party/httplib.cpp:703: undefined reference to `__imp_WSAGetLastError'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::bind_ip_address(unsigned long long, char const*)':
ccache/src/third_party/httplib.cpp:718: undefined reference to `__imp_getaddrinfo'
.../ld.exe: ccache/src/third_party/httplib.cpp:723: undefined reference to `__imp_bind'
.../ld.exe: ccache/src/third_party/httplib.cpp:729: undefined reference to `__imp_freeaddrinfo'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj):ccache/src/third_party/httplib.cpp:781: undefined reference to `__imp_connect'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `operator()':
ccache/src/third_party/httplib.cpp:798: undefined reference to `__imp_setsockopt'
.../ld.exe: ccache/src/third_party/httplib.cpp:804: undefined reference to `__imp_setsockopt'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::get_remote_ip_and_port(sockaddr_storage const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&)':
ccache/src/third_party/httplib.cpp:824: undefined reference to `__imp_ntohs'
.../ld.exe: ccache/src/third_party/httplib.cpp:827: undefined reference to `__imp_ntohs'
.../ld.exe: ccache/src/third_party/httplib.cpp:831: undefined reference to `__imp_getnameinfo'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::get_remote_ip_and_port(unsigned long long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&)':
ccache/src/third_party/httplib.cpp:842: undefined reference to `__imp_getpeername'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::SocketStream::read(char*, unsigned long long)':
ccache/src/third_party/httplib.cpp:2578: undefined reference to `__imp_recv'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::SocketStream::write(char const*, unsigned long long)':
ccache/src/third_party/httplib.cpp:2592: undefined reference to `__imp_send'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj):ccache/src/third_party/httplib.cpp:3193: undefined reference to `__imp_bind'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `operator()':
ccache/src/third_party/httplib.cpp:3196: undefined reference to `__imp_listen'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::Server::bind_internal(char const*, int, int)':
ccache/src/third_party/httplib.cpp:3212: undefined reference to `__imp_getsockname'
.../ld.exe: ccache/src/third_party/httplib.cpp:3217: undefined reference to `__imp_ntohs'
.../ld.exe: ccache/src/third_party/httplib.cpp:3219: undefined reference to `__imp_ntohs'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::Server::listen_internal()':
ccache/src/third_party/httplib.cpp:3248: undefined reference to `__imp_accept'
.../ld.exe: ccache/src/third_party/httplib.cpp:3270: undefined reference to `__imp_setsockopt'
.../ld.exe: ccache/src/third_party/httplib.cpp:3276: undefined reference to `__imp_setsockopt'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj):ccache/src/third_party/httplib.cpp:624: undefined reference to `__imp_getaddrinfo'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `create_socket<httplib::detail::create_client_socket(char const*, int, int, bool, httplib::SocketOptions, time_t, time_t, time_t, time_t, time_t, time_t, const string&, httplib::Error&)::<lambda(socket_t, addrinfo&)> >':
ccache/src/third_party/httplib.cpp:635: undefined reference to `__imp_WSASocketW'
.../ld.exe: ccache/src/third_party/httplib.cpp:652: undefined reference to `__imp_socket'
.../ld.exe: ccache/src/third_party/httplib.cpp:665: undefined reference to `__imp_setsockopt'
.../ld.exe: ccache/src/third_party/httplib.cpp:673: undefined reference to `__imp_setsockopt'
.../ld.exe: ccache/src/third_party/httplib.cpp:679: undefined reference to `__imp_freeaddrinfo'
.../ld.exe: ccache/src/third_party/httplib.cpp:686: undefined reference to `__imp_freeaddrinfo'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj):ccache/src/third_party/httplib.cpp:624: undefined reference to `__imp_getaddrinfo'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `create_socket<httplib::Server::create_server_socket(char const*, int, int, httplib::SocketOptions) const::<lambda(socket_t, addrinfo&)> >':
ccache/src/third_party/httplib.cpp:635: undefined reference to `__imp_WSASocketW'
.../ld.exe: ccache/src/third_party/httplib.cpp:652: undefined reference to `__imp_socket'
.../ld.exe: ccache/src/third_party/httplib.cpp:665: undefined reference to `__imp_setsockopt'
.../ld.exe: ccache/src/third_party/httplib.cpp:673: undefined reference to `__imp_setsockopt'
.../ld.exe: ccache/src/third_party/httplib.cpp:679: undefined reference to `__imp_freeaddrinfo'
.../ld.exe: ccache/src/third_party/httplib.cpp:686: undefined reference to `__imp_freeaddrinfo'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::default_socket_options(unsigned long long)':
ccache/src/third_party/httplib.h:586: undefined reference to `__imp_setsockopt'
.../ld.exe: ccache/src/third_party/httplib.h:588: undefined reference to `__imp_setsockopt'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::WSInit::WSInit()':
ccache/src/third_party/httplib.cpp:2228: undefined reference to `__imp_WSAStartup'
.../ld.exe: src/third_party/libthird_party.a(httplib.cpp.obj): in function `httplib::detail::WSInit::~WSInit()':
ccache/src/third_party/httplib.cpp:2231: undefined reference to `__imp_WSACleanup'
```

With this fix the mingw packages can be built for MSYS2.  
