### PR TITLE
fix(test): Pass all three required arguments to expect_file_count

### DIFF
--- a/test/run
+++ b/test/run
@@ -317,7 +317,7 @@ expect_file_count() {
     local expected=$1
     local pattern=$2
     local dir=$3
-    local actual=`find $dir -type f -name "$pattern" | wc -l`
+    local actual=`find "$dir" -type f -name "$pattern" | wc -l`
     if [ $actual -ne $expected ]; then
         test_failed_internal "Found $actual (expected $expected) $pattern files in $dir"
     fi

--- a/test/suites/secondary_file.bash
+++ b/test/suites/secondary_file.bash
@@ -245,5 +245,5 @@ SUITE_secondary_file() {
     expect_stat primary_storage_miss 4
     expect_stat secondary_storage_hit 2
     expect_stat secondary_storage_miss 2
-    expect_file_count 0
+    expect_file_count 3 '*' secondary # CACHEDIR.TAG + result + manifest
 }


### PR DESCRIPTION
I got a strange `find: illegal option -- t` error due to `$dir` evaluating to nothing.
