### PR TITLE
fix(http-storage): Disable broken connection keep-alive

### DIFF
--- a/src/storage/secondary/HttpStorage.cpp
+++ b/src/storage/secondary/HttpStorage.cpp
@@ -110,7 +110,6 @@ HttpStorageBackend::HttpStorageBackend(const Params& params)
   m_http_client.set_default_headers({
     {"User-Agent", FMT("{}/{}", CCACHE_NAME, CCACHE_VERSION)},
   });
-  m_http_client.set_keep_alive(true);
 
   auto connect_timeout = k_default_connect_timeout;
   auto operation_timeout = k_default_operation_timeout;


### PR DESCRIPTION
If compilation takes very long and the remote end closes
the http connection between the GETs and the PUTs the
ccache process dies with a SIGPIPE. Better disable keep-alive
handling until httplib is fixed.