### PR TITLE
Use shell builtin pwd for basedir test

### DIFF
--- a/test/suites/basedir.bash
+++ b/test/suites/basedir.bash
@@ -281,7 +281,7 @@ EOF
 EOF
     backdate test.h
 
-    pwd="$(/bin/pwd -P)"
+    pwd="$(pwd -P)"
     $REAL_COMPILER -c $pwd/test.c 2>reference.stderr
 
     CCACHE_ABSSTDERR=1 CCACHE_BASEDIR="$pwd" $CCACHE_COMPILE -c $pwd/test.c 2>ccache.stderr


### PR DESCRIPTION
`/bin/pwd` won't exist on some systems (eg. NixOS). The only difference between the shell builtin and the binary is that the binary uses `-P` by default. By passing `-P` we can be sure that we get the actual path, and not the symlinked path, which was needed for #916.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->