### PR TITLE
Hash relative path even when using -frecord-gcc-switches

### DIFF
--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -228,3 +228,9 @@ Args::replace(size_t index, const Args& args)
     insert(index, args);
   }
 }
+
+void
+Args::replace(size_t index, const std::string& arg)
+{
+  m_args[index] = arg;
+}

--- a/src/Args.hpp
+++ b/src/Args.hpp
@@ -85,6 +85,9 @@ public:
   // Replace the argument at `index` with all arguments in `args`.
   void replace(size_t index, const Args& args);
 
+  // Replace the argument at `index` with an `arg`.
+  void replace(size_t index, const std::string& arg);
+
 private:
   std::deque<std::string> m_args;
 };

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -928,6 +928,11 @@ process_arg(Context& ctx,
 
   // Rewrite to relative to increase hit rate.
   args_info.input_file = Util::make_relative_path(ctx, args[i]);
+  if (i < ctx.orig_args.size()) {
+    // Rewrite to relative in original args in case hash_full_command_line
+    // is set (-frecord-gcc-switches) - to increase hit rate
+    ctx.orig_args.replace(i, args_info.input_file);
+  }
 
   return nullopt;
 }


### PR DESCRIPTION
Absolute path to input file is added to hash when `-frecord-gcc-switches` is set because all original arguments are appended to `extra_args_to_hash` in https://github.com/ccache/ccache/blob/bb03159d9b8e5ba44818a44b4038f181e61f6836/src/argprocessing.cpp#L1314 . This causes cache misses when compiling in different directories and using absolute path even when CCACHE_BASEDIR is set.
Fix by updating original argument whenever find it to be an input file. 

Fixes  [#937 ](https://github.com/ccache/ccache/issues/937)