### PR TITLE
feat: Add full_command_line sloppiness

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -918,6 +918,11 @@ Examples:
 *time_macros*::
     Ignore `+__DATE__+`, `+__TIME__+` and `+__TIMESTAMP__+` being present in the
     source code.
+*full_command_line*::
+    By default, ccache will add full command line to hash if `-frecord-gcc-
+    switches` is used, resulting in cache miss when compiling in
+    different directories. With this sloppiness set ccache will only hash
+    processed command line (see _<<Compiling in different directories>>_).
 --
 +
 See the discussion under _<<Troubleshooting>>_ for more information.

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -284,6 +284,8 @@ parse_sloppiness(const std::string& value)
       result.enable(core::Sloppy::modules);
     } else if (token == "ivfsoverlay") {
       result.enable(core::Sloppy::ivfsoverlay);
+    } else if (token == "full_command_line") {
+      result.enable(core::Sloppy::full_command_line);
     } // else: ignore unknown value for forward compatibility
     start = value.find_first_not_of(", ", end);
   }
@@ -326,6 +328,9 @@ format_sloppiness(core::Sloppiness sloppiness)
   }
   if (sloppiness.is_enabled(core::Sloppy::ivfsoverlay)) {
     result += "ivfsoverlay, ";
+  }
+  if (sloppiness.is_enabled(core::Sloppy::full_command_line)) {
+    result += "full_command_line, ";
   }
   if (!result.empty()) {
     // Strip last ", ".

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -1310,7 +1310,7 @@ process_args(Context& ctx)
   if (config.run_second_cpp()) {
     extra_args_to_hash.push_back(state.dep_args);
   }
-  if (state.hash_full_command_line) {
+  if (state.hash_full_command_line && !ctx.config.sloppiness().is_enabled(core::Sloppy::full_command_line)) {
     extra_args_to_hash.push_back(ctx.orig_args);
   }
 

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -1310,7 +1310,8 @@ process_args(Context& ctx)
   if (config.run_second_cpp()) {
     extra_args_to_hash.push_back(state.dep_args);
   }
-  if (state.hash_full_command_line && !ctx.config.sloppiness().is_enabled(core::Sloppy::full_command_line)) {
+  if (state.hash_full_command_line
+      && !ctx.config.sloppiness().is_enabled(core::Sloppy::full_command_line)) {
     extra_args_to_hash.push_back(ctx.orig_args);
   }
 

--- a/src/core/Sloppiness.hpp
+++ b/src/core/Sloppiness.hpp
@@ -46,6 +46,8 @@ enum class Sloppy : uint32_t {
   modules = 1U << 9,
   // Ignore virtual file system (VFS) overlay file.
   ivfsoverlay = 1U << 10,
+  // Don't hash full command line, e.g. when -frecord-gcc-switches is used.
+  full_command_line = 1U << 11,
 };
 
 class Sloppiness

--- a/test/suites/basedir.bash
+++ b/test/suites/basedir.bash
@@ -328,6 +328,34 @@ EOF
     expect_stat cache_miss 1
 
     # -------------------------------------------------------------------------
+    TEST "-frecord-gcc-switches"
+
+    if $COMPILER -frecord-gcc-switches -c test1.c >&/dev/null; then
+        cd dir1
+        CCACHE_BASEDIR="$(pwd)" $CCACHE_COMPILE -frecord-gcc-switches -I$(pwd)/include -c $(pwd)/src/test.c
+        expect_stat direct_cache_hit 0
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 1
+
+        cd ../dir2
+        CCACHE_BASEDIR="$(pwd)" $CCACHE_COMPILE -frecord-gcc-switches -I$(pwd)/include -c $(pwd)/src/test.c
+        expect_stat direct_cache_hit 0
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 2
+
+        CCACHE_BASEDIR="$(pwd)" CCACHE_SLOPPINESS=full_command_line $CCACHE_COMPILE -frecord-gcc-switches -I$(pwd)/include -c $(pwd)/src/test.c
+        expect_stat direct_cache_hit 0
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 3
+
+        cd ../dir1
+        CCACHE_BASEDIR="$(pwd)" CCACHE_SLOPPINESS=full_command_line $CCACHE_COMPILE -frecord-gcc-switches -I$(pwd)/include -c $(pwd)/src/test.c
+        expect_stat direct_cache_hit 0
+        expect_stat preprocessed_cache_hit 1
+        expect_stat cache_miss 3
+    fi
+
+    # -------------------------------------------------------------------------
     TEST "Unset PWD"
 
     unset PWD

--- a/unittest/test_Config.cpp
+++ b/unittest/test_Config.cpp
@@ -130,7 +130,7 @@ TEST_CASE("Config::update_from_file")
     "run_second_cpp = false\n"
     "sloppiness =     time_macros   ,include_file_mtime"
     "  include_file_ctime,file_stat_matches,file_stat_matches_ctime,pch_defines"
-    " ,  no_system_headers,system_headers,clang_index_store,ivfsoverlay\n"
+    " ,  no_system_headers,system_headers,clang_index_store,ivfsoverlay,full_command_line\n"
     "stats = false\n"
     "temporary_dir = ${USER}_foo\n"
     "umask = 777"); // Note: no newline.
@@ -177,7 +177,8 @@ TEST_CASE("Config::update_from_file")
             | static_cast<uint32_t>(core::Sloppy::system_headers)
             | static_cast<uint32_t>(core::Sloppy::pch_defines)
             | static_cast<uint32_t>(core::Sloppy::clang_index_store)
-            | static_cast<uint32_t>(core::Sloppy::ivfsoverlay)));
+            | static_cast<uint32_t>(core::Sloppy::ivfsoverlay)
+            | static_cast<uint32_t>(core::Sloppy::full_command_line)));
   CHECK_FALSE(config.stats());
   CHECK(config.temporary_dir() == FMT("{}_foo", user));
   CHECK(config.umask() == 0777u);


### PR DESCRIPTION
Add a sloppiness option `full_command_line` option for not hashing the full command line when `-frecord-gcc-switches` is set.

Closes #937 , mentioned in #804