### PR TITLE
bump: Upgrade to Hiredis 1.0.2

### DIFF
--- a/cmake/Findhiredis.cmake
+++ b/cmake/Findhiredis.cmake
@@ -1,5 +1,5 @@
 if(HIREDIS_FROM_INTERNET)
-  set(hiredis_version "1.0.0")
+  set(hiredis_version "1.0.2")
   set(hiredis_url https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz)
 
   set(hiredis_dir ${CMAKE_BINARY_DIR}/hiredis-${hiredis_version})


### PR DESCRIPTION
From https://github.com/redis/hiredis/releases/tag/v1.0.2
Hiredis v1.0.2 is a security release with a fix for CVE-2021-32765.
It is otherwise identical to v1.0.0 and backward compatible.
