### PR TITLE
fix: Correct debug dir handling on Windows

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -171,9 +171,7 @@ prepare_debug_path(const std::string& debug_dir,
   auto prefix = debug_dir.empty()
                   ? output_obj
                   : debug_dir + util::to_absolute_path_no_drive(output_obj);
-  try {
-    Util::ensure_dir_exists(Util::dir_name(prefix));
-  } catch (core::Error&) {
+  if (!Util::create_dir(Util::dir_name(prefix))) {
     // Ignore since we can't handle an error in another way in this context. The
     // caller takes care of logging when trying to open the path for writing.
   }

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -170,10 +170,7 @@ prepare_debug_path(const std::string& debug_dir,
 {
   auto prefix = debug_dir.empty()
                   ? output_obj
-                  : debug_dir + util::to_absolute_path(output_obj);
-#ifdef _WIN32
-  prefix.erase(std::remove(prefix.begin(), prefix.end(), ':'), prefix.end());
-#endif
+                  : debug_dir + util::to_absolute_path_no_drive(output_obj);
   try {
     Util::ensure_dir_exists(Util::dir_name(prefix));
   } catch (core::Error&) {

--- a/src/util/path.cpp
+++ b/src/util/path.cpp
@@ -58,4 +58,15 @@ to_absolute_path(nonstd::string_view path)
   }
 }
 
+std::string
+to_absolute_path_no_drive(nonstd::string_view path)
+{
+  std::string abs_path = to_absolute_path(path);
+#ifdef _WIN32
+  if (abs_path.length() >= 2 && abs_path[1] == ':')
+    abs_path.erase(0, 2);
+#endif
+  return abs_path;
+}
+
 } // namespace util

--- a/src/util/path.hpp
+++ b/src/util/path.hpp
@@ -40,6 +40,9 @@ std::vector<std::string> split_path_list(nonstd::string_view path_list);
 // Make `path` an absolute path.
 std::string to_absolute_path(nonstd::string_view path);
 
+// Make `path` an absolute path, but do not include Windows drive.
+std::string to_absolute_path_no_drive(nonstd::string_view path);
+
 // --- Inline implementations ---
 
 inline bool

--- a/unittest/test_util_path.cpp
+++ b/unittest/test_util_path.cpp
@@ -94,3 +94,24 @@ TEST_CASE("util::to_absolute_path")
   CHECK(util::to_absolute_path("../foo/bar")
         == FMT("{}/foo/bar", Util::dir_name(cwd)));
 }
+
+TEST_CASE("util::to_absolute_path_no_drive")
+{
+  CHECK(util::to_absolute_path_no_drive("/foo/bar") == "/foo/bar");
+
+#ifdef _WIN32
+  CHECK(util::to_absolute_path_no_drive("C:\\foo\\bar") == "\\foo\\bar");
+#endif
+
+  auto cwd = Util::get_actual_cwd();
+#ifdef _WIN32
+  cwd = cwd.substr(2);
+#endif
+
+  CHECK(util::to_absolute_path_no_drive("") == cwd);
+  CHECK(util::to_absolute_path_no_drive(".") == cwd);
+  CHECK(util::to_absolute_path_no_drive("..") == Util::dir_name(cwd));
+  CHECK(util::to_absolute_path_no_drive("foo") == FMT("{}/foo", cwd));
+  CHECK(util::to_absolute_path_no_drive("../foo/bar")
+        == FMT("{}/foo/bar", Util::dir_name(cwd)));
+}


### PR DESCRIPTION
The drive letter removal was incorrect.
