### PR TITLE
fix: (Util.cpp) use static_cast<int> on FICLONE, port downstream patch form alpine linux

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -253,7 +253,7 @@ clone_file(const std::string& src, const std::string& dest, bool via_tmp_file)
     }
   }
 
-  if (ioctl(*dest_fd, (int)FICLONE, *src_fd) != 0) {
+  if (ioctl(*dest_fd, static_cast<int>FICLONE, *src_fd) != 0) {
     throw core::Error(strerror(errno));
   }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -253,7 +253,7 @@ clone_file(const std::string& src, const std::string& dest, bool via_tmp_file)
     }
   }
 
-  if (ioctl(*dest_fd, static_cast<int>FICLONE, *src_fd) != 0) {
+  if (ioctl(*dest_fd, static_cast<int> FICLONE, *src_fd) != 0) {
     throw core::Error(strerror(errno));
   }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -253,7 +253,7 @@ clone_file(const std::string& src, const std::string& dest, bool via_tmp_file)
     }
   }
 
-  if (ioctl(*dest_fd, FICLONE, *src_fd) != 0) {
+  if (ioctl(*dest_fd, (int)FICLONE, *src_fd) != 0) {
     throw core::Error(strerror(errno));
   }
 


### PR DESCRIPTION
port downstream patch form alpine linux
enable support for file cloning on ppc64le
"musl uses an `int` instead of a `unsigend long` for the ioctl function
prototype, contrary to glibc, since POSIX mandates the former. This
causes a spurious error on ppc64le which can be silenced by casting to
int explicitly.

See https://www.openwall.com/lists/musl/2020/01/20/2"
https://gitlab.alpinelinux.org/alpine/aports/-/blob/de8bce08376a189ad14809d0272bb4c02e74cdf0/main/ccache/ioctl.patch
