### PR TITLE
fix: Make AVX2 code work also with MSVC

### DIFF
--- a/cmake/GenerateConfigurationFile.cmake
+++ b/cmake/GenerateConfigurationFile.cmake
@@ -73,7 +73,9 @@ include(CheckCXXSourceCompiles)
 check_cxx_source_compiles(
   [=[
     #include <immintrin.h>
+    #ifndef _MSC_VER // MSVC does not need explicit enabling of AVX2.
     void func() __attribute__((target("avx2")));
+    #endif
     void func() { _mm256_abs_epi8(_mm256_set1_epi32(42)); }
     int main()
     {


### PR DESCRIPTION
With GCC it's necessary to explicitly enable AVX2, otherwise GCC will complain about use of AVX2 intrinsics. But MSVC does not require any enabling, it's enough to write the intrinsics.
