### PR TITLE
fix: Use default object file extension .obj for MSVC

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -1041,7 +1041,14 @@ process_args(Context& ctx)
   // Determine output object file.
   const bool implicit_output_obj = args_info.output_obj.empty();
   if (implicit_output_obj && !args_info.input_file.empty()) {
-    string_view extension = state.found_S_opt ? ".s" : ".o";
+    string_view extension;
+    if (state.found_S_opt) {
+      extension = ".s";
+    } else if (ctx.config.compiler_type() != CompilerType::cl) {
+      extension = ".o";
+    } else {
+      extension = ".obj";
+    }
     args_info.output_obj =
       Util::change_extension(Util::base_name(args_info.input_file), extension);
   }


### PR DESCRIPTION
This is separated out from #954 , as this one is rather simple.
