### PR TITLE
fix: Ignore CCACHE_NOCPP2=1 with MSVC

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -867,6 +867,9 @@ the compiler. This will cause the compiler to leave the macros and other
 preprocessor information, and only process the *#include* directives. When run
 in this way, the preprocessor arguments will be passed to the compiler since it
 still has to do _some_ preprocessing (like macros).
++
+This option is ignored with MSVC, as there is no way to make it compile without
+preprocessing first.
 
 [#config_secondary_storage]
 *secondary_storage* (*CCACHE_SECONDARY_STORAGE*)::

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2046,6 +2046,12 @@ do_cache_compilation(Context& ctx, const char* const* argv)
 
   TRY(set_up_uncached_err());
 
+  if (!ctx.config.run_second_cpp()
+      && ctx.config.compiler_type() == CompilerType::cl) {
+    LOG_RAW("Second preprocessor cannot be disabled");
+    ctx.config.set_run_second_cpp(true);
+  }
+
   if (ctx.config.depend_mode()
       && (!ctx.args_info.generating_dependencies
           || ctx.args_info.output_dep == "/dev/null"


### PR DESCRIPTION
There does not appear to be any way to disable preprocessing with
MSVC. And invoking it with .ii file will result in warnings about
file type not being recognized and no action being performed.
