### PR TITLE
fix: Handle MSVC flags -MD[d], -MT[d] and -LT[d] properly

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -242,6 +242,15 @@ process_arg(const Context& ctx,
     return nullopt;
   }
 
+  bool changed_from_slash = false;
+  if (ctx.config.compiler_type() == CompilerType::cl
+      && util::starts_with(args[i], "/")) {
+    // MSVC understands both /option and -option, so convert all /option to
+    // -option to simplify our handling.
+    args[i][0] = '-';
+    changed_from_slash = true;
+  }
+
   // Ignore clang -ivfsoverlay <arg> to not detect multiple input files.
   if (args[i] == "-ivfsoverlay"
       && !(config.sloppiness().is_enabled(core::Sloppy::ivfsoverlay))) {
@@ -252,7 +261,11 @@ process_arg(const Context& ctx,
   }
 
   // Special case for -E.
-  if (args[i] == "-E" || args[i] == "/E") {
+  if (args[i] == "-E") {
+    return Statistic::called_for_preprocessing;
+  }
+  // MSVC -P is -E with output to a file.
+  if (args[i] == "-P" && ctx.config.compiler_type() == CompilerType::cl) {
     return Statistic::called_for_preprocessing;
   }
 
@@ -301,8 +314,8 @@ process_arg(const Context& ctx,
 
   // These are always too hard.
   if (compopt_too_hard(args[i]) || util::starts_with(args[i], "-fdump-")
-      || util::starts_with(args[i], "-MJ") || util::starts_with(args[i], "-Yc")
-      || util::starts_with(args[i], "/Yc")) {
+      || util::starts_with(args[i], "-MJ")
+      || util::starts_with(args[i], "-Yc")) {
     LOG("Compiler option {} is unsupported", args[i]);
     return Statistic::unsupported_compiler_option;
   }
@@ -400,13 +413,13 @@ process_arg(const Context& ctx,
   }
 
   // We must have -c.
-  if (args[i] == "-c" || args[i] == "/c") {
+  if (args[i] == "-c") {
     state.found_c_opt = true;
     return nullopt;
   }
 
-  // MSVC /Fo with no space.
-  if (util::starts_with(args[i], "/Fo")
+  // MSVC -Fo with no space.
+  if (util::starts_with(args[i], "-Fo")
       && config.compiler_type() == CompilerType::cl) {
     args_info.output_obj =
       Util::make_relative_path(ctx, string_view(args[i]).substr(3));
@@ -817,6 +830,12 @@ process_arg(const Context& ctx,
     state.hash_full_command_line = true;
   }
 
+  // MSVC -u is something else than GCC -u, handle it specially.
+  if (args[i] == "-u" && ctx.config.compiler_type() == CompilerType::cl) {
+    state.cpp_args.push_back(args[i]);
+    return nullopt;
+  }
+
   // Options taking an argument that we may want to rewrite to relative paths to
   // get better hit rate. A secondary effect is that paths in the standard error
   // output produced by the compiler will be normalized.
@@ -856,8 +875,7 @@ process_arg(const Context& ctx,
 
   // Same as above but options with concatenated argument beginning with a
   // slash.
-  if (args[i][0] == '-'
-      || (config.compiler_type() == CompilerType::cl && args[i][0] == '/')) {
+  if (args[i][0] == '-') {
     size_t slash_pos = args[i].find('/');
     if (slash_pos != std::string::npos) {
       std::string option = args[i].substr(0, slash_pos);
@@ -895,8 +913,7 @@ process_arg(const Context& ctx,
   }
 
   // Other options.
-  if (args[i][0] == '-'
-      || (config.compiler_type() == CompilerType::cl && args[i][0] == '/')) {
+  if (args[i][0] == '-') {
     if (compopt_affects_cpp_output(args[i])
         || compopt_prefix_affects_cpp_output(args[i])) {
       state.cpp_args.push_back(args[i]);
@@ -912,6 +929,9 @@ process_arg(const Context& ctx,
   // Note that "/dev/null" is an exception that is sometimes used as an input
   // file when code is testing compiler flags.
   if (args[i] != "/dev/null") {
+    if (changed_from_slash) {
+      args[i][0] = '/';
+    }
     auto st = Stat::stat(args[i]);
     if (!st || !st.is_regular()) {
       LOG("{} is not a regular file, not considering as input file", args[i]);

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -68,10 +68,14 @@ const CompOpt compopts[] = {
   {"--serialize-diagnostics", TAKES_ARG | TAKES_PATH},
   {"--specs", TAKES_ARG},
   {"-A", TAKES_ARG},
+  {"-AI", TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
   {"-B", TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-D", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG},
   {"-E", TOO_HARD},
+  {"-EP", TOO_HARD}, // msvc
   {"-F", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
+  {"-FI", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
+  {"-FU", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
   {"-G", TAKES_ARG},
   {"-I", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-L", TAKES_ARG},
@@ -91,6 +95,9 @@ const CompOpt compopts[] = {
   {"-Xclang", TAKES_ARG},
   {"-Xlinker", TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},
   {"-Xpreprocessor", AFFECTS_CPP | TOO_HARD_DIRECT | TAKES_ARG},
+  {"-Yc", TAKES_ARG | TOO_HARD}, // msvc
+  {"-ZI", TOO_HARD},             // msvc
+  {"-Zi", TOO_HARD},             // msvc
   {"-all_load", AFFECTS_COMP},
   {"-analyze", TOO_HARD}, // Clang
   {"-arch", TAKES_ARG},
@@ -142,20 +149,6 @@ const CompOpt compopts[] = {
   {"-stdlib=", AFFECTS_CPP | TAKES_CONCAT_ARG},
   {"-trigraphs", AFFECTS_CPP},
   {"-u", TAKES_ARG | TAKES_CONCAT_ARG},
-  {"/AI", TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},               // msvc
-  {"/D", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG},               // msvc
-  {"/E", TOO_HARD},                                                 // msvc
-  {"/EP", TOO_HARD},                                                // msvc
-  {"/FI", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
-  {"/FU", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
-  {"/I", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},  // msvc
-  {"/L", TAKES_ARG},                                                // msvc
-  {"/P", TOO_HARD},                                                 // msvc
-  {"/U", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG},               // msvc
-  {"/Yc", TAKES_ARG | TOO_HARD},                                    // msvc
-  {"/ZI", TOO_HARD},                                                // msvc
-  {"/Zi", TOO_HARD},                                                // msvc
-  {"/u", AFFECTS_CPP},                                              // msvc
 };
 
 static int


### PR DESCRIPTION
This depends on #954 .
