### PR TITLE
MSVC's -link option is too hard

### DIFF
--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -126,6 +126,7 @@ const CompOpt compopts[] = {
   {"-iwithprefixbefore",
    AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-ldir", AFFECTS_CPP | TAKES_ARG}, // nvcc
+  {"-link", TOO_HARD},                // msvc
   {"-nolibc", AFFECTS_COMP},
   {"-nostdinc", AFFECTS_CPP},
   {"-nostdinc++", AFFECTS_CPP},


### PR DESCRIPTION
Everything after it should be passed to the linker, which conflicts
with ccache appending its extra arguments when calling the compiler.
This probably could be handled somehow, but ccache shouldn't cache
compilations that also link, so either the option doesn't belong
there anyway, or the compilation cannot be cached.
