### PR TITLE
Fix copying of binary files on Windows

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -355,7 +355,7 @@ copy_fd(int fd_in, int fd_out)
 void
 copy_file(const std::string& src, const std::string& dest, bool via_tmp_file)
 {
-  Fd src_fd(open(src.c_str(), O_RDONLY));
+  Fd src_fd(open(src.c_str(), O_RDONLY | O_BINARY));
   if (!src_fd) {
     throw core::Error("{}: {}", src, strerror(errno));
   }

--- a/test/suites/secondary_file.bash
+++ b/test/suites/secondary_file.bash
@@ -51,6 +51,15 @@ SUITE_secondary_file() {
     expect_stat files_in_cache 2 # fetched from secondary
     expect_file_count 3 '*' secondary # CACHEDIR.TAG + result + manifest
 
+    $CCACHE_COMPILE -c test.c
+    expect_stat direct_cache_hit 3
+    expect_stat cache_miss 1
+    expect_stat primary_storage_hit 4
+    expect_stat primary_storage_miss 4 # 2 * (result + manifest)
+    expect_stat secondary_storage_hit 2 # result + manifest
+    expect_stat secondary_storage_miss 2 # result + manifest
+    expect_stat files_in_cache 2 # fetched from secondary
+    expect_file_count 3 '*' secondary # CACHEDIR.TAG + result + manifest
     # -------------------------------------------------------------------------
     TEST "Flat layout"
 

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -651,6 +651,25 @@ TEST_CASE("Util::read_file and Util::write_file")
                     "No such file or directory");
 }
 
+TEST_CASE(
+  "Util::read_file, Util::write_file and Util::copy_file with binary files")
+{
+  TestContext test_context;
+
+  std::string origin_data;
+  for (int i = 0; i < 512; i++) {
+    origin_data.push_back(static_cast<char>((32 + i) % 256));
+  }
+
+  Util::write_file("test", origin_data, std::ios_base::binary);
+  std::string data = Util::read_file("test");
+  CHECK(data == origin_data);
+
+  Util::copy_file("test", "copy");
+  data = Util::read_file("copy");
+  CHECK(data == origin_data);
+}
+
 TEST_CASE("Util::remove_extension")
 {
   CHECK(Util::remove_extension("") == "");


### PR DESCRIPTION
The Secondary Storage creates corrupted files when they are copied to the Primary Storage.

The flag `O_BINARY` fix that issue. 