### PR TITLE
fix: avoid .incbin false positive

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -567,8 +567,8 @@ process_preprocessed_file(Context& ctx, Hash& hash, const std::string& path)
           Statistic::could_not_use_precompiled_header);
       }
       p = q; // Everything of interest between p and q has been hashed now.
-    } else if (q[0] == '.' && q[1] == 'i' && q[2] == 'n' && q[3] == 'c'
-               && q[4] == 'b' && q[5] == 'i' && q[6] == 'n') {
+    } else if (strncmp(q, ".incbin \\\"", 10) == 0
+               || strncmp(q, ".incbin \"", 9) == 0) {
       // An assembler .inc bin (without the space) statement, which could be
       // part of inline assembly, refers to an external file. If the file
       // changes, the hash should change as well, but finding out what file to

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -1440,6 +1440,20 @@ EOF
     expect_stat preprocessed_cache_hit 0
     expect_stat cache_miss 0
     expect_stat unsupported_code_directive 2
+
+    cat <<EOF >incbin.cpp
+        struct A {
+             void incbin() const { }
+        };
+        void f() {
+             A a;
+             a.incbin();
+        }
+EOF
+    $CCACHE_COMPILE -x c++ -c incbin.cpp
+    expect_stat preprocessed_cache_hit 0
+    expect_stat unsupported_code_directive 2
+    expect_stat cache_miss 1
 fi
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
With this patch accepts C++ code like `obj.incbin(x)`.
Previously it complained `Found unsupported .incbin directive`.

Fixes: #982