### PR TITLE
Detect clang-cl as a compiler

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -241,6 +241,8 @@ parse_compiler_type(const std::string& value)
 {
   if (value == "clang") {
     return CompilerType::clang;
+  } else if (value == "clang-cl") {
+    return CompilerType::clangcl;
   } else if (value == "gcc") {
     return CompilerType::gcc;
   } else if (value == "msvc") {
@@ -451,6 +453,7 @@ compiler_type_to_string(CompilerType compiler_type)
     return "auto";
 
     CASE(clang);
+    CASE(clangcl);
     CASE(gcc);
     CASE(msvc);
     CASE(nvcc);

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -31,7 +31,7 @@
 #include <string>
 #include <unordered_map>
 
-enum class CompilerType { auto_guess, clang, gcc, msvc, nvcc, other };
+enum class CompilerType { auto_guess, clang, clangcl, gcc, msvc, nvcc, other };
 
 std::string compiler_type_to_string(CompilerType compiler_type);
 
@@ -48,6 +48,10 @@ public:
   const std::string& compiler() const;
   const std::string& compiler_check() const;
   CompilerType compiler_type() const;
+  // Returns true for clang or clangcl.
+  bool is_compiler_group_clang() const;
+  // Returns true for cl or clangcl.
+  bool is_compiler_group_cl() const;
   bool compression() const;
   int8_t compression_level() const;
   const std::string& cpp_extension() const;
@@ -230,6 +234,20 @@ inline CompilerType
 Config::compiler_type() const
 {
   return m_compiler_type;
+}
+
+inline bool
+Config::is_compiler_group_clang() const
+{
+  return m_compiler_type == CompilerType::clang
+         || m_compiler_type == CompilerType::clangcl;
+}
+
+inline bool
+Config::is_compiler_group_cl() const
+{
+  return m_compiler_type == CompilerType::msvc
+         || m_compiler_type == CompilerType::clangcl;
 }
 
 inline bool

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -229,7 +229,9 @@ guess_compiler(string_view path)
 
   const auto name =
     Util::to_lowercase(Util::remove_extension(Util::base_name(compiler_path)));
-  if (name.find("clang") != nonstd::string_view::npos) {
+  if (name.find("clang-cl") != nonstd::string_view::npos) {
+    return CompilerType::clangcl;
+  } else if (name.find("clang") != nonstd::string_view::npos) {
     return CompilerType::clang;
   } else if (name.find("gcc") != nonstd::string_view::npos
              || name.find("g++") != nonstd::string_view::npos) {
@@ -934,7 +936,7 @@ to_cache(Context& ctx,
          const Args& depend_extra_args,
          Hash* depend_mode_hash)
 {
-  if (ctx.config.compiler_type() == CompilerType::msvc) {
+  if (ctx.config.is_compiler_group_cl()) {
     args.push_back(fmt::format("-Fo{}", ctx.args_info.output_obj));
   } else {
     args.push_back("-o");
@@ -1500,7 +1502,7 @@ calculate_result_and_manifest_key(Context& ctx,
 
   // clang will emit warnings for unused linker flags, so we shouldn't skip
   // those arguments.
-  int is_clang = ctx.config.compiler_type() == CompilerType::clang
+  int is_clang = ctx.config.is_compiler_group_clang()
                  || ctx.config.compiler_type() == CompilerType::other;
 
   // First the arguments.
@@ -1827,7 +1829,7 @@ from_cache(Context& ctx, FromCacheCallMode mode, const Digest& result_key)
   //
   //     file 'foo.h' has been modified since the precompiled header 'foo.pch'
   //     was built
-  if ((ctx.config.compiler_type() == CompilerType::clang
+  if ((ctx.config.is_compiler_group_clang()
        || ctx.config.compiler_type() == CompilerType::other)
       && ctx.args_info.output_is_precompiled_header
       && mode == FromCacheCallMode::cpp) {
@@ -2120,8 +2122,7 @@ do_cache_compilation(Context& ctx, const char* const* argv)
 
   TRY(set_up_uncached_err());
 
-  if (!ctx.config.run_second_cpp()
-      && ctx.config.compiler_type() == CompilerType::msvc) {
+  if (!ctx.config.run_second_cpp() && ctx.config.is_compiler_group_cl()) {
     LOG_RAW("Second preprocessor cannot be disabled");
     ctx.config.set_run_second_cpp(true);
   }


### PR DESCRIPTION
Without this, clang-cl is detected as clang and then ccache barfs
because clang-cl produces stdout output.
