### PR TITLE
feat: Enable HTTP keep-alive by default

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -1105,13 +1105,7 @@ Optional attributes:
 
 * *connect-timeout*: Timeout (in ms) for network connection. The default is 100.
 * *keep-alive*: If *true*, keep the HTTP connection to the storage server open
-  to avoid reconnects. The default is *false*.
-+
-NOTE: Connection keep-alive is disabled by default because with the current
-HTTP implementation uploads to the remote end might fail in case the server
-closes the connection due to a keep-alive timeout. If the general case with
-short compilation times should be accelerated or the server is configured with
-a long-enough timeout, then connection keep-alive could be enabled.
+  to avoid reconnects. The default is *true*.
 * *layout*: How to map key names to the path part of the URL. Available values:
 +
 --

--- a/src/storage/secondary/HttpStorage.cpp
+++ b/src/storage/secondary/HttpStorage.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Joel Rosdahl and other contributors
+// Copyright (C) 2021-2022 Joel Rosdahl and other contributors
 //
 // See doc/AUTHORS.adoc for a complete list of contributors.
 //
@@ -110,7 +110,7 @@ HttpStorageBackend::HttpStorageBackend(const Params& params)
   m_http_client.set_default_headers({
     {"User-Agent", FMT("{}/{}", CCACHE_NAME, CCACHE_VERSION)},
   });
-  m_http_client.set_keep_alive(false);
+  m_http_client.set_keep_alive(true);
 
   auto connect_timeout = k_default_connect_timeout;
   auto operation_timeout = k_default_operation_timeout;


### PR DESCRIPTION
The issue that made us not enable HTTP keep-alive by default (yhirose/cpp-httplib#1041) was resolved in cpp-httplib 0.10.0 (upgraded in e22e934dcaf1).

@gjasny: Does this sound OK to you?