### PR TITLE
feat: Add option to use Bearer token with HTTP backend

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -1131,6 +1131,7 @@ values.
 +
 The default is *subdirs*.
 * *operation-timeout*: Timeout (in ms) for HTTP requests. The default is 10000.
+* *bearer-token*: Bearer token used to authorize the HTTP requests.
 
 
 === Redis storage backend

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -1103,6 +1103,7 @@ Examples:
 
 Optional attributes:
 
+* *bearer-token*: Bearer token used to authorize the HTTP requests.
 * *connect-timeout*: Timeout (in ms) for network connection. The default is 100.
 * *keep-alive*: If *true*, keep the HTTP connection to the storage server open
   to avoid reconnects. The default is *false*.
@@ -1131,7 +1132,6 @@ values.
 +
 The default is *subdirs*.
 * *operation-timeout*: Timeout (in ms) for HTTP requests. The default is 10000.
-* *bearer-token*: Bearer token used to authorize the HTTP requests.
 
 
 === Redis storage backend

--- a/src/storage/secondary/HttpStorage.cpp
+++ b/src/storage/secondary/HttpStorage.cpp
@@ -132,6 +132,8 @@ HttpStorageBackend::HttpStorageBackend(const Params& params)
       }
     } else if (attr.key == "operation-timeout") {
       operation_timeout = parse_timeout_attribute(attr.value);
+    } else if (attr.key == "bearer-token") {
+      m_http_client.set_bearer_token_auth(attr.value.c_str());
     } else if (!is_framework_attribute(attr.key)) {
       LOG("Unknown attribute: {}", attr.key);
     }

--- a/src/storage/secondary/HttpStorage.cpp
+++ b/src/storage/secondary/HttpStorage.cpp
@@ -116,7 +116,9 @@ HttpStorageBackend::HttpStorageBackend(const Params& params)
   auto operation_timeout = k_default_operation_timeout;
 
   for (const auto& attr : params.attributes) {
-    if (attr.key == "connect-timeout") {
+    if (attr.key == "bearer-token") {
+      m_http_client.set_bearer_token_auth(attr.value.c_str());
+    } else if (attr.key == "connect-timeout") {
       connect_timeout = parse_timeout_attribute(attr.value);
     } else if (attr.key == "keep-alive") {
       m_http_client.set_keep_alive(attr.value == "true");
@@ -132,8 +134,6 @@ HttpStorageBackend::HttpStorageBackend(const Params& params)
       }
     } else if (attr.key == "operation-timeout") {
       operation_timeout = parse_timeout_attribute(attr.value);
-    } else if (attr.key == "bearer-token") {
-      m_http_client.set_bearer_token_auth(attr.value.c_str());
     } else if (!is_framework_attribute(attr.key)) {
       LOG("Unknown attribute: {}", attr.key);
     }

--- a/src/storage/secondary/HttpStorage.cpp
+++ b/src/storage/secondary/HttpStorage.cpp
@@ -283,6 +283,15 @@ HttpStorage::redact_secrets(Backend::Params& params) const
   if (user_info.second) {
     url.user_info(FMT("{}:{}", user_info.first, k_redacted_password));
   }
+
+  auto bearer_token_attribute =
+    std::find_if(params.attributes.begin(),
+                 params.attributes.end(),
+                 [&](const auto& attr) { return attr.key == "bearer-token"; });
+  if (bearer_token_attribute != params.attributes.end()) {
+    bearer_token_attribute->value = k_redacted_password;
+    bearer_token_attribute->raw_value = k_redacted_password;
+  }
 }
 
 } // namespace secondary


### PR DESCRIPTION
This a proposal to add support for Bearer Authorization to the HTTP secondary storage backend.

I tested it locally and it worked perfectly: files were uploaded on GCloud during first build, and second build was much faster (after cleaning the cache).

Let me know if you prefer a different name than `"bearer-token"` or for any other improvement. Maybe we should redact the token in the logs (I don't know if it's logged) as it is done for the password?

Fixes #997.