### PR TITLE
Fix clang-cl display name

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -451,9 +451,10 @@ compiler_type_to_string(CompilerType compiler_type)
   switch (compiler_type) {
   case CompilerType::auto_guess:
     return "auto";
+  case CompilerType::clang_cl:
+    return "clang-cl";
 
     CASE(clang);
-    CASE(clang_cl);
     CASE(gcc);
     CASE(msvc);
     CASE(nvcc);


### PR DESCRIPTION
Amends 32c708525f80db08e6399628cdb944a67e4eba69
