### PR TITLE
CMake: Added support for cmake upstream zstd package configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,11 @@ endif()
 
 option(ZSTD_FROM_INTERNET "Download and use libzstd from the Internet" ${ZSTD_FROM_INTERNET_DEFAULT})
 find_package(zstd 1.1.2 REQUIRED)
+if(TARGET zstd::libzstd_shared)
+  set(ZSTD_LIBRARIES zstd::libzstd_shared)
+else()
+  set(ZSTD_LIBRARIES ZSTD::ZSTD)
+endif()
 
 option(REDIS_STORAGE_BACKEND "Enable Redis secondary storage" ON)
 if(REDIS_STORAGE_BACKEND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(
   ccache_framework
-  PRIVATE standard_settings standard_warnings ZSTD::ZSTD Threads::Threads third_party
+  PRIVATE standard_settings standard_warnings ${ZSTD_LIBRARIES} Threads::Threads third_party
 )
 
 target_include_directories(ccache_framework PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
I would like to use the `zstd` library with the name that is used upstream, not the cmake alias that `FindZSTD.cmake` creates. Sadly the names are slightly different. However its not very difficult to check if ZSTD was found via the upstream name or the CMake alias name, and use either or.

This change should be 100% backwards compatible. It only adds more broad support for finding ZSTD, but should not limit anything.