### PR TITLE
fix: Support UTF-16LE .rsp files

### DIFF
--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -54,7 +54,7 @@ Args::from_atfile(const std::string& filename, bool ignore_backslash)
 {
   std::string argtext;
   try {
-    argtext = Util::read_file(filename);
+    argtext = Util::read_text_file(filename);
   } catch (core::Error&) {
     return nullopt;
   }

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -293,6 +293,12 @@ bool read_fd(int fd, DataReceiver data_receiver);
 // without the path.
 std::string read_file(const std::string& path, size_t size_hint = 0);
 
+// Return contents of a text file as UTF-8 encoded string.
+//
+// Throws `core::Error` on error. The description contains the error message
+// without the path.
+std::string read_text_file(const std::string& path, size_t size_hint = 0);
+
 #ifndef _WIN32
 // Like readlink(2) but returns the string (or the empty string on failure).
 std::string read_link(const std::string& path);

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -667,6 +667,24 @@ TEST_CASE("Util::{read,write,copy}_file with binary files")
   CHECK(Util::read_file("copy") == data);
 }
 
+TEST_CASE("Util::read_text_file with UTF-16 little endian encoding")
+{
+  TestContext test_context;
+
+  std::string data;
+  data.push_back(static_cast<unsigned char>(0xff));
+  data.push_back(static_cast<unsigned char>(0xfe));
+  data.push_back('a');
+  data.push_back('\0');
+  data.push_back('b');
+  data.push_back('\0');
+  data.push_back('c');
+  data.push_back('\0');
+
+  Util::write_file("test", data);
+  CHECK(Util::read_text_file("test") == "abc");
+}
+
 TEST_CASE("Util::remove_extension")
 {
   CHECK(Util::remove_extension("") == "");


### PR DESCRIPTION
Visual Studio writes its .rsp files with UTF-16 encoding
which need to be converted to UTF-8 so that ccache
can be used within Visual Studio
