### PR TITLE
Add documentation that compiler plugins are hashed too

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -437,8 +437,9 @@ invocation you can use the `-d`/`--dir` command line option instead.
 
     By default, ccache includes the modification time ("`mtime`") and size of
     the compiler in the hash to ensure that results retrieved from the cache
-    are accurate. This option can be used to select another strategy. Possible
-    values are:
+    are accurate. If compiler plugins are used, these plugins will also be 
+    added to the hash. This option can be used to select another strategy.
+    Possible values are:
 +
 --
 *content*::


### PR DESCRIPTION
I've been bisecting the Linux kernel for a few days now, and had a hard time figuring out why ccache had a hit rate around 3% even though I've been recompiling the same code over and over again - until I learned about the existence of compiler plugins today. As the kernel's GCC plugins are rebuilt after every `make clean`, this kept triggering the compilercheck on every build, even though the compiler itself never changed (of course). Therefore adding a hint at the compilercheck documentation for future-me that plugins are considered in this check too.
