### PR TITLE
fix: Make conversion to relative paths more reliable on Windows

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -233,6 +233,31 @@ base_name(string_view path)
   return n == std::string::npos ? path : path.substr(n + 1);
 }
 
+bool
+is_absolute_path_with_prefix(nonstd::string_view path, size_t& split_pos)
+{
+#ifdef _WIN32
+  const char delim[] = "/\\";
+#else
+  const char delim[] = "/";
+#endif
+  split_pos = path.find_first_of(delim);
+  if (split_pos != std::string::npos) {
+#ifdef _WIN32
+    // -I/C:/foo and -I/c/foo will already be handled by delim_pos
+    // correctly resulting in -I and /C:/foo or /c/foo respectively.
+    // -IC:/foo will not as we would get -IC: and /foo
+    if (split_pos > 0 && path[split_pos - 1] == ':') {
+      split_pos = split_pos - 2;
+    }
+#endif
+    // this is not redundant on some platforms so nothing to simplify
+    // NOLINTNEXTLINE(readability-simplify-boolean-expr)
+    return true;
+  }
+  return false;
+}
+
 std::string
 change_extension(string_view path, string_view new_ext)
 {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -832,7 +832,7 @@ make_relative_path(const std::string& base_dir,
                    const std::string& apparent_cwd,
                    nonstd::string_view path)
 {
-  if (base_dir.empty() || !util::starts_with(path, base_dir)) {
+  if (base_dir.empty() || !util::path_starts_with(path, base_dir)) {
     return std::string(path);
   }
 

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -46,6 +46,10 @@ enum class UnlinkLog { log_failure, ignore_failure };
 // Get base name of path.
 nonstd::string_view base_name(nonstd::string_view path);
 
+// Determine if `path` is an absolute path with prefix, returning the split
+// point
+bool is_absolute_path_with_prefix(nonstd::string_view path, size_t& split_pos);
+
 // Get an integer value from bytes in big endian order.
 //
 // Parameters:

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -919,8 +919,8 @@ process_arg(const Context& ctx,
 
   // Potentially rewrite concatenated absolute path argument to relative.
   if (args[i][0] == '-') {
-    size_t slash_pos = args[i].find('/');
-    if (slash_pos != std::string::npos) {
+    size_t slash_pos = 0;
+    if (Util::is_absolute_path_with_prefix(args[i], slash_pos)) {
       std::string option = args[i].substr(0, slash_pos);
       if (compopt_takes_concat_arg(option) && compopt_takes_path(option)) {
         auto relpath =

--- a/src/util/path.cpp
+++ b/src/util/path.cpp
@@ -41,6 +41,35 @@ is_absolute_path(nonstd::string_view path)
   return !path.empty() && path[0] == '/';
 }
 
+bool
+path_starts_with(nonstd::string_view path, nonstd::string_view prefix)
+{
+  for (size_t i = 0, j = 0; i < path.length() && j < prefix.length();
+       ++i, ++j) {
+#ifdef _WIN32
+    // skip escaped backslashes \\\\ as seen by the preprocessor
+    if (i > 0 && path[i] == '\\' && path[i - 1] == '\\') {
+      ++i;
+    }
+    if (j > 0 && prefix[j] == '\\' && prefix[j - 1] == '\\') {
+      ++j;
+    }
+
+    // handle back and forward slashes as equal
+    if (path[i] == '/' && prefix[j] == '\\') {
+      continue;
+    }
+    if (path[i] == '\\' && prefix[j] == '/') {
+      continue;
+    }
+#endif
+    if (path[i] != prefix[j]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 std::vector<std::string>
 split_path_list(nonstd::string_view path_list)
 {

--- a/src/util/path.hpp
+++ b/src/util/path.hpp
@@ -33,6 +33,10 @@ bool is_absolute_path(nonstd::string_view path);
 // Return whether `path` includes at least one directory separator.
 bool is_full_path(nonstd::string_view path);
 
+// Return whether `path` starts with `prefix` considering path specifics on
+// Windows
+bool path_starts_with(nonstd::string_view path, nonstd::string_view prefix);
+
 // Split a list of paths (such as the content of $PATH on Unix platforms or
 // %PATH% on Windows platforms) into paths.
 std::vector<std::string> split_path_list(nonstd::string_view path_list);

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -489,6 +489,14 @@ TEST_CASE("Util::make_relative_path")
       make_relative_path(
         actual_cwd.substr(0, 3), actual_cwd, apparent_cwd, actual_cwd + "/x")
       == "./x");
+    CHECK(
+      make_relative_path(
+        actual_cwd.substr(0, 3), actual_cwd, apparent_cwd, actual_cwd + "\\x")
+      == ".\\x");
+    CHECK(
+      make_relative_path(
+        actual_cwd.substr(0, 3), actual_cwd, apparent_cwd, actual_cwd + "\\\\x")
+      == ".\\x");
 #else
     CHECK(make_relative_path("/", actual_cwd, apparent_cwd, actual_cwd + "/x")
           == "./x");

--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -52,6 +52,27 @@ TEST_CASE("Util::base_name")
   CHECK(Util::base_name("/foo/bar/f.txt") == "f.txt");
 }
 
+TEST_CASE("Util::is_absolute_path_with_prefix")
+{
+  size_t delim_pos = 0;
+  CHECK(Util::is_absolute_path_with_prefix("-I/c/foo", delim_pos));
+  CHECK(delim_pos == 2);
+  CHECK(Util::is_absolute_path_with_prefix("-W,path/c/foo", delim_pos));
+  CHECK(delim_pos == 7);
+  CHECK(!Util::is_absolute_path_with_prefix("-DMACRO", delim_pos));
+#ifdef _WIN32
+  CHECK(Util::is_absolute_path_with_prefix("-I/C:/foo", delim_pos));
+  CHECK(delim_pos == 2);
+  CHECK(Util::is_absolute_path_with_prefix("-IC:/foo", delim_pos));
+  CHECK(delim_pos == 2);
+  CHECK(Util::is_absolute_path_with_prefix("-W,path/c:/foo", delim_pos));
+  CHECK(delim_pos == 7);
+  CHECK(Util::is_absolute_path_with_prefix("-W,pathc:/foo", delim_pos));
+  CHECK(delim_pos == 7);
+  CHECK(!Util::is_absolute_path_with_prefix("-opt:value", delim_pos));
+#endif
+}
+
 TEST_CASE("Util::big_endian_to_int")
 {
   uint8_t bytes[8] = {0x70, 0x9e, 0x9a, 0xbc, 0xd6, 0x54, 0x4b, 0xca};

--- a/unittest/test_util_path.cpp
+++ b/unittest/test_util_path.cpp
@@ -115,3 +115,21 @@ TEST_CASE("util::to_absolute_path_no_drive")
   CHECK(util::to_absolute_path_no_drive("../foo/bar")
         == FMT("{}/foo/bar", Util::dir_name(cwd)));
 }
+
+TEST_CASE("util::path_starts_with")
+{
+  CHECK(util::path_starts_with("/foo/bar", "/foo"));
+  CHECK(!util::path_starts_with("/batz/bar", "/foo"));
+  CHECK(!util::path_starts_with("/foo/bar", "/foo/baz"));
+  CHECK(!util::path_starts_with("/beh/foo", "/foo"));
+#ifdef _WIN32
+  CHECK(util::path_starts_with("C:/foo/bar", "C:\\foo"));
+  CHECK(util::path_starts_with("C:/foo/bar", "C:\\\\foo"));
+  CHECK(util::path_starts_with("C:\\foo\\bar", "C:/foo"));
+  CHECK(util::path_starts_with("C:\\\\foo\\\\bar", "C:/foo"));
+  CHECK(!util::path_starts_with("C:\\foo\\bar", "/foo/baz"));
+  CHECK(!util::path_starts_with("C:\\foo\\bar", "C:/foo/baz"));
+  CHECK(!util::path_starts_with("C:\\beh\\foo", "/foo"));
+  CHECK(!util::path_starts_with("C:\\beh\\foo", "C:/foo"));
+#endif
+}


### PR DESCRIPTION
When testing `ccache` in my projects using MSVC via cmake and ninja I found that the relative path handling triggered via the "base_dir" config option would not work for all compiler invokations generated by CMake.

This is especially critical as some CIs like e.g. drone use unique build directories and as such caching depends on paths to be always relative.

This PR addresses the two issues I found in the code which prevented base paths to be properly generated in my setup.