### PR TITLE
Authenticate Redis before database selection

### DIFF
--- a/src/storage/secondary/RedisStorage.cpp
+++ b/src/storage/secondary/RedisStorage.cpp
@@ -127,8 +127,8 @@ RedisStorageBackend::RedisStorageBackend(const Params& params)
   }
 
   connect(url, connect_timeout.count(), operation_timeout.count());
-  select_database(url);
   authenticate(url);
+  select_database(url);
 }
 
 inline bool


### PR DESCRIPTION
Redis servers configured with authentication require successful authentication before database selection.

Fix bug that can only occur when attempting to use a non-zero database on a Redis server that requires authentication.
When connecting to a Redis server a client operates against database 0 by default.
The select_database function returns early without performing an action on the Redis server if the database in the URL variable is explicitly set to zero, or is not specified and therefore assumed to be database 0.
When the url contains a database of 1 or higher a redis transaction to select the requested database is performed, this transaction will fail if the Redis server requires authentication and authentication has not been performed.