### PR TITLE
docs: Add reference to reference build configs

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -43,7 +43,7 @@ Optional:
 
 Reference configurations:
 
-- see [CI configurations](../.github/workflows/build.yaml) for a selection of
+- See [CI configurations](../.github/workflows/build.yaml) for a selection of
   regularly tested build setups, including cross-compiling and explicit
   dependencies required in Debian/Ubuntu environment.
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -41,6 +41,11 @@ Optional:
 - [Asciidoctor](https://asciidoctor.org) to build the HTML documentation.
 - [Python](https://www.python.org) to debug and run the performance test suite.
 
+Reference configurations:
+
+- see [CI configurations](../.github/workflows/build.yaml) for a selection of
+  regularly tested build setups, including cross-compiling and explicit
+  dependencies required in Debian/Ubuntu environment.
 
 Installation
 ------------


### PR DESCRIPTION
Adding a reference to GH workflows as source of build setup information

Side effect of #1009 