### PR TITLE
fix: normalize abs paths when collecting includes to fix basedir option

### DIFF
--- a/src/ArgsInfo.hpp
+++ b/src/ArgsInfo.hpp
@@ -26,8 +26,11 @@
 // This class holds meta-information derived from the compiler arguments.
 struct ArgsInfo
 {
-  // The source file.
+  // The source file path.
   std::string input_file;
+
+  // The source file path run through Util::normalize_concrete_absolute_path.
+  std::string normalized_input_file;
 
   // In normal compiler operation an output file is created if there is no
   // compiler error. However certain flags like -fsyntax-only change this

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -1016,6 +1016,8 @@ process_arg(const Context& ctx,
 
   // Rewrite to relative to increase hit rate.
   args_info.input_file = Util::make_relative_path(ctx, args[i]);
+  args_info.normalized_input_file =
+    Util::normalize_concrete_absolute_path(args_info.input_file);
 
   return nullopt;
 }

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -553,23 +553,10 @@ process_preprocessed_file(Context& ctx, Hash& hash, const std::string& path)
       if (!ctx.has_absolute_include_headers) {
         ctx.has_absolute_include_headers = util::is_absolute_path(inc_path);
       }
+      inc_path = Util::normalize_concrete_absolute_path(inc_path);
       inc_path = Util::make_relative_path(ctx, inc_path);
 
-      bool should_hash_inc_path = true;
-      if (!ctx.config.hash_dir()) {
-        if (util::starts_with(inc_path, ctx.apparent_cwd)
-            && util::ends_with(inc_path, "//")) {
-          // When compiling with -g or similar, GCC adds the absolute path to
-          // CWD like this:
-          //
-          //   # 1 "CWD//"
-          //
-          // If the user has opted out of including the CWD in the hash, don't
-          // hash it. See also how debug_prefix_map is handled.
-          should_hash_inc_path = false;
-        }
-      }
-      if (should_hash_inc_path) {
+      if ((inc_path != ctx.apparent_cwd) || ctx.config.hash_dir()) {
         hash.hash(inc_path);
       }
 
@@ -911,17 +898,29 @@ rewrite_stdout_from_compiler(const Context& ctx, std::string&& stdout_data)
   using util::Tokenizer;
   using Mode = Tokenizer::Mode;
   using IncludeDelimiter = Tokenizer::IncludeDelimiter;
-  // distcc-pump outputs lines like this:
-  //
-  //   __________Using # distcc servers in pump mode
-  //
-  // We don't want to cache those.
   if (!stdout_data.empty()) {
     std::string new_stdout_text;
     for (const auto line : Tokenizer(
            stdout_data, "\n", Mode::include_empty, IncludeDelimiter::yes)) {
       if (util::starts_with(line, "__________")) {
         Util::send_to_fd(ctx, std::string(line), STDOUT_FILENO);
+      }
+      // Ninja uses the lines with 'Note: including file: ' to determine the
+      // used headers. Headers within basedir need to be changed into relative
+      // paths because otherwise Ninja will use the abs path to original header
+      // to check if a file needs to be recompiled.
+      else if (ctx.config.compiler_type() == CompilerType::msvc
+               && !ctx.config.base_dir().empty()
+               && util::starts_with(line, "Note: including file:")) {
+        std::string orig_line(line.data(), line.length());
+        std::string abs_inc_path =
+          util::replace_first(orig_line, "Note: including file:", "");
+        abs_inc_path = util::strip_whitespace(abs_inc_path);
+        std::string rel_inc_path = Util::make_relative_path(
+          ctx, Util::normalize_concrete_absolute_path(abs_inc_path));
+        std::string line_with_rel_inc =
+          util::replace_first(orig_line, abs_inc_path, rel_inc_path);
+        new_stdout_text.append(line_with_rel_inc);
       } else {
         new_stdout_text.append(line.data(), line.length());
       }

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -284,7 +284,7 @@ do_remember_include_file(Context& ctx,
     return true;
   }
 
-  if (path == ctx.args_info.input_file) {
+  if (path == ctx.args_info.normalized_input_file) {
     // Don't remember the input file.
     return true;
   }


### PR DESCRIPTION
On windows with basedir to set e.g. C:\Projects, it will
get normalized to C:/Projects. With a header in C:\Projects\repo\some_header.h,
during include reading it may be read as C:\\\\\\\\Projects\\\\\\\\\repo\\\\\\\\some_header.h
with additional slashes. It does not then match basedir and is not changed to
relative when it should be.

Also the header paths printed to stdout need to be changed to relative so that Ninja will
use the relative paths to headers to detect changes instead of absolute paths. Otherwise
Ninja will check for header changes from the original build dir if an object was restored
from cache to another build dir.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
