### PR TITLE
Fix ccache: error: Failed to read from file stream

### DIFF
--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1862,14 +1862,14 @@ from_cache(Context& ctx, FromCacheCallMode mode, const Digest& result_key)
     return false;
   }
 
-  File file(*result_path, "rb");
-  core::FileReader file_reader(file.get());
-  core::CacheEntryReader cache_entry_reader(file_reader);
-  Result::Reader result_reader(cache_entry_reader, *result_path);
-  ResultRetriever result_retriever(
-    ctx, should_rewrite_dependency_target(ctx.args_info));
-
   try {
+    File file(*result_path, "rb");
+    core::FileReader file_reader(file.get());
+    core::CacheEntryReader cache_entry_reader(file_reader);
+    Result::Reader result_reader(cache_entry_reader, *result_path);
+    ResultRetriever result_retriever(
+      ctx, should_rewrite_dependency_target(ctx.args_info));
+  
     result_reader.read(result_retriever);
   } catch (core::Error& e) {
     LOG("Failed to get result from cache: {}", e.what());

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1869,7 +1869,7 @@ from_cache(Context& ctx, FromCacheCallMode mode, const Digest& result_key)
     Result::Reader result_reader(cache_entry_reader, *result_path);
     ResultRetriever result_retriever(
       ctx, should_rewrite_dependency_target(ctx.args_info));
-  
+
     result_reader.read(result_retriever);
   } catch (core::Error& e) {
     LOG("Failed to get result from cache: {}", e.what());


### PR DESCRIPTION
A potential fix for ccache errors that terminate builds with:

ccache: error: Failed to read from file stream

This error happens sporadically when compiling and is hard to pin down
for reproduction.

It looks like this is caused by a code path missing a catch for the
core::Error exception that can happen when the fread returns zero bytes
in FileReader::read()

By code inspection the most probable place this could happen is in the
constructor of CacheEntryReader which consumes a Reader and performs
reads without exception handling around all of the reads.

Extend the try catch around the creation of the cache_entry_reader object
in the from_cache function to protect this code path.

There is potential for this error to also happen in inspect_path and
in the EXTRACT_RESULT case of process_main_options. However
these functions have no error handling around file reads, presumably
because they are debug functions so I didn't fix them.

It looks like this bug was introduced in release 4.6 by:
02dac1f18084c0931aa6b8c1a07e9aedfadb5642
feat: Add --inspect option instead of --dump-manifest/--dump-result

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
