### PR TITLE
fix: Add ASM and ASM_MASM to project() languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(ccache LANGUAGES C CXX)
+project(ccache LANGUAGES C CXX ASM ASM_MASM)
 if(MSVC)
   enable_language(ASM_MASM)
 else()


### PR DESCRIPTION
This fixes building and linking blake3 with MSVC for both Ninja and
msbuild.

See #1009.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>