### PR TITLE
Fix sporatic test.profiling failures

### DIFF
--- a/test/suites/profiling.bash
+++ b/test/suites/profiling.bash
@@ -2,7 +2,7 @@
 normalize_gcno_file() {
     local from="$1"
     local to="$2"
-    cut -b 13- "${from}" >"${to}"
+    tail -c +13 "${from}" >"${to}"
 }
 
 


### PR DESCRIPTION
Fixes two unrelated causes of sporatic failures in profiling tests.
1. Using `cut`, which is always line-based, to remove bytes from a binary file can cause problems if the binary timestamp field happens to contain a newline character, which causes `test.profiling` to fail <1% of the time.  Instead use `tail` which has a character mode that ignores newlines.
~~2. Sometimes ccache.log contains `test.c too new` so copy the format of `SETUP` in `direct.bash` to `profiling*.bash`.~~