### PR TITLE
feat: Generalize STATIC_LINK option + fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,12 +83,27 @@ include(GenerateVersionFile)
 # Static link configuration
 #
 
-if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  option(STATIC_LINK "Link statically with system libraries" ON)
+set(STATIC_LINK_DEFAULT OFF)
+if(WIN32)
+  set(STATIC_LINK_DEFAULT ON)
 endif()
 
-if(MSVC AND STATIC_LINK)
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+option(STATIC_LINK "Prefer linking libraries statically" ${STATIC_LINK_DEFAULT})
+
+if(STATIC_LINK)
+  list(INSERT CMAKE_FIND_LIBRARY_SUFFIXES 0 "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set(CMAKE_LINK_SEARCH_START_STATIC ON)
+
+  # Link MSVC runtime statically.
+  if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  # Link MINGW runtime statically.
+  elseif(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    list(APPEND CCACHE_EXTRA_LIBS -static-libgcc -static-libstdc++ -static -lwinpthread -dynamic)
+  # Link WIN32 clang libs statically.
+  elseif(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+    list(APPEND CCACHE_EXTRA_LIBS -Wl,-Bstatic -lc++ -lunwind -Wl,-Bdynamic)
+  endif()
 endif()
 
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,17 +44,14 @@ endif()
 add_library(ccache_framework STATIC ${source_files})
 
 if(WIN32)
-  target_link_libraries(ccache_framework PRIVATE "psapi")
+  list(APPEND CCACHE_EXTRA_LIBS psapi ws2_32)
+endif()
 
-  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    if(STATIC_LINK)
-      target_link_libraries(ccache_framework PRIVATE -static-libgcc -static-libstdc++ -static winpthread -dynamic)
-    else()
-      target_link_libraries(ccache_framework PRIVATE winpthread)
-    endif()
-  elseif(STATIC_LINK AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    target_link_libraries(ccache_framework PRIVATE -static c++ -dynamic)
-  endif()
+if(CCACHE_EXTRA_LIBS)
+  target_link_libraries(
+    ccache_framework
+    PRIVATE "${CCACHE_EXTRA_LIBS}"
+  )
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)


### PR DESCRIPTION
Set cmake to prefer static libraries in general when enabled, defaulting
to ON for Win32.

Hide the gory details in cmake/StaticLink.cmake.

If not using internet versions, try to find static versions of zstd and
hiredis and set the IMPORTED_LOCATION property accordingly. This links
the MSYS2 versions of zstd and hiredis statically correctly.

On MSVC rewrite /MD[d] to /MT[d] to link the runtime statically.

On MINGW add -static-gcc and -static-libstdc++ to link flags and static
libwinpthread to libs.

On Win32 Clang add static libc++ and libunwind to libs.

On Win32 also add the psapi and ws2_32 standard dlls, needed by static
versions of some libs.

All of this is stemming from the discussion in #1009, where the core
issue still needs investigation.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>
