### PR TITLE
Fix "Multiple precompiled headers used" error if /Yu option is used after /Fp

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -125,6 +125,7 @@ detect_pch(const std::string& option,
     if (state.found_valid_Fp) { // Use file set by -Fp.
       LOG("Detected use of precompiled header: {}", included_pch_file);
       pch_file = included_pch_file;
+      included_pch_file.clear(); // reset pch file set from /Fp
     } else {
       std::string file = Util::change_extension(arg, ".pch");
       if (Stat::stat(file)) {


### PR DESCRIPTION
When using ccache on Windows with MSVC with precompiled headers sometimes the following error occures: "Multiple precompiled headers used: precompiled_header.pch and precompiled_header.pch".  This happens if you specify /Fp before /Yu. I fixed it in the same manner as /Fp handles being after /Yu but not sure if it's the best approach.

