### PR TITLE
feat: Fetch/update secondary storage manifest on primary miss

### DIFF
--- a/src/storage/Storage.hpp
+++ b/src/storage/Storage.hpp
@@ -51,7 +51,10 @@ public:
   primary::PrimaryStorage primary;
 
   // Returns a path to a file containing the value.
-  std::optional<std::string> get(const Digest& key, core::CacheEntryType type);
+  enum class Mode { secondary_fallback, secondary_only, primary_only };
+  std::optional<std::string> get(const Digest& key,
+                                 core::CacheEntryType type,
+                                 const Mode mode = Mode::secondary_fallback);
 
   bool put(const Digest& key,
            core::CacheEntryType type,


### PR DESCRIPTION
On a manifest key miss in the primary cache the manifest from secondary
storage is fetched. This will incrementally update secondary storage
cache manifest files instead of overwriting them with modified primary
storage manifests. Which in turn makes direct hits being properly shared
between machines through secondary storage.

Partially resolves issue described in #1049 

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
