### PR TITLE
fix: Check for short reads in Reader::read_str

### DIFF
--- a/src/core/Reader.hpp
+++ b/src/core/Reader.hpp
@@ -72,7 +72,12 @@ inline std::string
 Reader::read_str(const size_t length)
 {
   std::string value(length, 0);
-  read(&value[0], length);
+  if (length > 0) {
+    const auto bytes_read = read(&value[0], length);
+    if (bytes_read != length) {
+      throw core::Error("Read underflow");
+    }
+  }
   return value;
 }
 


### PR DESCRIPTION
The `read_int` function checks for short reads so `read_str` should do as well.

Additionally don't trigger undefined behavior with `operator[]` on empty strings.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
