### PR TITLE
fix: Fix parsing of MSVC response files

### DIFF
--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -50,7 +50,7 @@ Args::from_string(const std::string& command)
 }
 
 optional<Args>
-Args::from_atfile(const std::string& filename, bool ignore_backslash)
+Args::from_atfile(const std::string& filename, AtFileFormat format)
 {
   std::string argtext;
   try {
@@ -72,17 +72,28 @@ Args::from_atfile(const std::string& filename, bool ignore_backslash)
   while (true) {
     switch (*pos) {
     case '\\':
-      if (ignore_backslash) {
-        break;
-      }
       pos++;
-      if (*pos == '\0') {
-        continue;
+      switch (format) {
+      case AtFileFormat::QuoteAny_EscapeAny:
+        if (*pos == '\0') {
+          continue;
+        }
+        break;
+      case AtFileFormat::QuoteDouble_EscapeQuoteEscape:
+        if (*pos != '"' && *pos != '\\') {
+          pos--;
+        }
+        break;
       }
       break;
 
-    case '"':
     case '\'':
+      if (format == AtFileFormat::QuoteDouble_EscapeQuoteEscape) {
+        break;
+      }
+      // Fall through.
+
+    case '"':
       if (quoting != '\0') {
         if (quoting == *pos) {
           quoting = '\0';

--- a/src/Args.hpp
+++ b/src/Args.hpp
@@ -36,8 +36,14 @@ public:
 
   static Args from_argv(int argc, const char* const* argv);
   static Args from_string(const std::string& command);
-  static nonstd::optional<Args> from_atfile(const std::string& filename,
-                                            bool ignore_backslash = false);
+
+  enum class AtFileFormat {
+    QuoteAny_EscapeAny, // '\'' and '"' quote, '\\' escapes any character
+    QuoteDouble_EscapeQuoteEscape, // '"' quotes, '\\' escapes only '"' and '\\'
+  };
+  static nonstd::optional<Args>
+  from_atfile(const std::string& filename,
+              AtFileFormat format = AtFileFormat::QuoteAny_EscapeAny);
 
   Args& operator=(const Args& other) = default;
   Args& operator=(Args&& other) noexcept;

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -307,7 +307,10 @@ process_arg(const Context& ctx,
       ++argpath;
     }
     auto file_args =
-      Args::from_atfile(argpath, ctx.config.is_compiler_group_msvc());
+      Args::from_atfile(argpath,
+                        config.is_compiler_group_msvc()
+                          ? Args::AtFileFormat::QuoteDouble_EscapeQuoteEscape
+                          : Args::AtFileFormat::QuoteAny_EscapeAny);
     if (!file_args) {
       LOG("Couldn't read arg file {}", argpath);
       return Statistic::bad_compiler_arguments;

--- a/unittest/test_Args.cpp
+++ b/unittest/test_Args.cpp
@@ -136,6 +136,25 @@ TEST_CASE("Args::from_atfile")
     CHECK(args[5] == "si'x\" th");
     CHECK(args[6] == "seve\nth");
   }
+
+  SUBCASE("Only escape double quote and backslash in alternate format")
+  {
+    Util::write_file("at_file", "\"\\\"\\a\\ \\\\\\ \\b\\\"\"\\");
+    args = *Args::from_atfile(
+      "at_file", Args::AtFileFormat::QuoteDouble_EscapeQuoteEscape);
+    CHECK(args.size() == 1);
+    CHECK(args[0] == "\"\\a\\ \\\\ \\b\"\\");
+  }
+
+  SUBCASE("Ignore single quote in alternate format")
+  {
+    Util::write_file("at_file", "'a b'");
+    args = *Args::from_atfile(
+      "at_file", Args::AtFileFormat::QuoteDouble_EscapeQuoteEscape);
+    CHECK(args.size() == 2);
+    CHECK(args[0] == "'a");
+    CHECK(args[1] == "b'");
+  }
 }
 
 TEST_CASE("Args copy assignment operator")


### PR DESCRIPTION
Inside response files passed to clang-cl or msvc:
1. `\` should not be ignored completely, but rather it should only escape `\` and `"`.
2. `'` should not be treated specially.