### PR TITLE
CMake: find zstd & hiredis with their config file first

### DIFF
--- a/cmake/Findhiredis.cmake
+++ b/cmake/Findhiredis.cmake
@@ -50,6 +50,13 @@ if(HIREDIS_FROM_INTERNET)
     PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${hiredis_dir}/include>")
 else()
+  find_package(hiredis QUIET CONFIG)
+  if(hiredis_FOUND)
+    add_library(HIREDIS::HIREDIS INTERFACE IMPORTED)
+    set_target_properties(HIREDIS::HIREDIS PROPERTIES INTERFACE_LINK_LIBRARIES hiredis::hiredis)
+    return()
+  endif()
+
   find_package(PkgConfig)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(HIREDIS hiredis>=${hiredis_FIND_VERSION})

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -41,6 +41,17 @@ if(ZSTD_FROM_INTERNET)
 
   set(zstd_FOUND TRUE)
 else()
+  find_package(zstd QUIET CONFIG)
+  if(zstd_FOUND)
+    add_library(ZSTD::ZSTD INTERFACE IMPORTED)
+    if(TARGET zstd::libzstd_shared)
+      set_target_properties(ZSTD::ZSTD PROPERTIES INTERFACE_LINK_LIBRARIES zstd::libzstd_shared)
+    else()
+      set_target_properties(ZSTD::ZSTD PROPERTIES INTERFACE_LINK_LIBRARIES zstd::libzstd_static)
+    endif()
+    return()
+  endif()
+
   find_library(ZSTD_LIBRARY zstd)
   find_path(ZSTD_INCLUDE_DIR zstd.h)
 

--- a/cmake/GenerateVersionFile.cmake
+++ b/cmake/GenerateVersionFile.cmake
@@ -1,4 +1,4 @@
 configure_file(
-  ${CMAKE_SOURCE_DIR}/cmake/version.cpp.in
-  ${CMAKE_BINARY_DIR}/src/version.cpp
+  ${PROJECT_SOURCE_DIR}/cmake/version.cpp.in
+  ${PROJECT_BINARY_DIR}/src/version.cpp
   @ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ set(
   execute.cpp
   hashutil.cpp
   language.cpp
-  version.cpp
+  ${PROJECT_BINARY_DIR}/src/version.cpp
 )
 
 if(INODE_CACHE_SUPPORTED)


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->

Recent versions of `zstd` & `hiredis` provide a CMake config file. This PR proposes to check first existence of these config files for discovery/injection of these libraries.

There is also a small fix for out of source build, related to generation of the file `version.cpp`.