### PR TITLE
fix(win32execute): Handle space in paths when using response file

### DIFF
--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -151,7 +151,7 @@ win32execute(const char* path,
     TemporaryFile tmp_file(FMT("{}/cmd_args", temp_dir));
     args = Win32Util::argv_to_string(argv + 1, sh, true);
     Util::write_fd(*tmp_file.fd, args.data(), args.length());
-    args = FMT("{} @{}", full_path, tmp_file.path);
+    args = FMT(R"("{}" "@{}")", full_path, tmp_file.path);
     tmp_file_path = tmp_file.path;
     LOG("Arguments from {}", tmp_file.path);
   }


### PR DESCRIPTION
Putting all arguments in quotes is done in `argv_to_string`, however when ccache uses `cmd_args` response file, `argv[0]` ends up being without quotes which ends up badly if it has spaces in it. In my case it resulted in preprocessor error and subsequent cache misses.