### PR TITLE
xxhash.h: Fix build with gcc-12

### DIFF
--- a/src/third_party/xxhash.h
+++ b/src/third_party/xxhash.h
@@ -1501,7 +1501,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 #  define XXH_NO_INLINE static
 /* enable inlining hints */
 #elif defined(__GNUC__) || defined(__clang__)
-#  define XXH_FORCE_INLINE static __inline__ __attribute__((always_inline, unused))
+#  define XXH_FORCE_INLINE static
 #  define XXH_NO_INLINE static __attribute__((noinline))
 #elif defined(_MSC_VER)  /* Visual Studio */
 #  define XXH_FORCE_INLINE static __forceinline


### PR DESCRIPTION
Fixes:
  /buildarea/tmp/work/core2-64-poky-linux/ccache/4.6.1-r0/ccache-4.6.1/src/third_party/xxhash.h:3932:1: error: inlining failed in call to 'always_inline' 'XXH3_accumulate_512_sse2': function not considered for inlining
  3932 | XXH3_accumulate_512_sse2( void* XXH_RESTRICT acc,
      | ^~~~~~~~~~~~~~~~~~~~~~~~
  /buildarea/tmp/work/core2-64-poky-linux/ccache/4.6.1-r0/ccache-4.6.1/src/third_party/xxhash.h:4369:9: note: called from here
  4369 |         f_acc512(acc,
      |         ^~~~~~~~~~~~~
  4370 |                  in,
      |                  ~~~
  4371 |                  secret + n*XXH_SECRET_CONSUME_RATE);

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
