### PR TITLE
build: Fix build with newer MSVC 2022 versions

### DIFF
--- a/src/core/exceptions.hpp
+++ b/src/core/exceptions.hpp
@@ -43,7 +43,7 @@ public:
   Error(const std::string& message);
 
   // `args` are forwarded to `fmt::format`.
-  template<typename... T> inline Error(T&&... args);
+  template<typename... T> inline Error(const char* format, T&&... args);
 };
 
 inline Error::Error(const std::string& message) : ErrorBase(message)
@@ -51,8 +51,8 @@ inline Error::Error(const std::string& message) : ErrorBase(message)
 }
 
 template<typename... T>
-inline Error::Error(T&&... args)
-  : ErrorBase(fmt::format(std::forward<T>(args)...))
+inline Error::Error(const char* format, T&&... args)
+  : ErrorBase(fmt::format(format, std::forward<T>(args)...))
 {
 }
 
@@ -65,7 +65,7 @@ public:
   Fatal(const std::string& message);
 
   // `args` are forwarded to `fmt::format`.
-  template<typename... T> inline Fatal(T&&... args);
+  template<typename... T> inline Fatal(const char* format, T&&... args);
 };
 
 inline Fatal::Fatal(const std::string& message) : ErrorBase(message)
@@ -73,8 +73,8 @@ inline Fatal::Fatal(const std::string& message) : ErrorBase(message)
 }
 
 template<typename... T>
-inline Fatal::Fatal(T&&... args)
-  : ErrorBase(fmt::format(std::forward<T>(args)...))
+inline Fatal::Fatal(const char* format, T&&... args)
+  : ErrorBase(fmt::format(format, std::forward<T>(args)...))
 {
 }
 


### PR DESCRIPTION
So this is the simplest fix I came up with, if we specify the first argument to be exactly of type `const char *` then we definitely cannot intersect with special member functions.

The only downside is probably inability to use compile time argument checking with `FMT_STRING` but since it is not done currently I think it should not be a problem.

I understand that it may seem like a workaround but in reality this construct is fragile and could become broken for other compiler as I demonstrate here with adding `catch` (thanks to Jonathan Caves from Microsoft for pointing this out) https://gcc.godbolt.org/z/qG1rjPMsr 

Fixes #1076 