### PR TITLE
Support for intel compiler on windows

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -461,6 +461,7 @@ compiler_type_to_string(CompilerType compiler_type)
 
     CASE(clang);
     CASE(gcc);
+    CASE(icl);
     CASE(msvc);
     CASE(nvcc);
     CASE(other);

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -30,7 +30,16 @@
 #include <string>
 #include <unordered_map>
 
-enum class CompilerType { auto_guess, clang, clang_cl, gcc, msvc, nvcc, other };
+enum class CompilerType {
+  auto_guess,
+  clang,
+  clang_cl,
+  gcc,
+  icl,
+  msvc,
+  nvcc,
+  other
+};
 
 std::string compiler_type_to_string(CompilerType compiler_type);
 
@@ -87,7 +96,7 @@ public:
   // Return true for Clang and clang-cl.
   bool is_compiler_group_clang() const;
 
-  // Return true for MSVC (cl.exe) and clang-cl.
+  // Return true for MSVC (cl.exe), clang-cl, and icl.
   bool is_compiler_group_msvc() const;
 
   void set_base_dir(const std::string& value);
@@ -248,7 +257,8 @@ inline bool
 Config::is_compiler_group_msvc() const
 {
   return m_compiler_type == CompilerType::msvc
-         || m_compiler_type == CompilerType::clang_cl;
+         || m_compiler_type == CompilerType::clang_cl
+         || m_compiler_type == CompilerType::icl;
 }
 
 inline bool

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -251,6 +251,8 @@ guess_compiler(std::string_view path)
     return CompilerType::gcc;
   } else if (name.find("nvcc") != std::string_view::npos) {
     return CompilerType::nvcc;
+  } else if (name == "icl") {
+    return CompilerType::icl;
   } else if (name == "cl") {
     return CompilerType::msvc;
   } else {


### PR DESCRIPTION
Here's the pull request regarding https://github.com/ccache/ccache/discussions/1092.

What I did is to add icl to the group of windows compilers, i.e., the same that is already done for clang-cl. Without these changes I saw output like 

```
...
Compiler type: other
/nologo is not a regular file, not considering as input file
/EHsc is not a regular file, not considering as input file
/arch:sse2 is not a regular file, not considering as input file
/DWIN64 is not a regular file, not considering as input file
/DWIN32 is not a regular file, not considering as input file
/O2 is not a regular file, not considering as input file
/DNDEBUG is not a regular file, not considering as input file
/Qopt-report:0 is not a regular file, not considering as input file
/Qopt-report-phase:vec is not a regular file, not considering as input file
/Qdiag-disable:cpu-dispatch,11074,11075,13408,3920,2621 is not a regular file, not considering as input file
/Qalign-loops:32 is not a regular file, not considering as input file
/Qfnalign:64 is not a regular file, not considering as input file
/Qaxcore-avx2 is not a regular file, not considering as input file
...
```

which indicates that ccache isn't able to parse the compiler call correctly. Hence I did not see any cache hits. With this PR everything works as expected.