### PR TITLE
Add https support as storage option

### DIFF
--- a/src/storage/Storage.cpp
+++ b/src/storage/Storage.cpp
@@ -52,6 +52,7 @@ const std::unordered_map<std::string /*scheme*/,
   k_secondary_storage_implementations = {
     {"file", std::make_shared<secondary::FileStorage>()},
     {"http", std::make_shared<secondary::HttpStorage>()},
+    {"https", std::make_shared<secondary::HttpStorage>()},
 #ifdef HAVE_REDIS_STORAGE_BACKEND
     {"redis", std::make_shared<secondary::RedisStorage>()},
 #endif

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -6,6 +6,13 @@ else()
   target_compile_definitions(third_party PUBLIC -DSTATIC_GETOPT)
 endif()
 
+find_package(OpenSSL)
+if(OPENSSL_FOUND)
+  message(STATUS "Compiling with support for Https")
+  target_compile_definitions(third_party PRIVATE -DCPPHTTPLIB_OPENSSL_SUPPORT=1)
+  target_link_libraries(third_party PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif()
+
 if(WIN32)
   target_sources(third_party PRIVATE win32/mktemp.c)
 endif ()


### PR DESCRIPTION
- Find OpenSsl library, enable https support if found
- Compile httplib with ssl/https support
- Register the 'https' scheme with the http backend as a secondary_storage option

The ccache docs explicitly state "HTTPS is not supported.". That note could be removed with this change.
It strikes me as careless to use unencrypted network-connections for something as sensitive as a build-cache.
I guess insecure http is only intended to be used to connect to a local proxy, and not really to a remote endpoint because of that.
Unless I'm missing something, enabling https seems quick and easy.

---

I needed https support to use Google-Cloud-Storage (GCS) as a backend.
And GCS, of course, does not allow requests using insecure http.
That can be achieved now by configuring:
`
secondary_storage = https://{bucket_name}.storage.googleapis.com|bearer-token={auth_token}
`
Whereas the auth-token can be generated with `gcloud auth print-access-token` (or via Api, of course)
That could be added as an example here: https://github.com/ccache/ccache/wiki/HTTP-storage#google-cloud-storage-gcs

I would have liked to add a test-case, but doing that would require disabling the ssl-certificate check to run a local server.
Regarding the implementation i wasn't sure whether both schemas should point to the same HttpStorage object. I also didn't see an easy way to do that in the global initialization context.