### PR TITLE
Allow using dict for compressing and decompressing

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -1289,6 +1289,35 @@ are currently compressed with a different level than the target level will be
 recompressed.
 
 
+== Compression dictionary
+
+Zstandard supports using a dictionary compression, for better performance and
+also compression ratio, by using a "dictionary" pre-trained from sample files.
+Different data types using different dictionaries, so for ccache there is one
+file for the manifest cache entries and one file for the result cache entries.
+
+In order to train a dictionary, the cache must be filled with enough samples.
+The contents must be uncompressed, to generate the compression dictionary !
+Typically the dictionary files are generated once, based on the compiler etc.
+There are _lots_ of training parameters that can be tweaked, see zstd help.
+
+Example script, for generating the Zstandard dictionary files:
+
+-------------------------------------------------------------------------------
+ccache -X uncompressed
+find $CCACHE_DIR -type f -name '*M' | xargs zstd --train -o $CCACHE_DIR/M.dict
+find $CCACHE_DIR -type f -name '*R' | xargs zstd --train -o $CCACHE_DIR/R.dict
+ccache -X 0 # compress
+-------------------------------------------------------------------------------
+
+Notes:
+
+* Dictionary compression support requires zstd version 1.4.0 or later.
+* The dictionary files are **required** to access the compressed data.
+* Dictionary compression is most effective for small files, <100 KiB.
+* The dictionary files are rather small, the default size is 110 KiB.
+
+
 == Cache statistics
 
 `ccache --show-stats` shows a summary of statistics, including cache size,

--- a/src/Result.cpp
+++ b/src/Result.cpp
@@ -335,7 +335,8 @@ Writer::do_finalize()
   header.set_entry_size_from_payload_size(payload_size);
 
   core::FileWriter file_writer(atomic_result_file.stream());
-  core::CacheEntryWriter writer(file_writer, header);
+  std::string dict_dir = compression::dict_dir_from_config(m_ctx.config);
+  core::CacheEntryWriter writer(file_writer, dict_dir, header);
 
   writer.write_int(k_result_format_version);
   writer.write_int<uint8_t>(m_entries_to_write.size());

--- a/src/compression/Compressor.cpp
+++ b/src/compression/Compressor.cpp
@@ -33,13 +33,14 @@ Compressor::create_from_type(const Type type,
                              core::Writer& writer,
                              const int8_t compression_level)
 {
-  return create_from_type(type, writer, compression_level, -1);
+  return create_from_type(type, writer, compression_level, "", -1);
 }
 
 std::unique_ptr<Compressor>
 Compressor::create_from_type(const Type type,
                              core::Writer& writer,
                              const int8_t compression_level,
+                             std::string dict_dir,
                              const int8_t entry_type)
 {
   switch (type) {
@@ -48,7 +49,7 @@ Compressor::create_from_type(const Type type,
 
   case compression::Type::zstd:
     return std::make_unique<ZstdCompressor>(
-      writer, compression_level, entry_type);
+      writer, compression_level, dict_dir, entry_type);
   }
 
   ASSERT(false);

--- a/src/compression/Compressor.cpp
+++ b/src/compression/Compressor.cpp
@@ -33,12 +33,22 @@ Compressor::create_from_type(const Type type,
                              core::Writer& writer,
                              const int8_t compression_level)
 {
+  return create_from_type(type, writer, compression_level, -1);
+}
+
+std::unique_ptr<Compressor>
+Compressor::create_from_type(const Type type,
+                             core::Writer& writer,
+                             const int8_t compression_level,
+                             const int8_t entry_type)
+{
   switch (type) {
   case compression::Type::none:
     return std::make_unique<NullCompressor>(writer);
 
   case compression::Type::zstd:
-    return std::make_unique<ZstdCompressor>(writer, compression_level);
+    return std::make_unique<ZstdCompressor>(
+      writer, compression_level, entry_type);
   }
 
   ASSERT(false);

--- a/src/compression/Compressor.hpp
+++ b/src/compression/Compressor.hpp
@@ -39,6 +39,10 @@ public:
 
   static std::unique_ptr<Compressor>
   create_from_type(Type type, core::Writer& writer, int8_t compression_level);
+  static std::unique_ptr<Compressor> create_from_type(Type type,
+                                                      core::Writer& writer,
+                                                      int8_t compression_level,
+                                                      int8_t entry_type);
 
   virtual int8_t actual_compression_level() const = 0;
 };

--- a/src/compression/Compressor.hpp
+++ b/src/compression/Compressor.hpp
@@ -42,6 +42,7 @@ public:
   static std::unique_ptr<Compressor> create_from_type(Type type,
                                                       core::Writer& writer,
                                                       int8_t compression_level,
+                                                      std::string dict_dir,
                                                       int8_t entry_type);
 
   virtual int8_t actual_compression_level() const = 0;

--- a/src/compression/Decompressor.cpp
+++ b/src/compression/Decompressor.cpp
@@ -27,12 +27,20 @@ namespace compression {
 std::unique_ptr<Decompressor>
 Decompressor::create_from_type(Type type, core::Reader& reader)
 {
+  return create_from_type(type, reader, -1);
+}
+
+std::unique_ptr<Decompressor>
+Decompressor::create_from_type(Type type,
+                               core::Reader& reader,
+                               int8_t entry_type)
+{
   switch (type) {
   case compression::Type::none:
     return std::make_unique<NullDecompressor>(reader);
 
   case compression::Type::zstd:
-    return std::make_unique<ZstdDecompressor>(reader);
+    return std::make_unique<ZstdDecompressor>(reader, entry_type);
   }
 
   ASSERT(false);

--- a/src/compression/Decompressor.cpp
+++ b/src/compression/Decompressor.cpp
@@ -27,12 +27,13 @@ namespace compression {
 std::unique_ptr<Decompressor>
 Decompressor::create_from_type(Type type, core::Reader& reader)
 {
-  return create_from_type(type, reader, -1);
+  return create_from_type(type, reader, "", -1);
 }
 
 std::unique_ptr<Decompressor>
 Decompressor::create_from_type(Type type,
                                core::Reader& reader,
+                               std::string dict_dir,
                                int8_t entry_type)
 {
   switch (type) {
@@ -40,7 +41,7 @@ Decompressor::create_from_type(Type type,
     return std::make_unique<NullDecompressor>(reader);
 
   case compression::Type::zstd:
-    return std::make_unique<ZstdDecompressor>(reader, entry_type);
+    return std::make_unique<ZstdDecompressor>(reader, dict_dir, entry_type);
   }
 
   ASSERT(false);

--- a/src/compression/Decompressor.hpp
+++ b/src/compression/Decompressor.hpp
@@ -33,6 +33,8 @@ public:
   // Create a decompressor for the specified type.
   static std::unique_ptr<Decompressor> create_from_type(Type type,
                                                         core::Reader& reader);
+  static std::unique_ptr<Decompressor>
+  create_from_type(Type type, core::Reader& reader, int8_t entry_type);
 
   // Finalize decompression.
   //

--- a/src/compression/Decompressor.hpp
+++ b/src/compression/Decompressor.hpp
@@ -33,8 +33,17 @@ public:
   // Create a decompressor for the specified type.
   static std::unique_ptr<Decompressor> create_from_type(Type type,
                                                         core::Reader& reader);
-  static std::unique_ptr<Decompressor>
-  create_from_type(Type type, core::Reader& reader, int8_t entry_type);
+  static std::unique_ptr<Decompressor> create_from_type(Type type,
+                                                        core::Reader& reader,
+                                                        std::string dict_dir,
+                                                        int8_t entry_type);
+
+  // Dictionary ID (required to decompress), or 0 if not using a dictionary.
+  virtual unsigned
+  dict_id()
+  {
+    return 0;
+  }
 
   // Finalize decompression.
   //

--- a/src/compression/ZstdCompressor.cpp
+++ b/src/compression/ZstdCompressor.cpp
@@ -29,8 +29,11 @@
 
 namespace compression {
 
-ZstdCompressor::ZstdCompressor(core::Writer& writer, int8_t compression_level)
+ZstdCompressor::ZstdCompressor(core::Writer& writer,
+                               int8_t compression_level,
+                               int8_t entry_type)
   : m_writer(writer),
+    m_entry_type(entry_type),
     m_zstd_stream(ZSTD_createCStream()),
     m_zstd_in(std::make_unique<ZSTD_inBuffer_s>()),
     m_zstd_out(std::make_unique<ZSTD_outBuffer_s>())

--- a/src/compression/ZstdCompressor.hpp
+++ b/src/compression/ZstdCompressor.hpp
@@ -35,7 +35,9 @@ namespace compression {
 class ZstdCompressor : public Compressor, NonCopyable
 {
 public:
-  ZstdCompressor(core::Writer& writer, int8_t compression_level);
+  ZstdCompressor(core::Writer& writer,
+                 int8_t compression_level,
+                 int8_t entry_type);
 
   ~ZstdCompressor() override;
 
@@ -47,6 +49,7 @@ public:
 
 private:
   core::Writer& m_writer;
+  int8_t m_entry_type;
   ZSTD_CCtx_s* m_zstd_stream;
   std::unique_ptr<ZSTD_inBuffer_s> m_zstd_in;
   std::unique_ptr<ZSTD_outBuffer_s> m_zstd_out;

--- a/src/compression/ZstdCompressor.hpp
+++ b/src/compression/ZstdCompressor.hpp
@@ -22,6 +22,8 @@
 
 #include <NonCopyable.hpp>
 
+#include <zstd.h>
+
 #include <cstdint>
 #include <memory>
 
@@ -37,9 +39,16 @@ class ZstdCompressor : public Compressor, NonCopyable
 public:
   ZstdCompressor(core::Writer& writer,
                  int8_t compression_level,
+                 std::string dict_dir,
                  int8_t entry_type);
 
   ~ZstdCompressor() override;
+
+  unsigned
+  dict_id()
+  {
+    return m_zstd_dict_id;
+  }
 
   int8_t actual_compression_level() const override;
   void write(const void* data, size_t count) override;
@@ -51,6 +60,10 @@ private:
   core::Writer& m_writer;
   int8_t m_entry_type;
   ZSTD_CCtx_s* m_zstd_stream;
+  unsigned m_zstd_dict_id;
+#if ZSTD_VERSION_NUMBER >= 10400 /* 1.4.0 */
+  ZSTD_CDict_s* m_zstd_dict;
+#endif
   std::unique_ptr<ZSTD_inBuffer_s> m_zstd_in;
   std::unique_ptr<ZSTD_outBuffer_s> m_zstd_out;
   int8_t m_compression_level;

--- a/src/compression/ZstdDecompressor.cpp
+++ b/src/compression/ZstdDecompressor.cpp
@@ -24,8 +24,9 @@
 
 namespace compression {
 
-ZstdDecompressor::ZstdDecompressor(core::Reader& reader)
+ZstdDecompressor::ZstdDecompressor(core::Reader& reader, int8_t entry_type)
   : m_reader(reader),
+    m_entry_type(entry_type),
     m_input_size(0),
     m_input_consumed(0),
     m_zstd_stream(ZSTD_createDStream()),

--- a/src/compression/ZstdDecompressor.hpp
+++ b/src/compression/ZstdDecompressor.hpp
@@ -30,7 +30,7 @@ namespace compression {
 class ZstdDecompressor : public Decompressor
 {
 public:
-  explicit ZstdDecompressor(core::Reader& reader);
+  explicit ZstdDecompressor(core::Reader& reader, int8_t entry_type);
 
   ~ZstdDecompressor() override;
 
@@ -39,6 +39,7 @@ public:
 
 private:
   core::Reader& m_reader;
+  int8_t m_entry_type;
   char m_input_buffer[CCACHE_READ_BUFFER_SIZE];
   size_t m_input_size;
   size_t m_input_consumed;

--- a/src/compression/ZstdDecompressor.hpp
+++ b/src/compression/ZstdDecompressor.hpp
@@ -30,9 +30,17 @@ namespace compression {
 class ZstdDecompressor : public Decompressor
 {
 public:
-  explicit ZstdDecompressor(core::Reader& reader, int8_t entry_type);
+  explicit ZstdDecompressor(core::Reader& reader,
+                            std::string dict_dir,
+                            int8_t entry_type);
 
   ~ZstdDecompressor() override;
+
+  virtual unsigned
+  dict_id() override
+  {
+    return m_zstd_dict_id;
+  }
 
   size_t read(void* data, size_t count) override;
   void finalize() override;
@@ -44,6 +52,10 @@ private:
   size_t m_input_size;
   size_t m_input_consumed;
   ZSTD_DStream* m_zstd_stream;
+  unsigned m_zstd_dict_id;
+#if ZSTD_VERSION_NUMBER >= 10400 /* 1.4.0 */
+  ZSTD_DDict_s* m_zstd_dict;
+#endif
   ZSTD_inBuffer m_zstd_in;
   ZSTD_outBuffer m_zstd_out;
   bool m_reached_stream_end;

--- a/src/compression/types.cpp
+++ b/src/compression/types.cpp
@@ -22,6 +22,7 @@
 #include <Context.hpp>
 #include <assertions.hpp>
 #include <core/exceptions.hpp>
+#include <fmtmacros.hpp>
 
 namespace compression {
 
@@ -31,10 +32,22 @@ level_from_config(const Config& config)
   return config.compression() ? config.compression_level() : 0;
 }
 
+std::string
+dict_dir_from_config(const Config& config)
+{
+  return config.cache_dir();
+}
+
 Type
 type_from_config(const Config& config)
 {
   return config.compression() ? Type::zstd : Type::none;
+}
+
+std::string
+dict_path_from_entry_type(const std::string dict_dir, int8_t entry_type)
+{
+  return FMT("{}/{}.dict", dict_dir, entry_type ? "M" : "R");
 }
 
 Type

--- a/src/compression/types.hpp
+++ b/src/compression/types.hpp
@@ -30,9 +30,14 @@ enum class Type : uint8_t {
   zstd = 1,
 };
 
+std::string dict_dir_from_config(const Config& config);
+
 int8_t level_from_config(const Config& config);
 
 Type type_from_config(const Config& config);
+
+std::string dict_path_from_entry_type(const std::string dict_dir,
+                                      int8_t entry_type);
 
 Type type_from_int(uint8_t type);
 

--- a/src/core/CacheEntryReader.cpp
+++ b/src/core/CacheEntryReader.cpp
@@ -74,7 +74,7 @@ CacheEntryReader::CacheEntryReader(core::Reader& reader)
     entry_size);
 
   m_decompressor = compression::Decompressor::create_from_type(
-    m_header->compression_type, reader);
+    m_header->compression_type, reader, static_cast<int8_t>(entry_type));
   m_checksumming_reader.set_reader(*m_decompressor);
 }
 

--- a/src/core/CacheEntryReader.cpp
+++ b/src/core/CacheEntryReader.cpp
@@ -41,7 +41,8 @@ cache_entry_type_from_int(const uint8_t entry_type)
 
 namespace core {
 
-CacheEntryReader::CacheEntryReader(core::Reader& reader)
+CacheEntryReader::CacheEntryReader(core::Reader& reader,
+                                   const std::string dict_dir)
   : m_checksumming_reader(reader)
 {
   const auto magic = m_checksumming_reader.read_int<uint16_t>();
@@ -74,7 +75,10 @@ CacheEntryReader::CacheEntryReader(core::Reader& reader)
     entry_size);
 
   m_decompressor = compression::Decompressor::create_from_type(
-    m_header->compression_type, reader, static_cast<int8_t>(entry_type));
+    m_header->compression_type,
+    reader,
+    dict_dir,
+    static_cast<int8_t>(entry_type));
   m_checksumming_reader.set_reader(*m_decompressor);
 }
 

--- a/src/core/CacheEntryReader.hpp
+++ b/src/core/CacheEntryReader.hpp
@@ -32,7 +32,7 @@ class CacheEntryReader : public Reader
 {
 public:
   // Read cache entry data from `reader`.
-  CacheEntryReader(Reader& reader);
+  CacheEntryReader(Reader& reader, const std::string dict_dir);
 
   size_t read(void* data, size_t count) override;
   using Reader::read;
@@ -45,6 +45,8 @@ public:
 
   const CacheEntryHeader& header() const;
 
+  unsigned dict_id();
+
 private:
   ChecksummingReader m_checksumming_reader;
   std::unique_ptr<CacheEntryHeader> m_header;
@@ -56,6 +58,12 @@ inline const CacheEntryHeader&
 CacheEntryReader::header() const
 {
   return *m_header;
+}
+
+inline unsigned
+CacheEntryReader::dict_id()
+{
+  return m_decompressor->dict_id();
 }
 
 } // namespace core

--- a/src/core/CacheEntryWriter.cpp
+++ b/src/core/CacheEntryWriter.cpp
@@ -26,7 +26,10 @@ CacheEntryWriter::CacheEntryWriter(core::Writer& writer,
                                    const CacheEntryHeader& header)
   : m_checksumming_writer(writer),
     m_compressor(compression::Compressor::create_from_type(
-      header.compression_type, writer, header.compression_level))
+      header.compression_type,
+      writer,
+      header.compression_level,
+      static_cast<int8_t>(header.entry_type)))
 {
   m_checksumming_writer.write_int(header.magic);
   m_checksumming_writer.write_int(header.entry_format_version);

--- a/src/core/CacheEntryWriter.cpp
+++ b/src/core/CacheEntryWriter.cpp
@@ -22,13 +22,15 @@
 
 namespace core {
 
-CacheEntryWriter::CacheEntryWriter(core::Writer& writer,
+CacheEntryWriter::CacheEntryWriter(Writer& writer,
+                                   const std::string dict_dir,
                                    const CacheEntryHeader& header)
   : m_checksumming_writer(writer),
     m_compressor(compression::Compressor::create_from_type(
       header.compression_type,
       writer,
       header.compression_level,
+      dict_dir,
       static_cast<int8_t>(header.entry_type)))
 {
   m_checksumming_writer.write_int(header.magic);

--- a/src/core/CacheEntryWriter.hpp
+++ b/src/core/CacheEntryWriter.hpp
@@ -31,7 +31,9 @@ struct CacheEntryHeader;
 class CacheEntryWriter : public Writer
 {
 public:
-  CacheEntryWriter(Writer& writer, const CacheEntryHeader& header);
+  CacheEntryWriter(Writer& writer,
+                   const std::string dict_dir,
+                   const CacheEntryHeader& header);
 
   void write(const void* data, size_t count) override;
   using Writer::write;

--- a/src/storage/primary/PrimaryStorage_cleanup.cpp
+++ b/src/storage/primary/PrimaryStorage_cleanup.cpp
@@ -173,7 +173,8 @@ PrimaryStorage::clean_dir(const std::string& subdir,
       try {
         File file_stream(file.path(), "rb");
         core::FileReader file_reader(*file_stream);
-        core::CacheEntryReader reader(file_reader);
+        // Don't need compression dictionary for looking at the header.
+        core::CacheEntryReader reader(file_reader, "");
         if (reader.header().namespace_ != *namespace_) {
           continue;
         }


### PR DESCRIPTION
One `M.dict` for manifest, one `R.dict` for result

Cache contents are unreadable without these!

Requires zstd version 1.4.0+, such as 1.5.2

Closes #1109