### PR TITLE
feat: auto dep FROM_INTERNET when unavailable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,21 +109,16 @@ endif()
 #
 # Third party
 #
-set(HIREDIS_FROM_INTERNET_DEFAULT OFF)
-set(ZSTD_FROM_INTERNET_DEFAULT OFF)
+option(ZSTD_FROM_INTERNET
+  "Download and use libzstd from the Internet if not available" ON)
+option(HIREDIS_FROM_INTERNET
+  "Download and use libhiredis from the Internet if not available" ON)
 
-# Default to downloading deps for Visual Studio, unless using a package manager.
-if(MSVC AND NOT CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg|conan")
-  set(HIREDIS_FROM_INTERNET_DEFAULT ON)
-  set(ZSTD_FROM_INTERNET_DEFAULT ON)
-endif()
-
-option(ZSTD_FROM_INTERNET "Download and use libzstd from the Internet" ${ZSTD_FROM_INTERNET_DEFAULT})
 find_package(zstd 1.1.2 MODULE REQUIRED)
 
 option(REDIS_STORAGE_BACKEND "Enable Redis secondary storage" ON)
+
 if(REDIS_STORAGE_BACKEND)
-  option(HIREDIS_FROM_INTERNET "Download and use libhiredis from the Internet" ${HIREDIS_FROM_INTERNET_DEFAULT})
   find_package(hiredis 0.13.3 MODULE REQUIRED)
 endif()
 

--- a/cmake/Findhiredis.cmake
+++ b/cmake/Findhiredis.cmake
@@ -1,26 +1,57 @@
-if(HIREDIS_FROM_INTERNET)
-  set(hiredis_version "1.0.2")
-  set(hiredis_url https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz)
+if(hiredis_FOUND)
+  return()
+endif()
 
-  set(hiredis_dir ${CMAKE_BINARY_DIR}/hiredis-${hiredis_version})
-  set(hiredis_build ${CMAKE_BINARY_DIR}/hiredis-build)
+set(hiredis_FOUND FALSE)
 
-  if(NOT EXISTS "${hiredis_dir}.tar.gz")
-    file(DOWNLOAD "${hiredis_url}" "${hiredis_dir}.tar.gz" STATUS download_status)
-    list(GET download_status 0 error_code)
-    if(error_code)
-      file(REMOVE "${hiredis_dir}.tar.gz")
-      list(GET download_status 1 error_message)
-      message(FATAL "Failed to download hiredis: ${error_message}")
-    endif()
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(HIREDIS hiredis>=${hiredis_FIND_VERSION})
+  find_library(HIREDIS_LIBRARY ${HIREDIS_LIBRARIES} HINTS ${HIREDIS_LIBDIR})
+  find_path(HIREDIS_INCLUDE_DIR hiredis/hiredis.h HINTS ${HIREDIS_PREFIX}/include)
+else()
+  find_library(HIREDIS_LIBRARY hiredis)
+  find_path(HIREDIS_INCLUDE_DIR hiredis/hiredis.h)
+endif()
+
+if(HIREDIS_INCLUDE_DIR AND HIREDIS_LIBRARY)
+  mark_as_advanced(HIREDIS_INCLUDE_DIR HIREDIS_LIBRARY)
+
+  add_library(HIREDIS::HIREDIS UNKNOWN IMPORTED)
+  set_target_properties(
+    HIREDIS::HIREDIS
+    PROPERTIES
+    IMPORTED_LOCATION "${HIREDIS_LIBRARY}"
+    INTERFACE_COMPILE_OPTIONS "${HIREDIS_CFLAGS_OTHER}"
+    INTERFACE_INCLUDE_DIRECTORIES "${HIREDIS_INCLUDE_DIR}")
+  if(WIN32 AND STATIC_LINK)
+    target_link_libraries(HIREDIS::HIREDIS INTERFACE ws2_32)
   endif()
 
-  execute_process(
-    COMMAND tar xf "${hiredis_dir}.tar.gz"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-    RESULT_VARIABLE tar_error)
-  if(NOT tar_error EQUAL 0)
-    message(FATAL "extracting ${hiredis_dir}.tar.gz failed")
+  set(hiredis_FOUND TRUE)
+  set(target HIREDIS::HIREDIS)
+elseif(HIREDIS_FROM_INTERNET)
+  message(STATUS "*** WARNING ***: Using hiredis from the internet because it was NOT found and HIREDIS_FROM_INTERNET is TRUE")
+
+  set(hiredis_version "1.0.2")
+
+  set(hiredis_dir   ${CMAKE_BINARY_DIR}/hiredis-${hiredis_version})
+  set(hiredis_build ${CMAKE_BINARY_DIR}/hiredis-build)
+
+  include(FetchContent)
+
+  FetchContent_Declare(
+    hiredis
+    URL         https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz
+    URL_HASH    SHA256=e0ab696e2f07deb4252dda45b703d09854e53b9703c7d52182ce5a22616c3819
+    SOURCE_DIR  ${hiredis_dir}
+    BINARY_DIR  ${hiredis_build}
+  )
+
+  FetchContent_GetProperties(hiredis)
+
+  if(NOT hiredis_POPULATED)
+    FetchContent_Populate(hiredis)
   endif()
 
   set(
@@ -36,9 +67,9 @@ if(HIREDIS_FROM_INTERNET)
   )
   add_library(libhiredis_static STATIC EXCLUDE_FROM_ALL ${hiredis_sources})
   add_library(HIREDIS::HIREDIS ALIAS libhiredis_static)
+
   if(WIN32)
     target_compile_definitions(libhiredis_static PRIVATE _CRT_SECURE_NO_WARNINGS)
-    target_link_libraries(libhiredis_static PUBLIC ws2_32)
   endif()
 
   make_directory("${hiredis_dir}/include")
@@ -49,39 +80,20 @@ if(HIREDIS_FROM_INTERNET)
     libhiredis_static
     PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${hiredis_dir}/include>")
-else()
-  find_package(PkgConfig)
-  if(PKG_CONFIG_FOUND)
-    pkg_check_modules(HIREDIS hiredis>=${hiredis_FIND_VERSION})
-    find_library(HIREDIS_LIBRARY ${HIREDIS_LIBRARIES} HINTS ${HIREDIS_LIBDIR})
-    find_path(HIREDIS_INCLUDE_DIR hiredis/hiredis.h HINTS ${HIREDIS_PREFIX}/include)
-  else()
-    find_library(HIREDIS_LIBRARY hiredis)
-    find_path(HIREDIS_INCLUDE_DIR hiredis/hiredis.h)
-  endif()
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(
-    hiredis
-    "please install libhiredis or use -DHIREDIS_FROM_INTERNET=ON or disable with -DREDIS_STORAGE_BACKEND=OFF"
-    HIREDIS_INCLUDE_DIR HIREDIS_LIBRARY)
-  mark_as_advanced(HIREDIS_INCLUDE_DIR HIREDIS_LIBRARY)
-
-  add_library(HIREDIS::HIREDIS UNKNOWN IMPORTED)
-  set_target_properties(
-    HIREDIS::HIREDIS
-    PROPERTIES
-    IMPORTED_LOCATION "${HIREDIS_LIBRARY}"
-    INTERFACE_COMPILE_OPTIONS "${HIREDIS_CFLAGS_OTHER}"
-    INTERFACE_INCLUDE_DIRECTORIES "${HIREDIS_INCLUDE_DIR}")
-  if(WIN32 AND STATIC_LINK)
-    target_link_libraries(HIREDIS::HIREDIS INTERFACE ws2_32)
-  endif()
+  set(hiredis_FOUND TRUE)
+  set(target libhiredis_static)
 endif()
+
+if(WIN32 AND hiredis_FOUND)
+  target_link_libraries(${target} INTERFACE ws2_32)
+endif()
+unset(target)
 
 include(FeatureSummary)
 set_package_properties(
   hiredis
   PROPERTIES
   URL "https://github.com/redis/hiredis"
-  DESCRIPTION "Hiredis is a minimalistic C client library for the Redis database")
+  DESCRIPTION "Hiredis is a minimalistic C client library for the Redis database"
+)

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -2,32 +2,47 @@ if(zstd_FOUND)
   return()
 endif()
 
-if(ZSTD_FROM_INTERNET)
+set(zstd_FOUND FALSE)
+
+find_library(ZSTD_LIBRARY zstd)
+find_path(ZSTD_INCLUDE_DIR zstd.h)
+
+if(ZSTD_LIBRARY AND ZSTD_INCLUDE_DIR)
+  mark_as_advanced(ZSTD_INCLUDE_DIR ZSTD_LIBRARY)
+
+  add_library(ZSTD::ZSTD UNKNOWN IMPORTED)
+  set_target_properties(
+    ZSTD::ZSTD
+    PROPERTIES
+    IMPORTED_LOCATION "${ZSTD_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIR}")
+
+  set(zstd_FOUND TRUE)
+elseif(ZSTD_FROM_INTERNET)
+  message(STATUS "*** WARNING ***: Using zstd from the internet because it was NOT found and ZSTD_FROM_INTERNET is TRUE")
+
   # Although ${zstd_FIND_VERSION} was requested, let's download a newer version.
   # Note: The directory structure has changed in 1.3.0; we only support 1.3.0
   # and newer.
   set(zstd_version "1.5.2")
-  set(zstd_url https://github.com/facebook/zstd/archive/v${zstd_version}.tar.gz)
 
-  set(zstd_dir ${CMAKE_BINARY_DIR}/zstd-${zstd_version})
+  set(zstd_dir   ${CMAKE_BINARY_DIR}/zstd-${zstd_version})
   set(zstd_build ${CMAKE_BINARY_DIR}/zstd-build)
 
-  if(NOT EXISTS "${zstd_dir}.tar.gz")
-    file(DOWNLOAD "${zstd_url}" "${zstd_dir}.tar.gz" STATUS download_status)
-    list(GET download_status 0 error_code)
-    if(error_code)
-      file(REMOVE "${zstd_dir}.tar.gz")
-      list(GET download_status 1 error_message)
-      message(FATAL "Failed to download zstd: ${error_message}")
-    endif()
-  endif()
+  include(FetchContent)
 
-  execute_process(
-    COMMAND tar xf "${zstd_dir}.tar.gz"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-    RESULT_VARIABLE tar_error)
-  if(NOT tar_error EQUAL 0)
-    message(FATAL "extracting ${zstd_dir}.tar.gz failed")
+  FetchContent_Declare(
+    zstd
+    URL         https://github.com/facebook/zstd/archive/v${zstd_version}.tar.gz
+    URL_HASH    SHA256=f7de13462f7a82c29ab865820149e778cbfe01087b3a55b5332707abf9db4a6e
+    SOURCE_DIR  ${zstd_dir}
+    BINARY_DIR  ${zstd_build}
+  )
+
+  FetchContent_GetProperties(zstd)
+
+  if(NOT zstd_POPULATED)
+    FetchContent_Populate(zstd)
   endif()
 
   set(ZSTD_BUILD_SHARED OFF)
@@ -37,25 +52,10 @@ if(ZSTD_FROM_INTERNET)
   set_target_properties(
     libzstd_static
     PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${zstd_dir}/lib>")
+    INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${zstd_dir}/lib>"
+  )
 
   set(zstd_FOUND TRUE)
-else()
-  find_library(ZSTD_LIBRARY zstd)
-  find_path(ZSTD_INCLUDE_DIR zstd.h)
-
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(
-    zstd "please install libzstd or use -DZSTD_FROM_INTERNET=ON"
-    ZSTD_INCLUDE_DIR ZSTD_LIBRARY)
-  mark_as_advanced(ZSTD_INCLUDE_DIR ZSTD_LIBRARY)
-
-  add_library(ZSTD::ZSTD UNKNOWN IMPORTED)
-  set_target_properties(
-    ZSTD::ZSTD
-    PROPERTIES
-    IMPORTED_LOCATION "${ZSTD_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIR}")
 endif()
 
 include(FeatureSummary)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 add_library(ccache_framework STATIC ${source_files})
 
 if(WIN32)
-  list(APPEND CCACHE_EXTRA_LIBS psapi ws2_32)
+  list(APPEND CCACHE_EXTRA_LIBS psapi)
 endif()
 
 if(CCACHE_EXTRA_LIBS)


### PR DESCRIPTION
Signed-off-by: Rafael Kitover <rkitover@gmail.com>

This is the auto `FROM_INTERNET` thing I promised to do.

This is almost completely backwards compatible, except the behavior of the `FROM_INTERNET` cmake options is slightly different, they are `ON` by default, and if the user did not enable `STATIC_LINK` and a system library is available, it will be linked shared.

Also a loud warning is printed when a dep is used `FROM_INTERNET`.

Still smoothing out some minor details, so this PR is a draft.