### PR TITLE
Add script to create archive tarball from cache

### DIFF
--- a/misc/create-archive
+++ b/misc/create-archive
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# This script creates an archive of the contents of the cache from primary storage.
+
+import tarfile
+import os
+import sys
+
+import progress.bar
+import humanize
+
+filename = "ccache.tar"
+if len(sys.argv) > 1:
+    filename = sys.argv[1]
+archive = tarfile.open(filename, "w")
+
+ccache = os.getenv("CCACHE_DIR", os.path.expanduser("~/.cache/ccache"))
+filelist = []
+for dirpath, dirnames, filenames in os.walk(ccache):
+    for filename in filenames:
+        if filename.endswith(".lock"):
+            continue
+        stat = os.stat(os.path.join(dirpath, filename))
+        filelist.append((dirpath, filename, stat.st_size, stat.st_mtime))
+filelist.sort()
+files = result = manifest = objects = 0
+size = 0
+columns = os.get_terminal_size()[0]
+width = min(columns - 22, 100)
+bar = progress.bar.Bar(
+    "Archiving...", max=len(filelist), fill="=", suffix="%(percent).1f%%", width=width
+)
+for dirpath, filename, filesize, mtime in filelist:
+    dirname = dirpath.replace(ccache + os.path.sep, "")
+    if dirname == "tmp":
+        continue
+    elif filename == "CACHEDIR.TAG" or filename == "stats":
+        # ignore these
+        files = files + 1
+    else:
+        (base, ext) = filename[:-1], filename[-1:]
+        if ext == "R" or ext == "M":
+            if ext == "R":
+                result = result + 1
+            if ext == "M":
+                manifest = manifest + 1
+            key = "".join(list(os.path.split(dirname)) + [base])
+            val = open(os.path.join(dirpath, filename), "rb")
+            if val:
+                # print("%s: %s %d" % (key, ext, filesize))
+                name = key[0:2] + "/" + key[2:]
+                info = tarfile.TarInfo(name)
+                info.size = filesize
+                info.mtime = mtime
+                archive.addfile(info, val)
+                objects = objects + 1
+        files = files + 1
+        size = size + filesize
+    bar.next()
+archive.close()
+bar.finish()
+print(
+    "%d files, %d result (%d manifest) = %d objects (%s)"
+    % (files, result, manifest, objects, humanize.naturalsize(size, binary=True))
+)


### PR DESCRIPTION
Small variation on the old `upload-redis` script.

This .tar can be used as a secondary file storage.