### PR TITLE
feat: Support multiple -Xarch_* arguments matching -arch

### DIFF
--- a/src/ArgsInfo.hpp
+++ b/src/ArgsInfo.hpp
@@ -22,6 +22,7 @@
 
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // This class holds meta-information derived from the compiler arguments.
@@ -130,6 +131,9 @@ struct ArgsInfo
 
   // Architectures from -arch options.
   std::vector<std::string> arch_args;
+
+  // Values for -Xarch_* options.
+  std::unordered_map<std::string, std::vector<std::string>> xarch_args;
 
   // Relocating debuginfo in the format old=new.
   std::vector<std::string> debug_prefix_maps;

--- a/test/suites/multi_arch.bash
+++ b/test/suites/multi_arch.bash
@@ -36,20 +36,43 @@ SUITE_multi_arch() {
     expect_stat direct_cache_hit 2
     expect_stat cache_miss 3
 
-    # A single -Xarch_* matching -arch is supported.
     CCACHE_DEBUG=1 $CCACHE_COMPILE -arch x86_64 -Xarch_x86_64 -I. -c test1.c
     expect_stat direct_cache_hit 2
     expect_stat cache_miss 4
-    expect_contains     test1.o.*.ccache-log "clang -Xarch_x86_64 -I. -arch x86_64 -E"
-    expect_not_contains test1.o.*.ccache-log "clang -Xarch_x86_64 -I. -I. -arch x86_64 -E"
+    expect_contains     test1.o.*.ccache-log "clang -arch x86_64 -Xarch_x86_64 -I. -E"
+    expect_not_contains test1.o.*.ccache-log "clang -arch x86_64 -Xarch_x86_64 -I. -I. -E"
 
     $CCACHE_COMPILE -arch x86_64 -Xarch_x86_64 -I. -c test1.c
     expect_stat direct_cache_hit 3
     expect_stat cache_miss 4
 
-    # The parameter following -Xarch should be processed.
-    $CCACHE_COMPILE -arch x86_64 -Xarch_x86_64 -analyze -I. -c test1.c
-    expect_stat unsupported_compiler_option 1
+    # -------------------------------------------------------------------------
+    TEST "cache hit, direct mode, multiple -Xarch_* arguments"
+
+    CCACHE_DEBUG=1 $CCACHE_COMPILE -arch x86_64 -arch arm64 -Xarch_x86_64 -I. -Xarch_arm64 -I. -c test1.c
+    expect_stat direct_cache_hit 0
+    expect_stat cache_miss 1
+    expect_contains     test1.o.*.ccache-log "clang -arch x86_64 -Xarch_x86_64 -I. -E"
+    expect_not_contains test1.o.*.ccache-log "clang -arch x86_64 -Xarch_x86_64 -I. -I. -E"
+    expect_contains     test1.o.*.ccache-log "clang -arch arm64 -Xarch_arm64 -I. -E"
+    expect_not_contains test1.o.*.ccache-log "clang -arch arm64 -Xarch_arm64 -I. -I. -E"
+
+    $CCACHE_COMPILE -arch x86_64 -arch arm64 -Xarch_x86_64 -I. -Xarch_arm64 -I. -c test1.c
+    expect_stat direct_cache_hit 1
+    expect_stat cache_miss 1
+
+    # -------------------------------------------------------------------------
+    TEST "cache hit, direct mode, multiple -Xarch_* arguments for single arch"
+
+    CCACHE_DEBUG=1 $CCACHE_COMPILE -arch x86_64 -Xarch_x86_64 -I. -Xarch_x86_64 -Ifoo -c test1.c
+    expect_stat direct_cache_hit 0
+    expect_stat cache_miss 1
+    expect_contains     test1.o.*.ccache-log "clang -arch x86_64 -Xarch_x86_64 -I. -Xarch_x86_64 -Ifoo -E"
+    expect_not_contains test1.o.*.ccache-log "clang -arch x86_64 -Xarch_x86_64 -I. -I. -Xarch_x86_64 -Ifoo -E"
+
+    $CCACHE_COMPILE -arch x86_64 -Xarch_x86_64 -I. -Xarch_x86_64 -Ifoo -c test1.c
+    expect_stat direct_cache_hit 1
+    expect_stat cache_miss 1
 
     # -------------------------------------------------------------------------
     TEST "cache hit, preprocessor mode"


### PR DESCRIPTION
This pull request should bring more flexibility to iOS build caching. I admit that I am by far not a compiler expert so I did a lot of assumptions and I am opening this PR to get feedback.

The current situation is that multiple `-Xarch_*` arguments are not supported. Based on #874 I took a step forward and now match `-Xarch_*` to `-arch` and if they match, treat them as `-arch` arguments so adding them together to the each preprocessor run.

This allows me to efficiently cache multiarch iOS builds but I did not runtime test it yet if the output actually makes sense (the compilation finishes fine).