### PR TITLE
Fix build with musl when using gcc12

### DIFF
--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -22,6 +22,8 @@
 
 #include <core/Sloppiness.hpp>
 
+#include <sys/types.h>
+
 #include <cstdint>
 #include <functional>
 #include <limits>

--- a/src/core/Statistics.hpp
+++ b/src/core/Statistics.hpp
@@ -21,6 +21,7 @@
 #include <core/StatisticsCounters.hpp>
 
 #include <cstdint>
+#include <ctime>
 #include <string>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
The build issues are seen with musl + gcc12, the issues are latent with glibc which is indirectly including these headers 
