### PR TITLE
ci: Add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     env:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -17,8 +17,15 @@ on:
     # Full scan once a week
     - cron: '0 14 * * 3'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     name: Analyze
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows. 

GitHub Actions workflows have a GITHUB_TOKEN with `write` access to multiple scopes. 
Here is an example of the permissions in one of the workflows:
https://github.com/ccache/ccache/actions/runs/3046687499/jobs/4909809113#step:1:19

After this change, the scopes will be reduced to the minimum needed for each workflow. 

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced. 
- GitHub recommends defining minimum GITHUB_TOKEN permissions. 
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository. 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>