### PR TITLE
fix: small typo in the run script

### DIFF
--- a/test/run
+++ b/test/run
@@ -649,7 +649,7 @@ for suite in $suites; do
 done
 
 cd /
-if [ -z "$KEEP_TESTDIR"]; then
+if [ -z "$KEEP_TESTDIR" ]; then
     rm -rf $ABS_TESTDIR
 fi
 if $skipped; then


### PR DESCRIPTION
Missing space inside bash condition

Without this fix, there is an error returned when executing the run script with the option to keep the test directory `KEEP_TESTDIR`:

    ./run: line 645: [: missing `]'

