### PR TITLE
fix: remove potential windows newline from the stats

### DIFF
--- a/test/run
+++ b/test/run
@@ -179,8 +179,11 @@ expect_stat() {
         fi
     done < <($CCACHE --print-stats)
 
+    # strip any windows newline char from the value
+    value=${value//$'\r'/}
+
     if [ "$expected_value" != "$value" ]; then
-        test_failed_internal "Expected $stat to be $expected_value, actual $value"
+        test_failed_internal "Expected $stat to be \"$expected_value\", actual \"$value\""
     fi
 }
 


### PR DESCRIPTION
On windows machines, this could happen, the symptom is a failure message like the following:

    FAILED

    Test suite:     basedir (line 22)
    Test case:      Enabled CCACHE_BASEDIR
    Failure reason: Expected direct_cache_hit to be 0, actual 0

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
