### PR TITLE
fix: fix windows issues in run script

### DIFF
--- a/test/run
+++ b/test/run
@@ -449,9 +449,15 @@ TEST() {
     remove_cache
     rm -rf $ABS_TESTDIR/run $ABS_TESTDIR/run.real
 
+if ! $HOST_OS_WINDOWS && ! $HOST_OS_CYGWIN; then
     # Verify that tests behave well when apparent CWD != actual CWD.
     mkdir $ABS_TESTDIR/run.real
+
     ln -s run.real $ABS_TESTDIR/run
+else
+    # on windows, ln -s is not supported well
+    mkdir $ABS_TESTDIR/run
+fi
 
     cd $ABS_TESTDIR/run
     if type SUITE_${suite_name}_SETUP >/dev/null 2>&1; then
@@ -623,6 +629,11 @@ cd $TESTDIR || exit 1
 
 mkdir compiler
 COMPILER="$(pwd)/compiler/$(basename "$REAL_COMPILER_BIN")"
+if $HOST_OS_WINDOWS; then
+    # on windows, if the compiler executable has no extension, ccache will automatically
+    # add a .exe before invoking it and on a script, this fails
+    COMPILER="$COMPILER.sh"
+fi
 cat >"$COMPILER" <<EOF
 #!/bin/sh
 


### PR DESCRIPTION
On windows, the creation of symlinks is not supported so I removed this from the run script.

I also added an extension to the script replacing the compiler because otherwise ccache automatically adds a .exe extension to invoke it.

Signed-off-by: louiscaron <caron_louis@yahoo.fr>

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
