### PR TITLE
fix: spaces between target and colon in dependency files

### DIFF
--- a/src/Depfile.cpp
+++ b/src/Depfile.cpp
@@ -159,6 +159,20 @@ tokenize(std::string_view file_content)
         ++p;
       }
       if (!is_blank(token)) {
+        // if there were spaces between a token and the : sign, the :
+        // must be added to the same token to make sure it is seen as
+        // a target and not as a dependency
+        if (p < length) {
+          const char c = file_content[p];
+          if (c == ':') {
+            token.push_back(c);
+            ++p;
+            // chomp all spaces before next char
+            while (p < length && isspace(file_content[p])) {
+              ++p;
+            }
+          }
+        }
         result.push_back(token);
       }
       token.clear();
@@ -182,7 +196,7 @@ tokenize(std::string_view file_content)
           ++p;
           break;
         // Backslash followed by newline is interpreted like a space, so simply
-        // the backslash.
+        // discard the backslash.
         case '\n':
           ++p;
           continue;

--- a/unittest/test_Depfile.cpp
+++ b/unittest/test_Depfile.cpp
@@ -202,6 +202,30 @@ TEST_CASE("Depfile::tokenize")
     CHECK(result[0] == "cat.o:");
     CHECK(result[1] == "meow");
   }
+
+  SUBCASE("Parse depfile with a one space before colon")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat.o : meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow");
+  }
+
+  SUBCASE("Parse depfile with a two spaces before colon")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat.o  : meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow");
+  }
+
+  SUBCASE("Parse depfile with a plenty of spaces before colon")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat.o    :    meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow");
+  }
 }
 
 TEST_SUITE_END();

--- a/unittest/test_Depfile.cpp
+++ b/unittest/test_Depfile.cpp
@@ -226,6 +226,171 @@ TEST_CASE("Depfile::tokenize")
     CHECK(result[0] == "cat.o:");
     CHECK(result[1] == "meow");
   }
+
+  SUBCASE("Parse depfile with no space between colon and dependency")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat.o:meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "meow");
+  }
+
+  SUBCASE(
+    "Parse depfile with windows formatted filename (with backslashes in "
+    "target)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("e:\\cat.o: meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "e:\\cat.o:");
+    CHECK(result[1] == "meow");
+  }
+
+  SUBCASE(
+    "Parse depfile with windows formatted filename (with backslashes in "
+    "prerequisite)")
+  {
+    std::vector<std::string> result =
+      Depfile::tokenize("cat.o: c:\\meow\\purr");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "c:\\meow\\purr");
+  }
+
+  SUBCASE(
+    "Parse depfile with windows formatted filename (with slashes in target)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("e:/cat.o: meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "e:/cat.o:");
+    CHECK(result[1] == "meow");
+  }
+
+  SUBCASE(
+    "Parse depfile with windows formatted filename (with slashes in "
+    "prerequisite)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat.o: c:/meow/purr");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "c:/meow/purr");
+  }
+
+  SUBCASE(
+    "Parse depfile with windows formatted filename (with slashes and trailing "
+    "colon)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat.o: c: /meow/purr");
+    REQUIRE(result.size() == 3);
+    CHECK(result[0] == "cat.o:");
+    CHECK(result[1] == "c:");
+    CHECK(result[2] == "/meow/purr");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest1)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat:/meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat:");
+    CHECK(result[1] == "/meow");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest2)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat:\\meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat:");
+    CHECK(result[1] == "\\meow");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest3)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat:\\ meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat:");
+    CHECK(result[1] == " meow");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest4)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat:c:/meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat:");
+    CHECK(result[1] == "c:/meow");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest5)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat:c:\\meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat:");
+    CHECK(result[1] == "c:\\meow");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest6)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat:c:");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat:");
+    CHECK(result[1] == "c:");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest7)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat:c:\\");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat:");
+    CHECK(result[1] == "c:\\");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest8)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat:c:/");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "cat:");
+    CHECK(result[1] == "c:/");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest9)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("cat:c:meow");
+    REQUIRE(result.size() == 3);
+    CHECK(result[0] == "cat:");
+    CHECK(result[1] == "c:");
+    CHECK(result[2] == "meow");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest10)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("c:c:/meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "c:");
+    CHECK(result[1] == "c:/meow");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest11)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("c:c:\\meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "c:");
+    CHECK(result[1] == "c:\\meow");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest12)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("c:z:\\meow");
+    REQUIRE(result.size() == 2);
+    CHECK(result[0] == "c:");
+    CHECK(result[1] == "z:\\meow");
+  }
+
+  SUBCASE("Parse depfile with windows formatted filename (subtest13)")
+  {
+    std::vector<std::string> result = Depfile::tokenize("c:cd:\\meow");
+    REQUIRE(result.size() == 3);
+    CHECK(result[0] == "c:");
+    CHECK(result[1] == "cd:");
+    CHECK(result[2] == "\\meow");
+  }
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Support dependency files that are generated with spaces between the target and the colon sign.  This is the case for the tasking compiler but since this is supported by definition of the target, it could be generated theoretically by any compiler

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
