### PR TITLE
feat: Add sloppiness for -frandom-seed

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -1002,6 +1002,9 @@ preprocessing first.
 *time_macros*::
     Ignore `+__DATE__+`, `+__TIME__+` and `+__TIMESTAMP__+` being present in the
     source code.
+*random_seed*::
+    By default, ccache will respect argument changes with `-frandom-seed`. This
+    sloppiness will allow cache hits even if the seed value is different.
 --
 +
 See the discussion under _<<Troubleshooting>>_ for more information.

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -304,6 +304,8 @@ parse_sloppiness(const std::string& value)
       result.enable(core::Sloppy::modules);
     } else if (token == "pch_defines") {
       result.enable(core::Sloppy::pch_defines);
+    } else if (token == "random_seed") {
+      result.enable(core::Sloppy::random_seed);
     } else if (token == "system_headers" || token == "no_system_headers") {
       result.enable(core::Sloppy::system_headers);
     } else if (token == "time_macros") {
@@ -347,6 +349,9 @@ format_sloppiness(core::Sloppiness sloppiness)
   }
   if (sloppiness.is_enabled(core::Sloppy::pch_defines)) {
     result += "pch_defines, ";
+  }
+  if (sloppiness.is_enabled(core::Sloppy::random_seed)) {
+    result += "random_seed, ";
   }
   if (sloppiness.is_enabled(core::Sloppy::system_headers)) {
     result += "system_headers, ";

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1555,6 +1555,15 @@ hash_argument(const Context& ctx,
     return {};
   }
 
+  // If we treat random_seed sloppily we ignore the argument when
+  // hashing.
+  if (util::starts_with(args[i], "-frandom-seed=")
+      && ctx.config.sloppiness().is_enabled(core::Sloppy::random_seed)) {
+    hash.hash_delimiter("arg");
+    hash.hash("-frandom-seed=");
+    return {};
+  }
+
   // When using the preprocessor, some arguments don't contribute to the hash.
   // The theory is that these arguments will change the output of -E if they are
   // going to have any effect at all. For precompiled headers this might not be

--- a/src/core/Sloppiness.hpp
+++ b/src/core/Sloppiness.hpp
@@ -49,6 +49,8 @@ enum class Sloppy : uint32_t {
   ivfsoverlay = 1U << 10,
   // Allow us to include incorrect working directory in .gcno files.
   gcno_cwd = 1U << 11,
+  // Ignore changes in -frandom-seed
+  random_seed = 1U << 12,
 };
 
 class Sloppiness


### PR DESCRIPTION
This allows the use different -frandom-seed
values without causing cache misses.

Should fix https://github.com/ccache/ccache/issues/1002

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
