### PR TITLE
fix: Capture MSVC stdout/stderr when running from Visual Studio

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1364,6 +1364,8 @@ unsetenv(const std::string& name)
 {
 #ifdef HAVE_UNSETENV
   ::unsetenv(name.c_str());
+#elif defined(_WIN32)
+  SetEnvironmentVariable(name.c_str(), NULL);
 #else
   putenv(strdup(name.c_str())); // Leak to environment.
 #endif

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2260,6 +2260,12 @@ do_cache_compilation(Context& ctx, const char* const* argv)
 
   TRY(set_up_uncached_err());
 
+  // VS_UNICODE_OUTPUT prevents capturing stdout/stderr, as the output is sent
+  // directly to Visual Studio.
+  if (ctx.config.compiler_type() == CompilerType::msvc) {
+    Util::unsetenv("VS_UNICODE_OUTPUT");
+  }
+
   for (const auto& name : {"DEPENDENCIES_OUTPUT", "SUNPRO_DEPENDENCIES"}) {
     if (getenv(name)) {
       LOG("Unsupported environment variable: {}", name);


### PR DESCRIPTION
When VS_UNICODE_OUTPUT is set, CL sends its (unicode) output to VS using a side-channel. This prevents the option to capture the output.

Unset this variable to enable capturing the output.
