### PR TITLE
fix: Fix implementation of unsetenv on Windows

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1364,6 +1364,8 @@ unsetenv(const std::string& name)
 {
 #ifdef HAVE_UNSETENV
   ::unsetenv(name.c_str());
+#elif defined(_WIN32)
+  SetEnvironmentVariable(name.c_str(), NULL);
 #else
   putenv(strdup(name.c_str())); // Leak to environment.
 #endif


### PR DESCRIPTION
`putenv("FOO")` doesn't really unset it. `putnev("FOO=")` sets an empty value, which might be good for most cases, but for really unsetting we need `SetEnvironmentVariable("FOO", NULL)`.
