### PR TITLE
feat: Support auto depend mode for MSVC without /showIncludes

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -1583,7 +1583,7 @@ The depend mode will be disabled if any of the following holds:
 * <<config_depend_mode,*depend_mode*>> is false.
 * <<config_run_second_cpp,*run_second_cpp*>> is false.
 * The compiler is not generating dependencies using `-MD` or `-MMD` (for MSVC,
-  /showIncludes).
+  /showIncludes is added automatically if not specified by the user).
 
 
 == Handling of newly created header files

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -120,6 +120,7 @@ public:
   void set_max_size(uint64_t value);
   void set_run_second_cpp(bool value);
   void set_temporary_dir(const std::string& value);
+  void set_msvc_dep_prefix(const std::string& value);
 
   // Where to write configuration changes.
   const std::string& config_path() const;
@@ -592,4 +593,10 @@ inline void
 Config::set_temporary_dir(const std::string& value)
 {
   m_temporary_dir = value;
+}
+
+inline void
+Config::set_msvc_dep_prefix(const std::string& value)
+{
+  m_msvc_dep_prefix = value;
 }

--- a/src/Context.hpp
+++ b/src/Context.hpp
@@ -118,6 +118,8 @@ public:
   std::unique_ptr<MiniTrace> mini_trace;
 #endif
 
+  bool auto_depend_mode = false;
+
   // Register a temporary file to remove at program exit.
   void register_pending_tmp_file(const std::string& path);
 

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -1499,6 +1499,13 @@ process_args(Context& ctx)
     }
   }
 
+  if (ctx.config.depend_mode() && !args_info.generating_includes
+      && ctx.config.compiler_type() == CompilerType::msvc) {
+    ctx.auto_depend_mode = true;
+    args_info.generating_includes = true;
+    args_info.depend_extra_args.push_back("-showIncludes");
+  }
+
   return {
     preprocessor_args,
     extra_args_to_hash,

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -1075,7 +1075,10 @@ to_cache(Context& ctx,
     Util::send_to_fd(
       ctx, util::to_string_view(result->stderr_data), STDERR_FILENO);
     Util::send_to_fd(
-      ctx, util::to_string_view(result->stdout_data), STDOUT_FILENO);
+      ctx,
+      util::to_string_view(core::ShowIncludesParser::strip_includes(
+        ctx, std::move(result->stdout_data))),
+      STDOUT_FILENO);
 
     auto failure = Failure(Statistic::compile_failed);
     failure.set_exit_code(result->exit_status);
@@ -1134,7 +1137,10 @@ to_cache(Context& ctx,
     ctx, util::to_string_view(result->stderr_data), STDERR_FILENO);
   // Send stdout after stderr, it makes the output clearer with MSVC.
   Util::send_to_fd(
-    ctx, util::to_string_view(result->stdout_data), STDOUT_FILENO);
+    ctx,
+    util::to_string_view(core::ShowIncludesParser::strip_includes(
+      ctx, std::move(result->stdout_data))),
+    STDOUT_FILENO);
 
   return *result_key;
 }

--- a/src/core/ResultRetriever.cpp
+++ b/src/core/ResultRetriever.cpp
@@ -24,6 +24,7 @@
 
 #include <Context.hpp>
 #include <Stat.hpp>
+#include <core/ShowIncludesParser.hpp>
 #include <core/exceptions.hpp>
 #include <core/wincompat.hpp>
 #include <fmtmacros.hpp>
@@ -61,7 +62,10 @@ ResultRetriever::on_embedded_file(uint8_t file_number,
       data.size());
 
   if (file_type == FileType::stdout_output) {
-    Util::send_to_fd(m_ctx, util::to_string_view(data), STDOUT_FILENO);
+    Util::send_to_fd(
+      m_ctx,
+      util::to_string_view(ShowIncludesParser::strip_includes(m_ctx, data)),
+      STDOUT_FILENO);
   } else if (file_type == FileType::stderr_output) {
     Util::send_to_fd(m_ctx, util::to_string_view(data), STDERR_FILENO);
   } else {

--- a/src/core/ShowIncludesParser.cpp
+++ b/src/core/ShowIncludesParser.cpp
@@ -49,4 +49,28 @@ tokenize(std::string_view file_content, std::string_view prefix)
   return result;
 }
 
+util::Bytes
+strip_includes(const Context& ctx, util::Bytes&& stdout_data)
+{
+  using util::Tokenizer;
+  using Mode = Tokenizer::Mode;
+  using IncludeDelimiter = Tokenizer::IncludeDelimiter;
+
+  if (stdout_data.empty() || !ctx.auto_depend_mode
+      || ctx.config.compiler_type() != CompilerType::msvc) {
+    return std::move(stdout_data);
+  }
+
+  std::string new_stdout_text;
+  for (const auto line : Tokenizer(util::to_string_view(stdout_data),
+                                   "\n",
+                                   Mode::include_empty,
+                                   IncludeDelimiter::yes)) {
+    if (!util::starts_with(line, ctx.config.msvc_dep_prefix())) {
+      new_stdout_text.append(line.data(), line.length());
+    }
+  }
+  return util::Bytes(new_stdout_text.data(), new_stdout_text.size());
+}
+
 } // namespace core::ShowIncludesParser

--- a/src/core/ShowIncludesParser.hpp
+++ b/src/core/ShowIncludesParser.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <util/Bytes.hpp>
+
 #include <string_view>
 #include <vector>
 
@@ -27,5 +29,7 @@ namespace core::ShowIncludesParser {
 
 std::vector<std::string_view> tokenize(std::string_view file_content,
                                        std::string_view prefix);
+
+util::Bytes strip_includes(const Context& ctx, util::Bytes&& stdout_data);
 
 } // namespace core::ShowIncludesParser


### PR DESCRIPTION
If MSVC is executed *without* /showIncludes, and ccache is configured with depend mode, add /showIncludes, and strip the extra output from stdout.

Reviving #1158 which was reverted.

Depends on #992.