### PR TITLE
build: Add headers to CMake project files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,9 @@ if(WIN32)
   list(APPEND source_files Win32Util.cpp)
 endif()
 
+file(GLOB headers *.hpp)
+list(APPEND source_files ${headers})
+
 add_library(ccache_framework STATIC ${source_files})
 
 if(WIN32)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -14,4 +14,7 @@ set(
   types.cpp
 )
 
+file(GLOB headers *.hpp)
+list(APPEND sources ${headers})
+
 target_sources(ccache_framework PRIVATE ${sources})

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -6,4 +6,7 @@ set(
   Storage.cpp
 )
 
+file(GLOB headers *.hpp)
+list(APPEND sources ${headers})
+
 target_sources(ccache_framework PRIVATE ${sources})

--- a/src/storage/local/CMakeLists.txt
+++ b/src/storage/local/CMakeLists.txt
@@ -9,4 +9,7 @@ set(
   util.cpp
 )
 
+file(GLOB headers *.hpp)
+list(APPEND sources ${headers})
+
 target_sources(ccache_framework PRIVATE ${sources})

--- a/src/storage/remote/CMakeLists.txt
+++ b/src/storage/remote/CMakeLists.txt
@@ -9,4 +9,7 @@ if(REDIS_STORAGE_BACKEND)
   list(APPEND sources RedisStorage.cpp)
 endif()
 
+file(GLOB headers *.hpp)
+list(APPEND sources ${headers})
+
 target_sources(ccache_framework PRIVATE ${sources})

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -14,6 +14,9 @@ if(ENABLE_TRACING)
   target_sources(third_party PRIVATE minitrace.c)
 endif()
 
+file(GLOB headers *.h fmt/*.h nonstd/*.hpp win32/*.h)
+target_sources(third_party PRIVATE ${headers})
+
 set(xxhdispatchtest [=[
 #include "xxh_x86dispatch.c"
 

--- a/src/third_party/blake3/CMakeLists.txt
+++ b/src/third_party/blake3/CMakeLists.txt
@@ -115,3 +115,6 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     target_compile_definitions(blake3 PRIVATE BLAKE3_USE_NEON)
   endif()
 endif()
+
+file(GLOB headers *.h)
+target_sources(blake3 PRIVATE ${headers})

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -11,4 +11,7 @@ set(
   zstd.cpp
 )
 
+file(GLOB headers *.hpp)
+list(APPEND sources ${headers})
+
 target_sources(ccache_framework PRIVATE ${sources})

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -42,6 +42,9 @@ if(WIN32)
   list(APPEND source_files test_bsdmkstemp.cpp test_Win32Util.cpp)
 endif()
 
+file(GLOB headers *.hpp)
+list(APPEND source_files ${headers})
+
 add_executable(unittest ${source_files})
 
 if(MSVC)


### PR DESCRIPTION
Useful for listing them in the IDE project tree, for IDEs that use CMake file api (like Qt Creator).
