### PR TITLE
build: Remove clang64 msys target from ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,10 +138,6 @@ jobs:
             env: x86_64
             compiler: clang
 
-          - sys: clang64
-            env: clang-x86_64
-            compiler: clang
-
     name: 'Windows ${{ matrix.config.sys }} ${{ matrix.config.compiler }}'
     defaults:
       run:


### PR DESCRIPTION
It frequently fails to install packages.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
