### PR TITLE
build: apply standard settings and warnings to lockfile test

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,7 @@ if(REDIS_STORAGE_BACKEND)
 endif()
 
 add_executable(test-lockfile test_lockfile.cpp)
-target_link_libraries(test-lockfile PRIVATE ccache_framework)
+target_link_libraries(test-lockfile PRIVATE standard_settings standard_warnings ccache_framework)
 
 add_subdirectory(core)
 add_subdirectory(storage)


### PR DESCRIPTION
This ensures the required include of `config.h` to get `mode_t` defined on Windows.