### PR TITLE
fix: Process the argument following a -Xarch argument

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -385,8 +385,6 @@ process_option_arg(const Context& ctx,
       return Statistic::unsupported_compiler_option;
     }
     state.common_args.push_back(args[i]);
-    state.common_args.push_back(args[i + 1]);
-    ++i;
     return Statistic::none;
   }
 

--- a/test/suites/multi_arch.bash
+++ b/test/suites/multi_arch.bash
@@ -47,6 +47,10 @@ SUITE_multi_arch() {
     expect_stat direct_cache_hit 3
     expect_stat cache_miss 4
 
+    # The parameter following -Xarch should be processed.
+    $CCACHE_COMPILE -arch x86_64 -Xarch_x86_64 -analyze -I. -c test1.c
+    expect_stat unsupported_compiler_option 1
+
     # -------------------------------------------------------------------------
     TEST "cache hit, preprocessor mode"
 


### PR DESCRIPTION
Since there are already checks enforcing that all -Xarch arguments match each other and -arch, we can assume that the compiler would also interpret the following argument, so ccache should interpret it too.

Fixes #1198.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
