### PR TITLE
Add possibility of setting remote subdirs levels

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -1158,6 +1158,8 @@ Optional attributes:
 --
 +
 The default is *subdirs*.
+* *levels*: The number of levels of subdirectories to use for *subdirs*. The
+  default is 1.
 * *umask*: This attribute (an octal integer) overrides the umask to use for
   files and directories in the cache directory.
 * *update-mtime*: If *true*, update the modification time (mtime) of cache
@@ -1209,6 +1211,8 @@ values.
 --
 +
 The default is *subdirs*.
+* *levels*: The number of levels of subdirectories to use for *subdirs*. The
+  default is 1.
 * *operation-timeout*: Timeout (in ms) for HTTP requests. The default is 10000.
 
 

--- a/misc/convert-levels
+++ b/misc/convert-levels
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+# This script converts the number of levels in remote storage.
+
+import os
+import sys
+
+import progress.bar
+import humanize
+
+levels = 2
+digits = 2
+
+storage = "."
+filelist = []
+for dirpath, dirnames, filenames in os.walk(storage):
+    for filename in filenames:
+        if filename.endswith(".lock"):
+            continue
+        stat = os.stat(os.path.join(dirpath, filename))
+        filelist.append((dirpath, filename, stat.st_size, stat.st_mtime))
+filelist.sort()
+
+files = result = manifest = objects = 0
+size = 0
+columns = os.get_terminal_size()[0]
+width = min(columns - 22, 100)
+bar = progress.bar.Bar(
+    "Converting...", max=len(filelist), fill="=", suffix="%(percent).1f%%", width=width
+)
+subdirs = {}
+olddirs = {}
+for dirpath, filename, filesize, mtime in filelist:
+    path = os.path.join(dirpath, filename)
+    base = os.path.relpath(path, storage).replace("/", "")
+    if filesize < 4:
+        continue
+    val = open(path, "rb").read(4)
+    if val[0:2] == b"\xcc\xac":  # magic
+        objects += 1
+        if val[2] == 0 and val[3] == 0:
+            ext = "R"
+            result += 1
+        elif val[2] == 0 and val[3] == 1:
+            ext = "M"
+            manifest += 1
+        else:
+            bar.next()
+            continue
+        dirnames = []
+        for level in range(0, levels):
+            dirnames.append(base[level * digits : level * digits + digits])
+        dirname = os.path.join(*dirnames)
+        if dirname in subdirs:
+            subdirs[dirname] += 1
+        else:
+            subdirs[dirname] = 1
+        filename = base[levels * digits :]
+        if not os.path.exists(dirname):
+            os.makedirs(dirname, mode=0o755, exist_ok=True)
+        os.utime(dirname, times=(mtime, mtime))
+        os.rename(path, os.path.join(dirname, filename))
+        olddir = os.path.relpath(os.path.dirname(path), storage)
+        if not dirname.startswith(olddir):
+            olddirs[olddir] = True
+    files += 1
+    size += filesize
+    bar.next()
+bar.finish()
+
+print(
+    "%d files, %d result (%d manifest) = %d objects (%s)"
+    % (files, result, manifest, objects, humanize.naturalsize(size, binary=True))
+)
+for olddir in olddirs:
+    if olddir not in subdirs:
+        os.rmdir(olddir)
+avg = 0
+for subdir in subdirs:
+    avg += subdirs[subdir]
+avg /= len(subdirs)
+print("%d subdirs, %d levels (avg %.2f files)" % (len(subdirs.keys()), levels, avg))

--- a/src/storage/remote/FileStorage.cpp
+++ b/src/storage/remote/FileStorage.cpp
@@ -60,6 +60,7 @@ private:
   std::optional<mode_t> m_umask;
   bool m_update_mtime = false;
   Layout m_layout = Layout::subdirs;
+  uint8_t m_levels = 1;
 
   std::string get_entry_path(const Digest& key) const;
 };
@@ -93,6 +94,9 @@ FileStorageBackend::FileStorageBackend(const Params& params)
       } else {
         LOG("Unknown layout: {}", attr.value);
       }
+    } else if (attr.key == "levels") {
+      m_levels =
+        util::value_or_throw<core::Fatal>(util::parse_unsigned(attr.value, 1));
     } else if (attr.key == "umask") {
       m_umask =
         util::value_or_throw<core::Fatal>(util::parse_umask(attr.value));
@@ -182,7 +186,7 @@ FileStorageBackend::get_entry_path(const Digest& key) const
     const auto key_str = key.to_string();
     const uint8_t digits = 2;
     ASSERT(key_str.length() > digits);
-    return FMT("{}/{:.{}}/{}", m_dir, key_str, digits, &key_str[digits]);
+    return get_path_in_cache(m_dir, m_levels, digits, key_str);
   }
   }
 

--- a/src/storage/remote/HttpStorage.cpp
+++ b/src/storage/remote/HttpStorage.cpp
@@ -56,6 +56,7 @@ private:
   const std::string m_url_path;
   httplib::Client m_http_client;
   Layout m_layout = Layout::subdirs;
+  uint8_t m_levels = 1;
 
   std::string get_entry_path(const Digest& key) const;
 };
@@ -132,6 +133,9 @@ HttpStorageBackend::HttpStorageBackend(const Params& params)
       } else {
         LOG("Unknown layout: {}", attr.value);
       }
+    } else if (attr.key == "levels") {
+      m_levels =
+        util::value_or_throw<core::Fatal>(util::parse_unsigned(attr.value, 1));
     } else if (attr.key == "operation-timeout") {
       operation_timeout = parse_timeout_attribute(attr.value);
     } else if (!is_framework_attribute(attr.key)) {
@@ -262,7 +266,7 @@ HttpStorageBackend::get_entry_path(const Digest& key) const
     const auto key_str = key.to_string();
     const uint8_t digits = 2;
     ASSERT(key_str.length() > digits);
-    return FMT("{}/{:.{}}/{}", m_url_path, key_str, digits, &key_str[digits]);
+    return get_path_in_cache(m_url_path, m_levels, digits, key_str);
   }
   }
 

--- a/src/storage/remote/RemoteStorage.cpp
+++ b/src/storage/remote/RemoteStorage.cpp
@@ -41,7 +41,7 @@ std::string
 RemoteStorage::Backend::get_path_in_cache(const std::string& dir,
                                           const uint8_t level,
                                           const uint8_t digits,
-                                          const std::string_view name) const
+                                          const std::string_view name)
 {
   ASSERT(level >= 1 && level <= 8 / digits);
   ASSERT(name.length() >= level * digits);

--- a/src/storage/remote/RemoteStorage.cpp
+++ b/src/storage/remote/RemoteStorage.cpp
@@ -18,6 +18,7 @@
 
 #include "RemoteStorage.hpp"
 
+#include <assertions.hpp>
 #include <util/expected.hpp>
 #include <util/string.hpp>
 
@@ -34,6 +35,31 @@ RemoteStorage::Backend::parse_timeout_attribute(const std::string& value)
 {
   return std::chrono::milliseconds(util::value_or_throw<Failed>(
     util::parse_unsigned(value, 1, 60 * 1000, "timeout")));
+}
+
+std::string
+RemoteStorage::Backend::get_path_in_cache(const std::string& dir,
+                                          const uint8_t level,
+                                          const uint8_t digits,
+                                          const std::string_view name) const
+{
+  ASSERT(level >= 1 && level <= 8 / digits);
+  ASSERT(name.length() >= level * digits);
+
+  std::string path(dir);
+  path.reserve(path.size() + level * (digits + 1) + 1 + name.length()
+               - level * digits);
+
+  for (uint8_t i = 0; i < level; ++i) {
+    path.push_back('/');
+    path.append(name.substr(i * digits, digits));
+  }
+
+  path.push_back('/');
+  const std::string_view name_remaining = name.substr(level * digits);
+  path.append(name_remaining.data(), name_remaining.length());
+
+  return path;
 }
 
 } // namespace storage::remote

--- a/src/storage/remote/RemoteStorage.cpp
+++ b/src/storage/remote/RemoteStorage.cpp
@@ -44,7 +44,7 @@ RemoteStorage::Backend::get_path_in_cache(const std::string& dir,
                                           const std::string_view name)
 {
   ASSERT(level >= 1 && level <= 8 / digits);
-  ASSERT(name.length() >= level * digits);
+  ASSERT(name.length() >= static_cast<uint16_t>(level * digits));
 
   std::string path(dir);
   path.reserve(path.size() + level * (digits + 1) + 1 + name.length()

--- a/src/storage/remote/RemoteStorage.hpp
+++ b/src/storage/remote/RemoteStorage.hpp
@@ -102,6 +102,14 @@ public:
     // Parse a timeout `value`, throwing `Failed` on error.
     static std::chrono::milliseconds
     parse_timeout_attribute(const std::string& value);
+
+    // Join the cache directory, a '/' and `name` into a single path and return
+    // it. Additionally, `level` `digits`-character, '/'-separated subpaths are
+    // split from the beginning of `name` before joining them all.
+    std::string get_path_in_cache(const std::string& dir,
+                                  uint8_t level,
+                                  uint8_t digits,
+                                  std::string_view name) const;
   };
 
   virtual ~RemoteStorage() = default;

--- a/src/storage/remote/RemoteStorage.hpp
+++ b/src/storage/remote/RemoteStorage.hpp
@@ -106,10 +106,10 @@ public:
     // Join the cache directory, a '/' and `name` into a single path and return
     // it. Additionally, `level` `digits`-character, '/'-separated subpaths are
     // split from the beginning of `name` before joining them all.
-    std::string get_path_in_cache(const std::string& dir,
-                                  uint8_t level,
-                                  uint8_t digits,
-                                  std::string_view name) const;
+    static std::string get_path_in_cache(const std::string& dir,
+                                         uint8_t level,
+                                         uint8_t digits,
+                                         std::string_view name);
   };
 
   virtual ~RemoteStorage() = default;

--- a/test/suites/remote_file.bash
+++ b/test/suites/remote_file.bash
@@ -138,8 +138,8 @@ SUITE_remote_file() {
     expect_stat cache_miss 1
     expect_stat files_in_cache 2
     expect_exists remote/CACHEDIR.TAG
-    subdirs=$(find remote -type d | wc -l)
-    if [ "${subdirs}" -lt 5 ]; then # "remote" itself counts as one
+    subdirs=$(find remote -mindepth 2 -type d | wc -l)
+    if [ "${subdirs}" -lt 1 ]; then
         test_failed "Expected 2 levels of subdirectories in remote"
     fi
     expect_file_count 3 '*' remote # CACHEDIR.TAG + result + manifest

--- a/test/suites/remote_file.bash
+++ b/test/suites/remote_file.bash
@@ -129,6 +129,38 @@ SUITE_remote_file() {
     expect_file_count 3 '*' remote # CACHEDIR.TAG + result + manifest
 
     # -------------------------------------------------------------------------
+    TEST "Multiple levels"
+
+    CCACHE_REMOTE_STORAGE+="|levels=2"
+
+    $CCACHE_COMPILE -c test.c
+    expect_stat direct_cache_hit 0
+    expect_stat cache_miss 1
+    expect_stat files_in_cache 2
+    expect_exists remote/CACHEDIR.TAG
+    subdirs=$(find remote -type d | wc -l)
+    if [ "${subdirs}" -lt 5 ]; then # "remote" itself counts as one
+        test_failed "Expected 2 levels of subdirectories in remote"
+    fi
+    expect_file_count 3 '*' remote # CACHEDIR.TAG + result + manifest
+
+    $CCACHE_COMPILE -c test.c
+    expect_stat direct_cache_hit 1
+    expect_stat cache_miss 1
+    expect_stat files_in_cache 2
+    expect_file_count 3 '*' remote # CACHEDIR.TAG + result + manifest
+
+    $CCACHE -C >/dev/null
+    expect_stat files_in_cache 0
+    expect_file_count 3 '*' remote # CACHEDIR.TAG + result + manifest
+
+    $CCACHE_COMPILE -c test.c
+    expect_stat direct_cache_hit 2
+    expect_stat cache_miss 1
+    expect_stat files_in_cache 2 # fetched from remote
+    expect_file_count 3 '*' remote # CACHEDIR.TAG + result + manifest
+
+    # -------------------------------------------------------------------------
     TEST "Two directories"
 
     CCACHE_REMOTE_STORAGE+=" file://$PWD/remote_2"

--- a/test/suites/remote_http.bash
+++ b/test/suites/remote_http.bash
@@ -146,8 +146,8 @@ SUITE_remote_http() {
     expect_stat cache_miss 1
     expect_stat files_in_cache 2
     expect_file_count 2 '*' remote # result + manifest
-    subdirs=$(find remote -type d | wc -l)
-    if [ "${subdirs}" -lt 5 ]; then # "remote" itself counts as one
+    subdirs=$(find remote -mindepth 2 -type d | wc -l)
+    if [ "${subdirs}" -lt 1 ]; then
         test_failed "Expected 2 levels of subdirectories in remote"
     fi
 


### PR DESCRIPTION

Make it possible to use 1024 subdirectories / buckets,
by increasing levels = 1 to levels = 2 to get 256 x 256.
    
Each level after that will increase by another 1024x,
since it will use base32 digits instead of base16 digits.

----

When you have a cache directory, with more than 256k files.
Then you might want to to divide them into 1024 "buckets" :

levels=1
`storage/00/0b8psj1hu4710bvein42a6lp97qn5dc`

levels=2
`storage/00/0b/8psj1hu4710bvein42a6lp97qn5dc`

This is similar to the local cache levels, but uses 2 digits each.
There is probably no real reason to go above subdir level 2 ?

Most of the code "borrowed" from the local cache.