### PR TITLE
fix: Do not create /run directory on systems that don't have it when …

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1115,9 +1115,11 @@ Config::default_temporary_dir() const
 {
   static const std::string run_user_tmp_dir = [] {
 #ifdef HAVE_GETEUID
-    auto dir = FMT("/run/user/{}/ccache-tmp", geteuid());
-    if (Util::create_dir(dir) && access(dir.c_str(), W_OK) == 0) {
-      return dir;
+    if (Stat::stat("/run").is_directory()) {
+      auto dir = FMT("/run/user/{}/ccache-tmp", geteuid());
+      if (Util::create_dir(dir) && access(dir.c_str(), W_OK) == 0) {
+        return dir;
+      }
     }
 #endif
     return std::string();


### PR DESCRIPTION
…run as root

Some systems (e.g. FreeBSD) don't have /run directory. So when ccache is run as root it creates /run/... and uses it as tmp, that is not very good since / is not supposed to be written during the build. Fix this behavior by checking that /run is present before creating any subfolders.

Alternative idea was to have some kind of knob in config to move tmp into the cache dir (e.g. ```temporary_dir=${CCACHE_DIR}/tmp```} but I think having things working by default is a better idea.
This knpd still requires some patching because otherwise ccache will create /run on every call to default_temporary_dir() that is called, for example, from LocalStorage::finalize().