### PR TITLE
fix: posix_fallocate can return EINVAL if filesystem doesn't support …

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -486,7 +486,8 @@ fallocate(int fd, long new_size)
   if (posix_fallocate_err == 0 || posix_fallocate_err != EINVAL) {
     return posix_fallocate_err;
   }
-  //  the underlying filesystem does not support the operation so fallback to lseeks 
+  // the underlying filesystem does not support the operation so fallback to
+  // lseeks 
 #endif
   off_t saved_pos = lseek(fd, 0, SEEK_END);
   off_t old_size = lseek(fd, 0, SEEK_END);

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -487,7 +487,7 @@ fallocate(int fd, long new_size)
     return posix_fallocate_err;
   }
   // the underlying filesystem does not support the operation so fallback to
-  // lseeks 
+  // lseeks
 #endif
   off_t saved_pos = lseek(fd, 0, SEEK_END);
   off_t old_size = lseek(fd, 0, SEEK_END);


### PR DESCRIPTION
…it. Fallback to emulation in this case.

E.g. ZFS does so on FreeBSD (haven't tested with ZFS on linux).

This fixes Utill::fallocate unit tests on ZFS.