### PR TITLE
fix: Fix edge case where a non-temporal identifier is misidentified

### DIFF
--- a/src/hashutil.cpp
+++ b/src/hashutil.cpp
@@ -93,14 +93,14 @@ check_for_temporal_macros_helper(std::string_view str, size_t pos)
 }
 
 int
-check_for_temporal_macros_bmh(std::string_view str)
+check_for_temporal_macros_bmh(std::string_view str, size_t start = 0)
 {
   int result = 0;
 
   // We're using the Boyer-Moore-Horspool algorithm, which searches starting
   // from the *end* of the needle. Our needles are 8 characters long, so i
   // starts at 7.
-  size_t i = 7;
+  size_t i = start + 7;
 
   while (i < str.length()) {
     // Check whether the substring ending at str[i] has the form "_....E..". On
@@ -173,7 +173,7 @@ check_for_temporal_macros_avx2(std::string_view str)
     }
   }
 
-  result |= check_for_temporal_macros_bmh(str.substr(pos));
+  result |= check_for_temporal_macros_bmh(str, pos);
 
   return result;
 }

--- a/unittest/test_hashutil.cpp
+++ b/unittest/test_hashutil.cpp
@@ -167,6 +167,10 @@ TEST_CASE("check_for_temporal_macros")
     "#define alphabet abcdefghijklmnopqrstuvwxyz\n"
     "__DATE__";
 
+  const std::string_view no_temporal_at_avx_boundary =
+    "#define alphabet abcdefghijklmnopqrstuvwxyz\n"
+    "a__DATE__";
+
   CHECK(check_for_temporal_macros(time_start));
   CHECK(!check_for_temporal_macros(time_start.substr(1)));
 
@@ -226,8 +230,11 @@ TEST_CASE("check_for_temporal_macros")
   CHECK(!check_for_temporal_macros(no_temporal.substr(6)));
   CHECK(!check_for_temporal_macros(no_temporal.substr(7)));
 
-  for (size_t i = 0; i < sizeof(temporal_at_avx_boundary) - 8; ++i) {
+  for (size_t i = 0; i < temporal_at_avx_boundary.size() - 8; ++i) {
     CHECK(check_for_temporal_macros(temporal_at_avx_boundary.substr(i)));
+  }
+  for (size_t i = 0; i < no_temporal_at_avx_boundary.size() - 8; ++i) {
+    CHECK(!check_for_temporal_macros(no_temporal_at_avx_boundary.substr(i)));
   }
 }
 


### PR DESCRIPTION
If a non-temporal identifier, that ends with a temporal macro, happens to be at the end of the buffer with the temporal suffix starting on the avx boundary, then it would be incorrectly classified as a temporal macro. This since the helper function lacks the context to see that the data before the match is something that invalidates the match.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
