### PR TITLE
fix: Use spinlocks for inodes cache buckets protection

### DIFF
--- a/src/InodeCache.hpp
+++ b/src/InodeCache.hpp
@@ -132,4 +132,5 @@ private:
   util::Duration m_min_age;
   struct SharedRegion* m_sr = nullptr;
   bool m_failed = false;
+  const pid_t m_self_pid;
 };

--- a/test/suites/inode_cache.bash
+++ b/test/suites/inode_cache.bash
@@ -9,7 +9,7 @@ SUITE_inode_cache_PROBE() {
 
     touch test.c
     $CCACHE $COMPILER -c test.c
-    if [[ ! -f "${CCACHE_TEMPDIR}/inode-cache-32.v1" && ! -f "${CCACHE_TEMPDIR}/inode-cache-64.v1" ]]; then
+    if [[ ! -f "${CCACHE_TEMPDIR}/inode-cache-32.v2" && ! -f "${CCACHE_TEMPDIR}/inode-cache-64.v2" ]]; then
         local fs_type=$(stat -fLc %T "${CCACHE_DIR}")
         echo "inode cache not supported on ${fs_type}"
     fi

--- a/unittest/test_InodeCache.cpp
+++ b/unittest/test_InodeCache.cpp
@@ -177,7 +177,7 @@ TEST_CASE("Drop file")
   CHECK(Stat::stat(inode_cache.get_file()));
   CHECK(inode_cache.drop());
   CHECK(!Stat::stat(inode_cache.get_file()));
-  CHECK(!inode_cache.drop());
+  CHECK(inode_cache.drop());
 }
 
 TEST_CASE("Test content type")


### PR DESCRIPTION
These changes makes InodeCache working on FreeBSD (corresponging FSs were added to the list of supported filesystems).
Inode cache tests passes now on BSD and building a few large projects doesn't produces anything strange (inode cache file was created and updated during build).
