### PR TITLE
args: do not escape backslashes on msvc

### DIFF
--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -77,7 +77,7 @@ Args::from_atfile(const std::string& filename, AtFileFormat format)
         }
         break;
       case AtFileFormat::msvc:
-        if (*pos != '"' && *pos != '\\') {
+        if (*pos != '"') {
           pos--;
         }
         break;

--- a/unittest/test_Args.cpp
+++ b/unittest/test_Args.cpp
@@ -139,12 +139,12 @@ TEST_CASE("Args::from_atfile")
     CHECK(args[6] == "seve\nth");
   }
 
-  SUBCASE("Only escape double quote and backslash in alternate format")
+  SUBCASE("Only escape double quote in alternate format")
   {
-    util::write_file("at_file", "\"\\\"\\a\\ \\\\\\ \\b\\\"\"\\");
+    util::write_file("at_file", "\"\\\"\\a\\ \\b\\\"\"\\");
     args = *Args::from_atfile("at_file", Args::AtFileFormat::msvc);
     CHECK(args.size() == 1);
-    CHECK(args[0] == "\"\\a\\ \\\\ \\b\"\\");
+    CHECK(args[0] == "\"\\a\\ \\b\"\\");
   }
 
   SUBCASE("Ignore single quote in alternate format")
@@ -154,6 +154,14 @@ TEST_CASE("Args::from_atfile")
     CHECK(args.size() == 2);
     CHECK(args[0] == "'a");
     CHECK(args[1] == "b'");
+  }
+
+  SUBCASE("Do not escape backslash in alternate format")
+  {
+    util::write_file("at_file", "\"-DDIRSEP='\\\\'\"");
+    args = *Args::from_atfile("at_file", Args::AtFileFormat::msvc);
+    CHECK(args.size() == 1);
+    CHECK(args[0] == "-DDIRSEP='\\\\'");
   }
 }
 


### PR DESCRIPTION
Fixes #1216 , I tested the repro example provided and it should in fact compile. As such it seems that escaping backslashes is wrong all the other bug reports related to rsp parsing seems to only indicate issues with `"` whose escape behaviour remains.

Original fix #1071 did not indicate as to why backslashes should be escaped. As such I think its appropriate to revert that behaviour.