### PR TITLE
Make ccache compile with clang-cl on Windows

### DIFF
--- a/cmake/DevModeWarnings.cmake
+++ b/cmake/DevModeWarnings.cmake
@@ -74,6 +74,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
   # Disable C++20 compatibility for now.
   add_compile_flag_if_supported(CCACHE_COMPILER_WARNINGS "-Wno-c++2a-compat")
+  add_compile_flag_if_supported(CCACHE_COMPILER_WARNINGS "-Wno-c99-extensions")
+  add_compile_flag_if_supported(CCACHE_COMPILER_WARNINGS "-Wno-language-extension-token")
 
   # If compiler supports these warnings they have to be disabled for now.
   add_compile_flag_if_supported(

--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -12,7 +12,7 @@ else()
   )
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "^GNU|(Apple)?Clang$")
+if(CMAKE_CXX_COMPILER_ID MATCHES "^GNU|(Apple)?Clang$" AND NOT MSVC)
   option(ENABLE_COVERAGE "Enable coverage reporting for GCC/Clang" FALSE)
   if(ENABLE_COVERAGE)
     target_compile_options(standard_settings INTERFACE --coverage -O0 -g)
@@ -55,17 +55,16 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^GNU|(Apple)?Clang$")
 
   include(StdAtomic)
   include(StdFilesystem)
-
-elseif(MSVC)
+elseif(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "^Clang$")
   target_compile_options(
     standard_settings
-    INTERFACE /Zc:preprocessor /Zc:__cplusplus /D_CRT_SECURE_NO_WARNINGS
+    INTERFACE /Zc:preprocessor /Zc:__cplusplus
   )
 endif()
 
 if(WIN32)
   target_compile_definitions(
     standard_settings
-    INTERFACE WIN32_LEAN_AND_MEAN
+    INTERFACE WIN32_LEAN_AND_MEAN _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS
   )
 endif()

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -49,7 +49,7 @@ list(APPEND source_files ${headers})
 
 add_executable(unittest ${source_files})
 
-if(MSVC)
+if(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "^Clang$")
   # Turn off /Zc:preprocessor for this test because it triggers a bug in some older Windows 10 SDK headers.
   set_source_files_properties(test_Stat.cpp PROPERTIES COMPILE_FLAGS /Zc:preprocessor-)
 endif()


### PR DESCRIPTION
This makes ccache build out of the box with clang-cl on Windows. I haven't done any benchmarks yet since I couldn't find any benchmarking tests in the source that executes on Windows so I don't know if it improves things. But usually clang-cl + LTO is faster than MSVC on Windows.