### PR TITLE
remove CMake header checks

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -36,7 +36,7 @@
 
 #include "third_party/fmt/core.h"
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -28,7 +28,7 @@
 #include <util/TimePoint.hpp>
 #include <util/path.hpp>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/Fd.cpp
+++ b/src/Fd.cpp
@@ -20,7 +20,7 @@
 
 #include <core/wincompat.hpp>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -29,7 +29,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/InodeCache.cpp
+++ b/src/InodeCache.cpp
@@ -34,7 +34,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-#ifdef HAVE_LINUX_FS_H
+#if __has_include(<linux/fs.h>)
 #  include <linux/magic.h>
 #  include <sys/statfs.h>
 #elif defined(HAVE_STRUCT_STATFS_F_FSTYPENAME)
@@ -105,7 +105,7 @@ fd_is_on_known_to_work_file_system(int fd)
   if (fstatfs(fd, &buf) != 0) {
     LOG("fstatfs failed: {}", strerror(errno));
   } else {
-#ifdef HAVE_LINUX_FS_H
+#if __has_include(<linux/fs.h>)
     // statfs's f_type field is a signed 32-bit integer on some platforms. Large
     // values therefore cause narrowing warnings, so cast the value to a large
     // unsigned type.

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -28,16 +28,16 @@
 
 #include <core/wincompat.hpp>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 
-#ifdef HAVE_SYSLOG_H
+#if __has_include(<syslog.h>)
 #  include <syslog.h>
 #endif
 
 #ifdef __linux__
-#  ifdef HAVE_SYS_IOCTL_H
+#  if __has_include(<sys/ioctl.h>)
 #    include <sys/ioctl.h>
 #  endif
 #endif

--- a/src/MiniTrace.cpp
+++ b/src/MiniTrace.cpp
@@ -28,7 +28,7 @@
 
 #include <limits.h> // NOLINT: PATH_MAX is defined in limits.h
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/ProgressBar.cpp
+++ b/src/ProgressBar.cpp
@@ -34,7 +34,7 @@
 #  include <termios.h>
 #endif
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/TemporaryFile.cpp
+++ b/src/TemporaryFile.cpp
@@ -25,7 +25,7 @@
 
 #include <cstdlib>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -41,25 +41,25 @@ extern "C" {
 #include "third_party/base32hex.h"
 }
 
-#ifdef HAVE_DIRENT_H
+#if __has_include(<dirent.h>)
 #  include <dirent.h>
 #endif
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 
 #include <fcntl.h>
 
-#ifdef HAVE_PWD_H
+#if __has_include(<pwd.h>)
 #  include <pwd.h>
 #endif
 
 #ifdef __linux__
-#  ifdef HAVE_SYS_IOCTL_H
+#  if __has_include(<sys/ioctl.h>)
 #    include <sys/ioctl.h>
 #  endif
-#  ifdef HAVE_LINUX_FS_H
+#  if __has_include(<linux/fs.h>)
 #    include <linux/fs.h>
 #    ifndef FICLONE
 #      define FICLONE _IOW(0x94, 9, int)
@@ -69,7 +69,7 @@ extern "C" {
 #endif
 
 #ifdef __APPLE__
-#  ifdef HAVE_SYS_CLONEFILE_H
+#  if __has_include(<sys/clonefile.h>)
 #    include <sys/clonefile.h>
 #    ifdef CLONE_NOOWNERCOPY
 #      define FILE_CLONING_SUPPORTED 1
@@ -1181,7 +1181,7 @@ to_lowercase(std::string_view string)
   return result;
 }
 
-#ifdef HAVE_DIRENT_H
+#if __has_include(<dirent.h>)
 
 void
 traverse(const std::string& path, const TraverseVisitor& visitor)

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -29,7 +29,7 @@
 #include <core/wincompat.hpp>
 #include <util/string.hpp>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -66,7 +66,7 @@
 #include <optional>
 #include <string_view>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/core/Result.cpp
+++ b/src/core/Result.cpp
@@ -43,7 +43,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/core/ResultRetriever.cpp
+++ b/src/core/ResultRetriever.cpp
@@ -36,7 +36,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/core/mainoptions.cpp
+++ b/src/core/mainoptions.cpp
@@ -56,7 +56,7 @@
 #include <string>
 #include <thread>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -35,11 +35,11 @@
 #include <util/file.hpp>
 #include <util/path.hpp>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 
-#ifdef HAVE_SYS_WAIT_H
+#if __has_include(<sys/wait.h>)
 #  include <sys/wait.h>
 #endif
 

--- a/src/hashutil.cpp
+++ b/src/hashutil.cpp
@@ -41,11 +41,11 @@
 
 #include "third_party/blake3/blake3_cpu_supports_avx2.h"
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 
-#ifdef HAVE_SYS_WAIT_H
+#if __has_include(<sys/wait.h>)
 #  include <sys/wait.h>
 #endif
 

--- a/src/storage/local/LocalStorage.cpp
+++ b/src/storage/local/LocalStorage.cpp
@@ -58,7 +58,7 @@
 #include <string>
 #include <utility>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/util/LockFile.cpp
+++ b/src/util/LockFile.cpp
@@ -29,7 +29,7 @@
 
 #include "third_party/fmt/core.h"
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -25,7 +25,7 @@
 #include <fmtmacros.hpp>
 #include <util/Bytes.hpp>
 
-#ifdef HAVE_UNISTD_H
+#if __has_include(<unistd.h>)
 #  include <unistd.h>
 #endif
 
@@ -36,9 +36,9 @@
 #  include <sys/time.h>
 #else
 #  include <sys/types.h>
-#  ifdef HAVE_UTIME_H
+#  if __has_include(<utime.h>)
 #    include <utime.h>
-#  elif defined(HAVE_SYS_UTIME_H)
+#  elif __has_include(<sys/utime.h>)
 #    include <sys/utime.h>
 #  endif
 #endif


### PR DESCRIPTION
C++17 allows moving to the compiler, speeding compilation up.