### PR TITLE
Don't treat /Zi as unsupported for clang-cl.

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -608,7 +608,8 @@ process_option_arg(const Context& ctx,
     return Statistic::none;
   }
 
-  if (config.is_compiler_group_msvc() && util::starts_with(arg, "-Z")) {
+  if (config.is_compiler_group_msvc() && !config.is_compiler_group_clang()
+      && util::starts_with(arg, "-Z")) {
     state.last_seen_msvc_z_option = args[i];
     state.common_args.push_back(args[i]);
     return Statistic::none;

--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -746,4 +746,30 @@ TEST_CASE("MSVC debug information format options")
   }
 }
 
+// Check that clang-cl debug information is parsed different,
+// since for clang-cl /Zi and /Z7 is the same!
+TEST_CASE("ClangCL Debug information options")
+{
+  TestContext test_context;
+  Context ctx;
+  ctx.config.set_compiler_type(CompilerType::clang_cl);
+  util::write_file("foo.c", "");
+
+  SUBCASE("/Z7")
+  {
+    ctx.orig_args = Args::from_string("clang-cl.exe /c foo.c /Z7");
+    const ProcessArgsResult result = process_args(ctx);
+    REQUIRE(!result.error);
+    CHECK(result.preprocessor_args.to_string() == "clang-cl.exe /Z7");
+  }
+
+  SUBCASE("/Zi")
+  {
+    ctx.orig_args = Args::from_string("clang-cl.exe /c foo.c /Zi");
+    const ProcessArgsResult result = process_args(ctx);
+    REQUIRE(!result.error);
+    CHECK(result.preprocessor_args.to_string() == "clang-cl.exe /Zi");
+  }
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
For MSVC /Zi is unsupported since it writes a additional
.pdb file per each .obj file and it creates some messy
interaction with ccache. But for clang-cl /Zi is actually
treated as /Z7 and only embeds the debug info in the .obj
file so it makes sense to allow this flag when compiling
with clang-cl.
