### PR TITLE
feat: support llc compiler, .ll files

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -269,6 +269,8 @@ parse_compiler_type(const std::string& value)
     return CompilerType::nvcc;
   } else if (value == "other") {
     return CompilerType::other;
+  } else if (value == "llc") {
+    return CompilerType::llc;
   } else {
     // Allow any unknown value for forward compatibility.
     return CompilerType::auto_guess;
@@ -500,6 +502,7 @@ compiler_type_to_string(CompilerType compiler_type)
     CASE(msvc);
     CASE(nvcc);
     CASE(other);
+    CASE(llc);
   }
 #undef CASE
 

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -41,6 +41,7 @@ enum class CompilerType {
   icl,
   msvc,
   nvcc,
+  llc,
   other
 };
 
@@ -264,7 +265,8 @@ inline bool
 Config::is_compiler_group_clang() const
 {
   return m_compiler_type == CompilerType::clang
-         || m_compiler_type == CompilerType::clang_cl;
+         || m_compiler_type == CompilerType::clang_cl
+         || m_compiler_type == CompilerType::llc;
 }
 
 inline bool

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -1282,8 +1282,10 @@ process_args(Context& ctx)
   }
 
   // -fsyntax-only/-Zs does not need -c
+  // llc compiler does not need -c
   if (!state.found_c_opt && !state.found_dc_opt && !state.found_S_opt
-      && !state.found_syntax_only) {
+      && !state.found_syntax_only
+      && ctx.config.compiler_type() != CompilerType::llc) {
     if (args_info.output_is_precompiled_header) {
       state.common_args.push_back("-c");
     } else {

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -268,6 +268,8 @@ guess_compiler(std::string_view path)
     return CompilerType::icl;
   } else if (name == "cl") {
     return CompilerType::msvc;
+  } else if (name == "llc") {
+    return CompilerType::llc;
   } else {
     return CompilerType::other;
   }

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -52,6 +52,7 @@ const struct
   {".mi", "objective-c-cpp-output"},
   {".mii", "objective-c++-cpp-output"},
   {".s", "assembler"},
+  {".ll", "assembler"},
   // Header file (for precompilation):
   {".h", "c-header"},
   {".H", "c++-header"},


### PR DESCRIPTION
llc works, essentially, identcally to clang, except that the -c option is implicit. Thus, in the llc case, we cannot require it.

llc is commonly used for generating BPF objects, so it makes sense for ccache to support it, IMHO.

Additionally, indicate that .ll files are assembly. They're actually LLVM IR, but the effect is the same.

Fixes: #1267

Thanks!