### PR TITLE
test: Fix typo (missing line continuation)

### DIFF
--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -552,7 +552,7 @@ fi
     # -------------------------------------------------------------------------
     TEST "Directory is not hashed if using -gz"
 
-    if $COMPILER -c test1.c -gz 2>/dev/null
+    if $COMPILER -c test1.c -gz 2>/dev/null \
        && $COMPILER -E test1.c -gz >preprocessed.i 2>/dev/null \
        && [ -s preprocessed.i ] \
        && ! grep -Fq $PWD preprocessed.i; then


### PR DESCRIPTION
Fixes: ef634bdb292e1e24b8d1b5490e7857144a77c0fd