### PR TITLE
Fix MSBuild CI jobs + minor cmake fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -325,17 +325,16 @@ jobs:
             CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON
             TEST_CC: clang -target x86_64-pc-windows-msvc
 
-          # Issue: #1278
-          # - name: Windows VS2019 64-bit MSBuild
-          #   os: windows-2019
-          #   msvc_arch: x64
-          #   allow_test_failures: true  # For now, don't fail the build on failure
-          #   CC: cl
-          #   CXX: cl
-          #   ENABLE_CACHE_CLEANUP_TESTS: 1
-          #   CMAKE_GENERATOR: Visual Studio 16 2019
-          #   CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON -A x64
-          #   TEST_CC: clang -target x86_64-pc-windows-msvc
+          - name: Windows VS2019 64-bit MSBuild
+            os: windows-2019
+            msvc_arch: x64
+            allow_test_failures: true  # For now, don't fail the build on failure
+            CC: cl
+            CXX: cl
+            ENABLE_CACHE_CLEANUP_TESTS: 1
+            CMAKE_GENERATOR: Visual Studio 16 2019
+            CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON -A x64
+            TEST_CC: clang -target x86_64-pc-windows-msvc
 
           - name: Windows VS2022 32-bit Ninja
             os: windows-2022
@@ -370,17 +369,16 @@ jobs:
             CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON
             TEST_CC: clang -target x86_64-pc-windows-msvc
 
-          # Issue: #1278
-          # - name: Windows VS2022 64-bit MSBuild
-          #   os: windows-2022
-          #   msvc_arch: x64
-          #   allow_test_failures: true  # For now, don't fail the build on failure
-          #   CC: cl
-          #   CXX: cl
-          #   ENABLE_CACHE_CLEANUP_TESTS: 1
-          #   CMAKE_GENERATOR: Visual Studio 17 2022
-          #   CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON -A x64
-          #   TEST_CC: clang -target x86_64-pc-windows-msvc
+          - name: Windows VS2022 64-bit MSBuild
+            os: windows-2022
+            msvc_arch: x64
+            allow_test_failures: true  # For now, don't fail the build on failure
+            CC: cl
+            CXX: cl
+            ENABLE_CACHE_CLEANUP_TESTS: 1
+            CMAKE_GENERATOR: Visual Studio 17 2022
+            CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=CI -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON -A x64
+            TEST_CC: clang -target x86_64-pc-windows-msvc
 
           - name: Clang address & UB sanitizer
             os: ubuntu-20.04

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,86 @@
+{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }, {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }, {
+      "name": "x64-RelWithDebInfo",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }, {
+      "name": "x86-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "msvc_x86"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }, {
+      "name": "x86-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [
+        "msvc_x86"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }, {
+      "name": "x86-RelWithDebInfo",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [
+        "msvc_x86"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }, {
+      "name": "arm64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "msvc_arm64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }, {
+      "name": "arm64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [
+        "msvc_arm64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }, {
+      "name": "arm64-RelWithDebInfo",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [
+        "msvc_arm64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}"
+    }
+  ]
+}

--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -72,8 +72,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 === src/third_party/blake3/blake3_*
 
-This is a subset of https://github.com/BLAKE3-team/BLAKE3[BLAKE3] 1.3.1 with
-the following license:
+This is a subset of https://github.com/BLAKE3-team/BLAKE3[BLAKE3] (git SHA:
+https://github.com/BLAKE3-team/BLAKE3/commit/71a2646180c787e22f8681c5fec7655a0ad51e99[71a2646])
+with the following license:
 
 ----
 This work is released into the public domain with CC0 1.0. Alternatively, it is

--- a/cmake/Findhiredis.cmake
+++ b/cmake/Findhiredis.cmake
@@ -2,6 +2,11 @@ if(hiredis_FOUND)
   return()
 endif()
 
+if(POLICY CMP0135)
+  # Set timestamps on extracted files to time of extraction.
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 set(hiredis_FOUND FALSE)
 
 if(HIREDIS_FROM_INTERNET AND NOT HIREDIS_FROM_INTERNET STREQUAL "AUTO")

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -2,6 +2,11 @@ if(zstd_FOUND)
   return()
 endif()
 
+if(POLICY CMP0135)
+  # Set timestamps on extracted files to time of extraction.
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 set(zstd_FOUND FALSE)
 
 if(ZSTD_FROM_INTERNET AND NOT ZSTD_FROM_INTERNET STREQUAL "AUTO")

--- a/src/third_party/blake3/CMakeLists.txt
+++ b/src/third_party/blake3/CMakeLists.txt
@@ -27,7 +27,11 @@ function(add_source_if_enabled feature msvc_flags others_flags intrinsic)
 
   # First check if it's possible to use the assembler variant for the feature.
   string(TOUPPER "have_asm_${feature}" have_feature)
-  if(NOT DEFINED "${have_feature}" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+  if(NOT DEFINED "${have_feature}" AND CMAKE_SIZEOF_VOID_P EQUAL 8
+# Force intrinsic version for msbuild because of a bug in the cmake generator
+# or msbuild itself with masm flags.
+      AND NOT CMAKE_GENERATOR MATCHES "Visual Studio")
+
     if(NOT CMAKE_REQUIRED_QUIET)
       message(STATUS "Performing Test ${have_feature}")
     endif()

--- a/src/third_party/blake3/blake3.c
+++ b/src/third_party/blake3/blake3.c
@@ -246,7 +246,7 @@ INLINE size_t compress_parents_parallel(const uint8_t *child_chaining_values,
 
 // The wide helper function returns (writes out) an array of chaining values
 // and returns the length of that array. The number of chaining values returned
-// is the dyanmically detected SIMD degree, at most MAX_SIMD_DEGREE. Or fewer,
+// is the dynamically detected SIMD degree, at most MAX_SIMD_DEGREE. Or fewer,
 // if the input is shorter than that many chunks. The reason for maintaining a
 // wide array of chaining values going back up the tree, is to allow the
 // implementation to hash as many parents in parallel as possible.
@@ -254,7 +254,7 @@ INLINE size_t compress_parents_parallel(const uint8_t *child_chaining_values,
 // As a special case when the SIMD degree is 1, this function will still return
 // at least 2 outputs. This guarantees that this function doesn't perform the
 // root compression. (If it did, it would use the wrong flags, and also we
-// wouldn't be able to implement exendable ouput.) Note that this function is
+// wouldn't be able to implement exendable output.) Note that this function is
 // not used when the whole input is only 1 chunk long; that's a different
 // codepath.
 //

--- a/src/third_party/blake3/blake3.h
+++ b/src/third_party/blake3/blake3.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#define BLAKE3_VERSION_STRING "1.3.1"
+#define BLAKE3_VERSION_STRING "1.3.3"
 #define BLAKE3_KEY_LEN 32
 #define BLAKE3_OUT_LEN 32
 #define BLAKE3_BLOCK_LEN 64

--- a/src/third_party/blake3/blake3_avx2_x86-64_windows_gnu.S
+++ b/src/third_party/blake3/blake3_avx2_x86-64_windows_gnu.S
@@ -1784,7 +1784,7 @@ blake3_hash_many_avx2:
         vmovdqu xmmword ptr [rbx+0x10], xmm1
         jmp     4b
 
-.section .rodata
+.section .rdata
 .p2align  6
 ADD0:
         .long  0, 1, 2, 3, 4, 5, 6, 7

--- a/src/third_party/blake3/blake3_avx512_x86-64_windows_gnu.S
+++ b/src/third_party/blake3/blake3_avx512_x86-64_windows_gnu.S
@@ -2587,7 +2587,7 @@ blake3_compress_xof_avx512:
         add     rsp, 72
         ret
 
-.section .rodata
+.section .rdata
 .p2align  6
 INDEX0:
         .long    0,  1,  2,  3, 16, 17, 18, 19

--- a/src/third_party/blake3/blake3_dispatch.c
+++ b/src/third_party/blake3/blake3_dispatch.c
@@ -10,14 +10,14 @@
 #elif defined(__GNUC__)
 #include <immintrin.h>
 #else
-#error "Unimplemented!"
+#undef IS_X86 /* Unimplemented! */
 #endif
 #endif
 
 #define MAYBE_UNUSED(x) (void)((x))
 
 #if defined(IS_X86)
-static uint64_t xgetbv() {
+static uint64_t xgetbv(void) {
 #if defined(_MSC_VER)
   return _xgetbv(0);
 #else
@@ -82,7 +82,7 @@ static /* Allow the variable to be controlled manually for testing */
 static
 #endif
     enum cpu_feature
-    get_cpu_features() {
+    get_cpu_features(void) {
 
   if (g_cpu_features != UNDEFINED) {
     return g_cpu_features;
@@ -101,7 +101,7 @@ static
     if (*edx & (1UL << 26))
       features |= SSE2;
 #endif
-    if (*ecx & (1UL << 0))
+    if (*ecx & (1UL << 9))
       features |= SSSE3;
     if (*ecx & (1UL << 19))
       features |= SSE41;

--- a/src/third_party/blake3/blake3_impl.h
+++ b/src/third_party/blake3/blake3_impl.h
@@ -46,7 +46,6 @@ enum blake3_flags {
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif
-#include <immintrin.h>
 #endif
 
 #if !defined(BLAKE3_USE_NEON) 
@@ -88,7 +87,7 @@ static const uint8_t MSG_SCHEDULE[7][16] = {
 /* x is assumed to be nonzero.       */
 static unsigned int highest_one(uint64_t x) {
 #if defined(__GNUC__) || defined(__clang__)
-  return 63 ^ __builtin_clzll(x);
+  return 63 ^ (unsigned int)__builtin_clzll(x);
 #elif defined(_MSC_VER) && defined(IS_X86_64)
   unsigned long index;
   _BitScanReverse64(&index, x);
@@ -118,7 +117,7 @@ static unsigned int highest_one(uint64_t x) {
 // Count the number of 1 bits.
 INLINE unsigned int popcnt(uint64_t x) {
 #if defined(__GNUC__) || defined(__clang__)
-  return __builtin_popcountll(x);
+  return (unsigned int)__builtin_popcountll(x);
 #else
   unsigned int count = 0;
   while (x != 0) {

--- a/src/third_party/blake3/blake3_sse2_x86-64_windows_gnu.S
+++ b/src/third_party/blake3/blake3_sse2_x86-64_windows_gnu.S
@@ -2301,7 +2301,7 @@ blake3_compress_xof_sse2:
         ret
 
 
-.section .rodata
+.section .rdata
 .p2align  6
 BLAKE3_IV:
         .long  0x6A09E667, 0xBB67AE85

--- a/src/third_party/blake3/blake3_sse41_x86-64_windows_gnu.S
+++ b/src/third_party/blake3/blake3_sse41_x86-64_windows_gnu.S
@@ -2042,7 +2042,7 @@ blake3_compress_xof_sse41:
         ret
 
 
-.section .rodata
+.section .rdata
 .p2align  6
 BLAKE3_IV:
         .long  0x6A09E667, 0xBB67AE85


### PR DESCRIPTION
- Fix the MSBuild CI jobs #1278 
- Update blake3 from 1.3.1 to 71a2646
- Fix cmake dev warning when downloading zstd/hiredis
- Add a basic CMakeSettings.json for Visual Studio IDE with Ninja as the generator