### PR TITLE
build: fix Xcode build of zstd

### DIFF
--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -52,6 +52,11 @@ if(do_download)
   set(zstd_dir   ${CMAKE_BINARY_DIR}/zstd-${zstd_version})
   set(zstd_build ${CMAKE_BINARY_DIR}/zstd-build)
 
+  if(XCODE)
+    # See https://github.com/facebook/zstd/pull/3665
+    set(zstd_patch PATCH_COMMAND sed -i .bak -e s/^set_source_files_properties.*PROPERTIES.*LANGUAGE.*C/\#&/ build/cmake/lib/CMakeLists.txt)
+  endif()
+
   include(FetchContent)
   FetchContent_Declare(
     zstd
@@ -59,6 +64,7 @@ if(do_download)
     URL_HASH SHA256=9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4
     SOURCE_DIR ${zstd_dir}
     BINARY_DIR ${zstd_build}
+    ${zstd_patch}
   )
 
   FetchContent_GetProperties(zstd)


### PR DESCRIPTION
Reproducer (CMake `3.26.4`, Xcode `14.3`):
```
cmake -B _build -GXcode -DCMAKE_OSX_ARCHITECTURES=x86_64 -DZSTD_FROM_INTERNET=ON -DREDIS_STORAGE_BACKEND=OFF
cmake --build _build

```

See facebook/zstd#3622

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
