### PR TITLE
feat: Don't hash /Fd, /FS and /MP

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -623,6 +623,17 @@ process_option_arg(const Context& ctx,
     return Statistic::none;
   }
 
+  if (config.is_compiler_group_msvc() && util::starts_with(arg, "-Fd")) {
+    state.compiler_only_args_no_hash.push_back(args[i]);
+    return Statistic::none;
+  }
+
+  if (config.is_compiler_group_msvc()
+      && (util::starts_with(arg, "-MP") || arg == "-FS")) {
+    state.compiler_only_args_no_hash.push_back(args[i]);
+    return Statistic::none;
+  }
+
   // These options require special handling, because they behave differently
   // with gcc -E, when the output file is not specified.
   if ((arg == "-MD" || arg == "-MMD") && !config.is_compiler_group_msvc()) {


### PR DESCRIPTION
/Fd is to specify the file name of output PDB. But currently ccache only supports /Z7 which doesn't generate PDB at compile time.

/FS forces writes to PDB to be serialized through MSPDBSRV.EXE. It shouldn't affect generated files and it has no effect for /Z7.

/MP enables /FS. It creates multiple compiler instances and simultaneously compile multiple source files which is not supported by ccache.

### References
- `/Fd`: https://learn.microsoft.com/en-us/cpp/build/reference/fd-program-database-file-name
- `/FS`: https://learn.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes
- `/MP`: https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes

### Background

CMake adds `/Fd` and `/FS` unconditionally to compile options even though they only have effects with `/Zi` or `/ZI`.
https://gitlab.kitware.com/cmake/cmake/-/blob/v3.26.4/Modules/Platform/Windows-MSVC.cmake#L362-363

CMake runs `cl.exe /FdCMakeFiles\cmTC_91e0d.dir\ /FS -c CMakeCCompilerABI.c` at configure time. The `/Fd` paths are randomly generated. Including `/Fd` in hash causes cache miss.

**Edit:** Seems that the name specified by `/Fd` is embeded into `obj` file and final `pdb` file, anyway. But that should not have side effects.
```shell
> cl.exe /Z7 /Fdhello.pdb test.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.36.32532 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

test.cpp
Microsoft (R) Incremental Linker Version 14.36.32532.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:test.exe
/debug
test.obj

> strings test.obj | grep pdb
C:\tmp\hello.pdb
> strings test.exe | grep pdb
C:\tmp\test.pdb
> strings test.pdb | grep pdb
C:\tmp\hello.pdb
C:\tmp\test.pdb
C:\tmp\test.pdb
pdblVal
pdblVal
C:\tmp\hello.pdb
```
