### PR TITLE
fix: Improve handling of backslash in MSVC .rsp

### DIFF
--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -77,7 +77,7 @@ Args::from_atfile(const std::string& filename, AtFileFormat format)
         }
         break;
       case AtFileFormat::msvc:
-        if (*pos != '"') {
+        if (*pos != '"' && *pos != '\\') {
           pos--;
         }
         break;

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -60,7 +60,7 @@ Args::from_atfile(const std::string& filename, AtFileFormat format)
   auto pos = argtext->c_str();
   std::string argbuf;
   argbuf.resize(argtext->length() + 1);
-  auto argpos = argbuf.begin();
+  auto argpos = argbuf.data();
 
   // Used to track quoting state; if \0 we are not inside quotes. Otherwise
   // stores the quoting character that started it for matching the end quote.
@@ -69,17 +69,40 @@ Args::from_atfile(const std::string& filename, AtFileFormat format)
   while (true) {
     switch (*pos) {
     case '\\':
-      pos++;
       switch (format) {
       case AtFileFormat::gcc:
+        pos++;
         if (*pos == '\0') {
           continue;
         }
         break;
       case AtFileFormat::msvc:
-        if (*pos != '"' && *pos != '\\') {
-          pos--;
+        size_t count = 0;
+        while (*pos == '\\') {
+          count++;
+          pos++;
         }
+        if (*pos == '"') {
+          if (count == 1) {
+            // simple escape \"
+            break;
+          }
+          if (count % 2 != 0) {
+            // If an odd number of backslashes is followed by a double quotation
+            // mark, one backslash is placed in the argv array for every pair of
+            // backslashes, and the double quotation mark is "escaped" by the
+            // remaining backslash
+            pos--;
+          }
+          std::memset(argpos, '\\', count / 2);
+          argpos += count / 2;
+        } else {
+          // Backslashes are interpreted literally, unless they immediately
+          // precede a double quotation mark.
+          std::memset(argpos, '\\', count);
+          argpos += count;
+        }
+        continue;
         break;
       }
       break;
@@ -95,6 +118,13 @@ Args::from_atfile(const std::string& filename, AtFileFormat format)
         if (quoting == *pos) {
           quoting = '\0';
           pos++;
+          if (format == AtFileFormat::msvc && *pos == '"') {
+            // Any double-quote directly following a closing quote is treated as
+            // (or as part of) plain unwrapped text that is adjacent to the
+            // double-quoted group
+            // https://stackoverflow.com/questions/7760545/escape-double-quotes-in-parameter
+            break;
+          }
           continue;
         } else {
           break;
@@ -120,7 +150,7 @@ Args::from_atfile(const std::string& filename, AtFileFormat format)
       if (argbuf[0] != '\0') {
         args.push_back(argbuf.substr(0, argbuf.find('\0')));
       }
-      argpos = argbuf.begin();
+      argpos = argbuf.data();
       if (*pos == '\0') {
         return args;
       } else {

--- a/unittest/test_Args.cpp
+++ b/unittest/test_Args.cpp
@@ -158,10 +158,18 @@ TEST_CASE("Args::from_atfile")
 
   SUBCASE("Do not escape backslash in alternate format")
   {
-    util::write_file("at_file", "\"-DDIRSEP='\\\\'\"");
+    util::write_file("at_file", R"("-DDIRSEP='A\B\C'")");
     args = *Args::from_atfile("at_file", Args::AtFileFormat::msvc);
     CHECK(args.size() == 1);
-    CHECK(args[0] == "-DDIRSEP='\\\\'");
+    CHECK(args[0] == R"(-DDIRSEP='A\B\C')");
+  }
+
+  SUBCASE("Backslash can escape backslash in alternate format")
+  {
+    util::write_file("at_file", R"(/Fo"N.dir\Release\\")");
+    args = *Args::from_atfile("at_file", Args::AtFileFormat::msvc);
+    CHECK(args.size() == 1);
+    CHECK(args[0] == R"(/FoN.dir\Release\)");
   }
 }
 


### PR DESCRIPTION
Parse correctly backslash escaped by backslash as in `/Fo"Dir\Dir\\"`.

The flag in the unit test `/Fo"N.dir\Release\\"` is taken from .rsp from VS22 project build. VS22 solution was generated by cmake 3.26.4. I'm not sure what is driving the use of the trailing backslash in the path used in `/Fo` flag, but these cases are definitely occurring in the wild for us.

I wasn't able to find spec for this case, but these rsp files with these escapes are correctly handled by CL. It makes sense that backslash can escape backslash, because otherwise it would not be possible to have backslash before `"` as the trailing backslash would otherwise escape `"`.

Cheers,
Jiri

[![image](https://user-images.githubusercontent.com/44769714/83034194-45548080-a038-11ea-9960-de502a30d89d.png)](http://www.ptc.com/)
**Jiri Hörner**
Senior Software Development Engineer, Vuforia

jhoerner@ptc.com

[vuforia.com](http://www.vuforia.com/)

---
Parametric Technology Gesellschaft m.b.H., Ungargasse 37, 1030 Wien, Austria. Firmensitz: Wien, FN: 111171 m, Firmenbuchgericht: Handelsgericht Wien.
 
The information contained in this email transmission is confidential and may be privileged. If you are not the intended recipient, any use, dissemination, distribution, publication, or copying of the information contained in this email is strictly prohibited.  If you have received this email in error, please immediately notify me by calling the above number and delete the email from your system. Thank you for your co-operation.

Copyright © 2020 PTC Inc. and/or all its affiliates or subsidiaries. All rights reserved
