### PR TITLE
fix: How nvcc handles host warnings by adding Xcompiler and --Werror.

### DIFF
--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -52,9 +52,10 @@ struct CompOpt
 };
 
 const CompOpt compopts[] = {
-  {"--Werror", TAKES_ARG},                             // nvcc
+  {"--Werror", TAKES_ARG | AFFECTS_COMP},              // nvcc
   {"--analyze", TOO_HARD},                             // Clang
   {"--compiler-bindir", AFFECTS_CPP | TAKES_ARG},      // nvcc
+  {"--compiler-options", AFFECTS_CPP | TAKES_ARG},     // nvcc
   {"--config", TAKES_ARG},                             // Clang
   {"--gcc-toolchain=", TAKES_CONCAT_ARG | TAKES_PATH}, // Clang
   {"--libdevice-directory", AFFECTS_CPP | TAKES_ARG},  // nvcc
@@ -92,6 +93,7 @@ const CompOpt compopts[] = {
   {"-Wno-error", AFFECTS_COMP},
   {"-Xassembler", TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},
   {"-Xclang", TAKES_ARG},
+  {"-Xcompiler", AFFECTS_CPP | TAKES_ARG}, // nvcc
   {"-Xlinker", TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},
   {"-Xpreprocessor", AFFECTS_CPP | TOO_HARD_DIRECT | TAKES_ARG},
   {"-Yc", TAKES_ARG | TOO_HARD},                                    // msvc

--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -569,6 +569,42 @@ TEST_CASE("cuda_option_file")
   CHECK(result.compiler_args.to_string() == "nvcc -g -Wall -DX -c");
 }
 
+TEST_CASE("nvcc_warning_flags_short")
+{
+  // With -Werror. This should conflict with host's -Werror flag.
+  TestContext test_context;
+  Context ctx;
+  ctx.config.set_compiler_type(CompilerType::nvcc);
+  ctx.orig_args =
+    Args::from_string("nvcc -Werror all-warnings -Xcompiler -Werror -c foo.cu");
+  util::write_file("foo.cu", "");
+  const ProcessArgsResult result = process_args(ctx);
+
+  CHECK(!result.error);
+  CHECK(result.preprocessor_args.to_string() == "nvcc -Xcompiler -Werror");
+  CHECK(result.extra_args_to_hash.to_string() == "-Werror all-warnings");
+  CHECK(result.compiler_args.to_string()
+        == "nvcc -Werror all-warnings -Xcompiler -Werror -c");
+}
+
+TEST_CASE("nvcc_warning_flags_long")
+{
+  // With --Werror. This shouldn't conflict with host's -Werror flag.
+  TestContext test_context;
+  Context ctx;
+  ctx.config.set_compiler_type(CompilerType::nvcc);
+  ctx.orig_args = Args::from_string(
+    "nvcc --Werror all-warnings -Xcompiler -Werror -c foo.cu");
+  util::write_file("foo.cu", "");
+  const ProcessArgsResult result = process_args(ctx);
+
+  CHECK(!result.error);
+  CHECK(result.preprocessor_args.to_string() == "nvcc -Xcompiler -Werror");
+  CHECK(result.extra_args_to_hash.to_string() == "--Werror all-warnings");
+  CHECK(result.compiler_args.to_string()
+        == "nvcc --Werror all-warnings -Xcompiler -Werror -c");
+}
+
 TEST_CASE("-Xclang")
 {
   TestContext test_context;


### PR DESCRIPTION
This PR addresses a bug that was uncovered while trying to enable `Werror` for both nvcc and the host compiler:

```bash
ccache nvcc -Werror all-warnings -Xcompiler -Werror -c foo.cu
```
```text
...
[2023-06-19T10:25:56.473230 5474 ] Command line: ccache nvcc -Werror all-warnings -Xcompiler -Werror -c foo.cu
[2023-06-19T10:25:56.473259 5474 ] Hostname: scrubbed
[2023-06-19T10:25:56.473270 5474 ] Working directory: /tmp
[2023-06-19T10:25:56.473281 5474 ] Compiler type: nvcc
[2023-06-19T10:25:56.473374 5474 ] No -c option found
[2023-06-19T10:25:56.473401 5474 ] Failed; falling back to running the real compiler
...
```
The primary change was defining `-Xcompiler/--compiler-options` as flags that take arguments. Modifications or changes are welcome - I'm by no means an expert with this codebase.