### PR TITLE
feat: Expand  environment variables in debug_dir configuration entry

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -981,7 +981,7 @@ Config::set_item(const std::string& key,
     break;
 
   case ConfigItem::debug_dir:
-    m_debug_dir = value;
+    m_debug_dir = Util::expand_environment_variables(value);
     break;
 
   case ConfigItem::depend_mode:

--- a/unittest/test_Config.cpp
+++ b/unittest/test_Config.cpp
@@ -109,6 +109,7 @@ TEST_CASE("Config::update_from_file")
     "compression=false\n"
     "compression_level= 2\n"
     "cpp_extension = .foo\n"
+    "debug_dir = $USER$/${USER}/.ccache_debug\n"
     "depend_mode = true\n"
     "direct_mode = false\n"
     "disable = true\n"
@@ -150,6 +151,7 @@ TEST_CASE("Config::update_from_file")
   CHECK_FALSE(config.compression());
   CHECK(config.compression_level() == 2);
   CHECK(config.cpp_extension() == ".foo");
+  CHECK(config.debug_dir() == FMT("{0}$/{0}/.ccache_debug", user));
   CHECK(config.depend_mode());
   CHECK_FALSE(config.direct_mode());
   CHECK(config.disable());


### PR DESCRIPTION
Config directives such as cache_dir expand environment variables in their values ; debug_dir does not.
This is actually useful for me as I have  a ccache config I distribute to developers , I use their home directory for some ccache directory configs but could not do it for debug_dir.