### PR TITLE
feat: Allow specifying debug level

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -681,6 +681,15 @@ is `/home/user` and the object file is `build/output.o` then the debug log will
 be written to `/example/home/user/build/output.o.ccache-log`. See also
 _<<Cache debugging>>_.
 
+[#config_debug_level]
+*debug_level* (*CCACHE_DEBUGLEVEL*)::
+
+    Specifies amount of information dumped when the <<config_debug,debug mode>>
+    is enabled. If set 1, only `<objectfile>.<timestamp>.ccache-log` files with
+    per-file caching statistics are dumped. Otherwise, all possible debug
+    data is dumped. See _<<Cache debugging>>_ for more information. The default
+    is 2.
+
 [#config_depend_mode]
 *depend_mode* (*CCACHE_DEPEND* or *CCACHE_NODEPEND*, see _<<Boolean values>>_ above)::
 
@@ -1678,6 +1687,12 @@ Log for this object file.
  The timestamp format is
 `<year><month><day>_<hour><minute><second>_<microsecond>`.
 
+`<objectfile>.<timestamp>.ccache-log` files can be useful for checking
+caching results for every file. If you only need such statistics and don't
+need `<objectfile>.<timestamp>.ccache-input-*` files then you can set
+<<config_debug,*debug_level*>> (or environment variable `CCACHE_DEBUGLEVEL`) 
+to 1.
+
 If <<config_debug_dir,*debug_dir*>> (environment variable `CCACHE_DEBUGDIR`) is
 set, the files above will be written to that directory with full absolute paths
 instead of next to the object file.
@@ -1701,7 +1716,6 @@ something like this:
 4. Compare the `<objectfile>.<timestamp>.ccache-input-text` files for the two
    builds. This together with the `<objectfile>.<timestamp>.ccache-log` files
    should give you some clues about what is happening.
-
 
 == Compiling in different directories
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -81,6 +81,7 @@ enum class ConfigItem {
   cpp_extension,
   debug,
   debug_dir,
+  debug_level,
   depend_mode,
   direct_mode,
   disable,
@@ -136,6 +137,7 @@ const std::unordered_map<std::string, ConfigKeyTableEntry> k_config_key_table =
     {"cpp_extension", {ConfigItem::cpp_extension}},
     {"debug", {ConfigItem::debug}},
     {"debug_dir", {ConfigItem::debug_dir}},
+    {"debug_level", {ConfigItem::debug_level}},
     {"depend_mode", {ConfigItem::depend_mode}},
     {"direct_mode", {ConfigItem::direct_mode}},
     {"disable", {ConfigItem::disable}},
@@ -184,6 +186,7 @@ const std::unordered_map<std::string, std::string> k_env_variable_table = {
   {"CPP2", "run_second_cpp"},
   {"DEBUG", "debug"},
   {"DEBUGDIR", "debug_dir"},
+  {"DEBUGLEVEL", "debug_level"},
   {"DEPEND", "depend_mode"},
   {"DIR", "cache_dir"},
   {"DIRECT", "direct_mode"},
@@ -785,6 +788,9 @@ Config::get_string_value(const std::string& key) const
   case ConfigItem::debug_dir:
     return m_debug_dir;
 
+  case ConfigItem::debug_level:
+    return FMT("{}", m_debug_level);
+
   case ConfigItem::depend_mode:
     return format_bool(m_depend_mode);
 
@@ -1021,6 +1027,11 @@ Config::set_item(const std::string& key,
 
   case ConfigItem::debug_dir:
     m_debug_dir = value;
+    break;
+
+  case ConfigItem::debug_level:
+    m_debug_level = util::value_or_throw<core::Error>(
+      util::parse_unsigned(value, std::nullopt, std::nullopt, "debug_level"));
     break;
 
   case ConfigItem::depend_mode:

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -64,6 +64,7 @@ public:
   const std::string& cpp_extension() const;
   bool debug() const;
   const std::string& debug_dir() const;
+  uint8_t debug_level() const;
   bool depend_mode() const;
   bool direct_mode() const;
   bool disable() const;
@@ -178,6 +179,7 @@ private:
   std::string m_cpp_extension;
   bool m_debug = false;
   std::string m_debug_dir;
+  uint8_t m_debug_level = 2;
   bool m_depend_mode = false;
   bool m_direct_mode = true;
   bool m_disable = false;
@@ -303,6 +305,12 @@ inline const std::string&
 Config::debug_dir() const
 {
   return m_debug_dir;
+}
+
+inline uint8_t
+Config::debug_level() const
+{
+  return m_debug_level;
 }
 
 inline bool

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -220,7 +220,7 @@ init_hash_debug(Context& ctx,
                 std::string_view section_name,
                 FILE* debug_text_file)
 {
-  if (!ctx.config.debug()) {
+  if (!ctx.config.debug() || ctx.config.debug_level() < 2) {
     return;
   }
 
@@ -2500,7 +2500,7 @@ do_cache_compilation(Context& ctx)
   LOG("Object file: {}", ctx.args_info.output_obj);
   MTR_META_THREAD_NAME(ctx.args_info.output_obj.c_str());
 
-  if (ctx.config.debug()) {
+  if (ctx.config.debug() && ctx.config.debug_level() >= 2) {
     const auto path = prepare_debug_path(ctx.config.debug_dir(),
                                          ctx.time_of_invocation,
                                          ctx.args_info.orig_output_obj,

--- a/unittest/test_Config.cpp
+++ b/unittest/test_Config.cpp
@@ -51,6 +51,7 @@ TEST_CASE("Config: default values")
   CHECK(config.cpp_extension().empty());
   CHECK(!config.debug());
   CHECK(config.debug_dir().empty());
+  CHECK(config.debug_level() == 2);
   CHECK(!config.depend_mode());
   CHECK(config.direct_mode());
   CHECK(!config.disable());
@@ -111,6 +112,7 @@ TEST_CASE("Config::update_from_file")
     "compression_level= 2\n"
     "cpp_extension = .foo\n"
     "debug_dir = $USER$/${USER}/.ccache_debug\n"
+    "debug_level = 2\n"
     "depend_mode = true\n"
     "direct_mode = false\n"
     "disable = true\n"
@@ -153,6 +155,7 @@ TEST_CASE("Config::update_from_file")
   CHECK(config.compression_level() == 2);
   CHECK(config.cpp_extension() == ".foo");
   CHECK(config.debug_dir() == FMT("{0}$/{0}/.ccache_debug", user));
+  CHECK(config.debug_level() == 2);
   CHECK(config.depend_mode());
   CHECK_FALSE(config.direct_mode());
   CHECK(config.disable());
@@ -396,6 +399,7 @@ TEST_CASE("Config::visit_items")
     "cpp_extension = ce\n"
     "debug = false\n"
     "debug_dir = /dd\n"
+    "debug_level = 2\n"
     "depend_mode = true\n"
     "direct_mode = false\n"
     "disable = true\n"
@@ -457,6 +461,7 @@ TEST_CASE("Config::visit_items")
     "(test.conf) cpp_extension = ce",
     "(test.conf) debug = false",
     "(test.conf) debug_dir = /dd",
+    "(test.conf) debug_level = 2",
     "(test.conf) depend_mode = true",
     "(test.conf) direct_mode = false",
     "(test.conf) disable = true",


### PR DESCRIPTION
... via debug_level option or CCACHE_DEBUGLEVEL env variable.

With debug_level=2 (default), ccache behavior in debug mode is not changed.

With debug_level=1, ccache will only dump *.ccache-log files (and not the *input* ones). This is useful for getting per-file caching results.

Closes #1285 

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
