### PR TITLE
fix: relative path handling for clang PCH header

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -425,6 +425,7 @@ process_option_arg(const Context& ctx,
   if (arg == "-Xclang" && i + 1 < args.size()
       && (args[i + 1] == "-emit-pch" || args[i + 1] == "-emit-pth"
           || args[i + 1] == "-include-pch" || args[i + 1] == "-include-pth"
+          || args[i + 1] == "-include"
           || args[i + 1] == "-fno-pch-timestamp")) {
     if (compopt_affects_compiler_output(args[i + 1])) {
       state.compiler_only_args.push_back(args[i]);


### PR DESCRIPTION
cmake may generate both -include and -include-pch. Example:

c++ ... -Xclang -include-pch -Xclang /abs/path/cmake_pch.hxx.pch
        -Xclang -include -Xclang /abs/path/cmake_pch.hxx ...

Both paths needs to be converted to relative path if CCACHE_BASEDIR is set for better cache hit rate in some CI systems.