### PR TITLE
fix: Allow wildcards in port url validation

### DIFF
--- a/src/third_party/url.cpp
+++ b/src/third_party/url.cpp
@@ -375,12 +375,12 @@ inline std::string normalize_IPv6(const std::string &s) {
 
 
 inline bool is_port(const char *s, const char *e) {
-    return is_uint(s,e,65535) && s==e;
+    return *s == '*' || (is_uint(s,e,65535) && s==e);
 }
 
 
 inline bool is_port(const std::string &s) {
-    return is_port(s.data(),s.data()+s.length());
+    return s == "*" || (is_port(s.data(),s.data()+s.length()));
 }
 
 

--- a/test/suites/remote_http.bash
+++ b/test/suites/remote_http.bash
@@ -140,7 +140,7 @@ SUITE_remote_http() {
 
     start_http_server 12780 remote1
     start_http_server 12781 remote2
-    export CCACHE_REMOTE_STORAGE="http://localhost:*|shards=12780,12781"
+    export CCACHE_REMOTE_STORAGE="http://localhost:*|shards=12780,12781(2)"
 
     $CCACHE_COMPILE -c test.c
     expect_stat direct_cache_hit 0

--- a/test/suites/remote_redis.bash
+++ b/test/suites/remote_redis.bash
@@ -80,6 +80,18 @@ SUITE_remote_redis() {
     expect_number_of_redis_cache_entries 2 "$redis_url" # result + manifest
 
     # -------------------------------------------------------------------------
+    TEST "Sharding"
+
+    start_redis_server 7777
+    start_redis_server 7778
+    export CCACHE_REMOTE_STORAGE="redis://localhost:*|shards=7777,7778"
+
+    $CCACHE_COMPILE -c test.c
+    expect_stat direct_cache_hit 0
+    expect_stat cache_miss 1
+    expect_stat files_in_cache 2
+
+    # -------------------------------------------------------------------------
     TEST "Password"
 
     port=7777

--- a/test/suites/remote_url.bash
+++ b/test/suites/remote_url.bash
@@ -25,6 +25,20 @@ SUITE_remote_url() {
     expect_contains stderr.log "Cannot parse URL"
 
     # -------------------------------------------------------------------------
+    TEST "Reject invalid port"
+
+    export CCACHE_REMOTE_STORAGE="http://localhost:*"
+    $CCACHE_COMPILE -c test.c 2>stderr.log
+    expect_contains stderr.log "Cannot parse URL"
+
+    # -------------------------------------------------------------------------
+    TEST "Reject invalid shard url"
+
+    export CCACHE_REMOTE_STORAGE="redis://localhost:*|shards=foo,bar"
+    $CCACHE_COMPILE -c test.c 2>stderr.log
+    expect_contains stderr.log "Cannot parse URL"
+
+    # -------------------------------------------------------------------------
 if $RUN_WIN_XFAIL; then
     TEST "Reject missing scheme"
 


### PR DESCRIPTION
Closes #1321

Separated the http client/server log based on port number, since otherwise you could only start one.