### PR TITLE
fix: src/InodeCache.cpp: avoid sign-compare warning on FreeBSD

### DIFF
--- a/src/InodeCache.cpp
+++ b/src/InodeCache.cpp
@@ -416,7 +416,8 @@ InodeCache::initialize()
         LOG("fstatfs failed: {}", strerror(errno));
         return false;
       }
-      if (buf.f_bavail * 512 < k_min_fs_mib_left * 1024 * 1024) {
+      if (static_cast<uint64_t>(buf.f_bavail) * 512
+          < k_min_fs_mib_left * 1024 * 1024) {
         LOG("Filesystem has less than {} MiB free space, not using inode cache",
             k_min_fs_mib_left);
         return false;


### PR DESCRIPTION
As on FreeBSD 13.2 `statfs.f_bavail` is signed, so InodeCache.cpp cannot be compiled but gets a sign-compare warning:

  src/InodeCache.cpp:409:30: error: comparison of integers of different signs:
    'long' and 'unsigned long' [-Werror,-Wsign-compare]
      if (buf.f_bavail * 512 < k_min_fs_mib_left * 1024 * 1024) {
          ~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~bareos
  1 error generated.

The problem is avoided by using static_cast to unsigned long on FreeBSD. 
To detect FreeBSD, now `sys/param.h` is included unconditionally.
