### PR TITLE
fix: Windows is_absolute_path() crash on drive letter

### DIFF
--- a/src/util/path.cpp
+++ b/src/util/path.cpp
@@ -88,7 +88,7 @@ bool
 is_absolute_path(std::string_view path)
 {
 #ifdef _WIN32
-  if (path.length() >= 2 && path[1] == ':'
+  if (path.length() >= 3 && path[1] == ':'
       && (path[2] == '/' || path[2] == '\\')) {
     return true;
   }

--- a/unittest/test_util_path.cpp
+++ b/unittest/test_util_path.cpp
@@ -36,9 +36,11 @@ TEST_CASE("util::is_absolute_path")
 {
 #ifdef _WIN32
   CHECK(util::is_absolute_path("C:/"));
+  CHECK(util::is_absolute_path("C:\\"));
   CHECK(util::is_absolute_path("C:\\foo/fie"));
   CHECK(util::is_absolute_path("/C:\\foo/fie")); // MSYS/Cygwin path
   CHECK(!util::is_absolute_path(""));
+  CHECK(!util::is_absolute_path("C:"));
   CHECK(!util::is_absolute_path("foo\\fie/fum"));
   CHECK(!util::is_absolute_path("C:foo/fie"));
 #endif
@@ -48,7 +50,7 @@ TEST_CASE("util::is_absolute_path")
   CHECK(!util::is_absolute_path("foo/fie"));
 }
 
-TEST_CASE("util::is_absolute_path")
+TEST_CASE("util::is_full_path")
 {
   CHECK(!util::is_full_path(""));
   CHECK(!util::is_full_path("foo"));


### PR DESCRIPTION
Prevents `path::is_absolute_path(path)` from reading characters further than `path` string length.