### PR TITLE
fix: cmake -DSTATIC_LINK=ON on Linux/macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ endif()
 include(CIBuildType)
 include(DefaultBuildType)
 include(UseFastestLinker)
+include(StaticLinkSupport)
 include(StandardSettings)
 include(StandardWarnings)
 
@@ -79,35 +80,6 @@ include(StandardWarnings)
 include(InstallDirs)
 include(GenerateConfigurationFile)
 include(GenerateVersionFile)
-
-#
-# Static link configuration
-#
-
-set(STATIC_LINK_DEFAULT OFF)
-if(WIN32)
-  set(STATIC_LINK_DEFAULT ON)
-endif()
-
-option(STATIC_LINK "Prefer linking libraries statically" ${STATIC_LINK_DEFAULT})
-
-if(STATIC_LINK)
-  list(INSERT CMAKE_FIND_LIBRARY_SUFFIXES 0 "${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  set(CMAKE_LINK_SEARCH_START_STATIC ON)
-
-  # Link MSVC runtime statically.
-  if(MSVC)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-  # Link MINGW runtime statically.
-  elseif(WIN32)
-    if((CMAKE_CXX_COMPILER_ID STREQUAL GNU) OR (CMAKE_CXX_COMPILER_ID STREQUAL Clang))
-      list(APPEND CCACHE_EXTRA_LIBS -static-libgcc -static-libstdc++ -static -lwinpthread -dynamic)
-    endif()
-    if(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-      list(APPEND CCACHE_EXTRA_LIBS -fuse-ld=lld)
-    endif()
-  endif()
-endif()
 
 #
 # Third party

--- a/cmake/StaticLinkSupport.cmake
+++ b/cmake/StaticLinkSupport.cmake
@@ -1,0 +1,35 @@
+# This sets up support for maximum static linking of dependent libraries on
+# supported platforms.
+
+set(STATIC_LINK_DEFAULT OFF)
+if(WIN32)
+  set(STATIC_LINK_DEFAULT ON)
+endif()
+
+option(STATIC_LINK "Link most libraries statically" ${STATIC_LINK_DEFAULT})
+
+if(NOT STATIC_LINK)
+  return()
+endif()
+
+set(CMAKE_LINK_SEARCH_START_STATIC ON)
+set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+if(WIN32)
+  # Link MSVC runtime statically.
+  if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  # Link MINGW runtime statically.
+  else()
+    if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang)\$")
+      list(APPEND CCACHE_EXTRA_LIBS -static-libgcc -static-libstdc++ -static -lwinpthread -dynamic)
+    endif()
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      list(APPEND CCACHE_EXTRA_LIBS -fuse-ld=lld)
+    endif()
+  endif()
+else()
+  if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang)\$")
+    list(APPEND CCACHE_EXTRA_LIBS -static-libgcc -static-libstdc++)
+  endif()
+endif()


### PR DESCRIPTION
Make linking dependent libraries as static a hard requirement when
STATIC_LINK is ON, as opposed to the previous behavior of falling back
to dynamic libraries.

A side-effect of this is that if only a dynamic zstd/hiredis is
available on a system, it will not be found, and the download and build
code will be invoked to build a static version from the internet.

Add a general case to handle Linux, macOS and similar by linking
libgcc/libstdc++ statically on gcc/clang.

Move the code into cmake/StaticLinkSupport.cmake and include it from the
main file.

Fix #1330