### PR TITLE
feat: cmake -DOFFLINE=TRUE for offline builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,11 +112,22 @@ endif()
 #
 # Third party
 #
+
 set(ZSTD_FROM_INTERNET AUTO CACHE STRING "Download and use libzstd from the Internet")
 set_property(CACHE ZSTD_FROM_INTERNET PROPERTY STRINGS AUTO ON OFF)
 
 set(HIREDIS_FROM_INTERNET AUTO CACHE STRING "Download and use libhiredis from the Internet")
 set_property(CACHE HIREDIS_FROM_INTERNET PROPERTY STRINGS AUTO ON OFF)
+
+option(
+  OFFLINE "Do not download anything from the internet"
+  "$(FETCHCONTENT_FULLY_DISCONNECTED}"
+)
+if(OFFLINE)
+  set(FETCHCONTENT_FULLY_DISCONNECTED ON)
+  set(ZSTD_FROM_INTERNET OFF)
+  set(HIREDIS_FROM_INTERNET OFF)
+endif()
 
 find_package(zstd 1.1.2 MODULE REQUIRED)
 

--- a/cmake/Findhiredis.cmake
+++ b/cmake/Findhiredis.cmake
@@ -51,6 +51,12 @@ else()
   elseif(HIREDIS_FROM_INTERNET STREQUAL "AUTO")
     message(STATUS "*** WARNING ***: Using hiredis from the Internet because it was not found and HIREDIS_FROM_INTERNET is AUTO")
     set(do_download TRUE)
+  else()
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(
+      hiredis
+      REQUIRED_VARS HIREDIS_LIBRARY HIREDIS_INCLUDE_DIR
+    )
   endif()
 endif()
 

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -46,6 +46,12 @@ else()
   elseif(ZSTD_FROM_INTERNET STREQUAL "AUTO")
     message(STATUS "*** WARNING ***: Using zstd from the Internet because it was not found and ZSTD_FROM_INTERNET is AUTO")
     set(do_download TRUE)
+  else()
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(
+      zstd
+      REQUIRED_VARS ZSTD_LIBRARY ZSTD_INCLUDE_DIR
+    )
   endif()
 endif()
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -14,9 +14,10 @@ To build ccache you need:
 - [libzstd](http://www.zstd.net). If you don't have libzstd installed and can't
   or don't want to install it in a standard system location, it will be
   automatically downloaded, built and linked statically as part of the build
-  process. To disable this, pass `-DZSTD_FROM_INTERNET=OFF` to `cmake`, or pass
-  `-DZSTD_FROM_INTERNET=ON` to force downloading. You can also install zstd in a
-  custom path and pass `-DCMAKE_PREFIX_PATH=/some/custom/path` to `cmake`.
+  process. To disable this, pass `-DOFFLINE=TRUE` or `-DZSTD_FROM_INTERNET=OFF`
+  to `cmake`, or pass `-DZSTD_FROM_INTERNET=ON` to force downloading. You can
+  also install zstd in a custom path and pass
+  `-DCMAKE_PREFIX_PATH=/some/custom/path` to `cmake`.
 
   To link libzstd statically (and you have a static libzstd available), pass
   `-DSTATIC_LINK=ON` to `cmake`. This is the default on Windows. Alternatively,
@@ -25,12 +26,13 @@ To build ccache you need:
 Optional:
 
 - [hiredis](https://github.com/redis/hiredis) for the Redis storage backend. If
-  you don't have libhiredis installed and can't or don't want to install it in a
-  standard system location, it will be automatically downloaded, built and
+  you don't have libhiredis installed and can't or don't want to install it in
+  a standard system location, it will be automatically downloaded, built and
   linked statically as part of the build process. To disable this, pass
-  `-DHIREDIS_FROM_INTERNET=OFF` to `cmake`, or pass `-DHIREDIS_FROM_INTERNET=ON`
-  to force downloading.. You can also install hiredis in a custom path and pass
-  `-DCMAKE_PREFIX_PATH=/some/custom/path` to `cmake`.
+  `-DOFFLINE=TRUE` or `-DHIREDIS_FROM_INTERNET=OFF` to `cmake`, or pass
+  `-DHIREDIS_FROM_INTERNET=ON` to force downloading. You can also install
+  hiredis in a custom path and pass `-DCMAKE_PREFIX_PATH=/some/custom/path` to
+  `cmake`.
 
   To link libhiredis statically (and you have a static libhiredis available),
   pass `-DSTATIC_LINK=ON` to `cmake`. This is the default on Windows.


### PR DESCRIPTION
Add the cmake option OFFLINE, defaulting to the value of the standard
variable FETCHCONTENT_FULLY_DISCONNECTED, which is OFF by default, to
disable downloading anything from the internet.

When ON, set FETCHCONTENT_FULLY_DISCONNECTED to ON, ZSTD_FROM_INTERNET
to OFF and HIREDIS_FROM_INTERNET to OFF.

When downloading is OFF and either library is not found, throw an error
using find_package_handle_standard_args().

Add the option to INSTALL.md doc.