### PR TITLE
fix: devmode unused function warnings on new MSVC

### DIFF
--- a/cmake/DevModeWarnings.cmake
+++ b/cmake/DevModeWarnings.cmake
@@ -121,5 +121,7 @@ elseif(MSVC)
     /wd4706
     # Non-underscore-prefixed POSIX functions:
     /wd4996
+    # Dead local functions overridden by headers:
+    /wd4505
   )
 endif()


### PR DESCRIPTION
MSVC apparently has overrides for the two definitions of operator== in
unittest/test_util_string.cpp in the <utility> header, raising a warning
about them being local unused functions:

https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4505?view=msvc-170

Disable this warning type in cmake/DevModeWarnings.cmake for MSVC.