### PR TITLE
(feat)add support for clang --analyze

### DIFF
--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -60,6 +60,7 @@ struct ArgumentProcessingState
   bool found_c_opt = false;
   bool found_dc_opt = false;
   bool found_S_opt = false;
+  bool found_analyze_opt = false;
   bool found_pch = false;
   bool found_fpch_preprocess = false;
   bool found_Yu = false;
@@ -527,6 +528,12 @@ process_option_arg(const Context& ctx,
   if (arg == "-S") {
     state.common_args.push_back(args[i]);
     state.found_S_opt = true;
+    return Statistic::none;
+  }
+
+  // --analyze changes the default extension too
+  if (arg == "--analyze") {
+    state.found_analyze_opt = true;
     return Statistic::none;
   }
 
@@ -1131,7 +1138,8 @@ process_arg(const Context& ctx,
     if (supported_source_extension(args[i])) {
       LOG("Multiple input files: {} and {}", args_info.input_file, args[i]);
       return Statistic::multiple_source_files;
-    } else if (!state.found_c_opt && !state.found_dc_opt) {
+    } else if (!state.found_c_opt && !state.found_dc_opt
+               && !state.found_analyze_opt) {
       LOG("Called for link with {}", args[i]);
       if (args[i].find("conftest.") != std::string::npos) {
         return Statistic::autoconf_test;
@@ -1221,8 +1229,14 @@ process_args(Context& ctx)
   }
 
   if (output_obj_by_source && !args_info.input_file.empty()) {
-    std::string_view extension =
-      state.found_S_opt ? ".s" : get_default_object_file_extension(ctx.config);
+    std::string_view extension;
+    if (state.found_S_opt) {
+      extension = ".s";
+    } else if (state.found_analyze_opt) {
+      extension = ".plist";
+    } else {
+      extension = get_default_object_file_extension(ctx.config);
+    }
     args_info.output_obj +=
       Util::change_extension(Util::base_name(args_info.input_file), extension);
   }
@@ -1309,7 +1323,7 @@ process_args(Context& ctx)
 
   // -fsyntax-only/-Zs does not need -c
   if (!state.found_c_opt && !state.found_dc_opt && !state.found_S_opt
-      && !state.found_syntax_only) {
+      && !state.found_syntax_only && !state.found_analyze_opt) {
     if (args_info.output_is_precompiled_header) {
       state.common_args.push_back("-c");
     } else {
@@ -1511,6 +1525,10 @@ process_args(Context& ctx)
 
   if (state.found_dc_opt) {
     compiler_args.push_back("-dc");
+  }
+
+  if (state.found_analyze_opt) {
+    compiler_args.push_back("--analyze");
   }
 
   if (!state.xarch_args.empty()) {

--- a/src/argprocessing.cpp
+++ b/src/argprocessing.cpp
@@ -533,6 +533,7 @@ process_option_arg(const Context& ctx,
 
   // --analyze changes the default extension too
   if (arg == "--analyze") {
+    state.common_args.push_back(args[i]);
     state.found_analyze_opt = true;
     return Statistic::none;
   }
@@ -1230,10 +1231,10 @@ process_args(Context& ctx)
 
   if (output_obj_by_source && !args_info.input_file.empty()) {
     std::string_view extension;
-    if (state.found_S_opt) {
-      extension = ".s";
-    } else if (state.found_analyze_opt) {
+    if (state.found_analyze_opt) {
       extension = ".plist";
+    } else if (state.found_S_opt) {
+      extension = ".s";
     } else {
       extension = get_default_object_file_extension(ctx.config);
     }
@@ -1525,10 +1526,6 @@ process_args(Context& ctx)
 
   if (state.found_dc_opt) {
     compiler_args.push_back("-dc");
-  }
-
-  if (state.found_analyze_opt) {
-    compiler_args.push_back("--analyze");
   }
 
   if (!state.xarch_args.empty()) {

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -53,6 +53,7 @@ struct CompOpt
 
 const CompOpt compopts[] = {
   {"--Werror", TAKES_ARG | AFFECTS_COMP},              // nvcc
+  {"--analyzer-output", TOO_HARD},                     // Clang
   {"--compiler-bindir", AFFECTS_CPP | TAKES_ARG},      // nvcc
   {"--compiler-options", AFFECTS_CPP | TAKES_ARG},     // nvcc
   {"--config", TAKES_ARG},                             // Clang

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -53,7 +53,6 @@ struct CompOpt
 
 const CompOpt compopts[] = {
   {"--Werror", TAKES_ARG | AFFECTS_COMP},              // nvcc
-  {"--analyze", TOO_HARD},                             // Clang
   {"--compiler-bindir", AFFECTS_CPP | TAKES_ARG},      // nvcc
   {"--compiler-options", AFFECTS_CPP | TAKES_ARG},     // nvcc
   {"--config", TAKES_ARG},                             // Clang

--- a/unittest/test_compopt.cpp
+++ b/unittest/test_compopt.cpp
@@ -51,6 +51,7 @@ TEST_CASE("too_hard")
   CHECK(compopt_too_hard("-save-temps=cwd"));
   CHECK(compopt_too_hard("-save-temps=obj"));
   CHECK(compopt_too_hard("-analyze"));
+  CHECK(compopt_too_hard("--analyzer-output"));
   CHECK(!compopt_too_hard("--analyze"));
   CHECK(!compopt_too_hard("-MD"));
   CHECK(!compopt_too_hard("-fprofile-arcs"));

--- a/unittest/test_compopt.cpp
+++ b/unittest/test_compopt.cpp
@@ -51,7 +51,7 @@ TEST_CASE("too_hard")
   CHECK(compopt_too_hard("-save-temps=cwd"));
   CHECK(compopt_too_hard("-save-temps=obj"));
   CHECK(compopt_too_hard("-analyze"));
-  CHECK(compopt_too_hard("--analyze"));
+  CHECK(!compopt_too_hard("--analyze"));
   CHECK(!compopt_too_hard("-MD"));
   CHECK(!compopt_too_hard("-fprofile-arcs"));
   CHECK(!compopt_too_hard("-ftest-coverage"));


### PR DESCRIPTION
add support for static analysis option in clang: --analyze
static analysis is performed separately from compilation and usually takes more time,
but its results can be captured the same way as regular compilation results: some
warnings may be printed and result is stored in .plist file instead of .o

this is partial solution for static analysis: -analyze option for cc1 is not supported
as I am macOS using Xcode, so modules are always enabled and I had to use direct mode
--analyzer-output option is also not supported, only default .plist format

I have not added much of the testing as I found no similar tests and not sure what would
 be needed. If you provide some hints or guidance here I probably could fix that