### PR TITLE
feat: Handle Texas Instruments c6000 compiler arguments (#1352)

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -537,6 +537,7 @@ compiler_type_to_string(CompilerType compiler_type)
     CASE(icl);
     CASE(msvc);
     CASE(nvcc);
+    CASE(ti);
     CASE(other);
   }
 #undef CASE

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -41,6 +41,7 @@ enum class CompilerType {
   icl,
   msvc,
   nvcc,
+  ti,
   other
 };
 

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -283,6 +283,8 @@ guess_compiler(std::string_view path)
     return CompilerType::icl;
   } else if (name == "cl") {
     return CompilerType::msvc;
+  } else if (name == "cl6x") {
+    return CompilerType::ti;
   } else {
     return CompilerType::other;
   }
@@ -1066,6 +1068,8 @@ to_cache(Context& ctx,
 {
   if (ctx.config.is_compiler_group_msvc()) {
     args.push_back(fmt::format("-Fo{}", ctx.args_info.output_obj));
+  } else if (ctx.config.compiler_type() == CompilerType::ti) {
+    args.push_back(fmt::format("--output_file={}", ctx.args_info.output_obj));
   } else {
     args.push_back("-o");
     args.push_back(ctx.args_info.output_obj);
@@ -1257,6 +1261,9 @@ get_result_key_from_cpp(Context& ctx, Args& args, Hash& hash)
     if (ctx.config.is_compiler_group_msvc()) {
       args.push_back("-P");
       args.push_back(FMT("-Fi{}", preprocessed_path));
+    } else if (ctx.config.compiler_type() == CompilerType::ti) {
+      args.push_back("--preproc_with_line");
+      args.push_back(FMT("--output_file={}", preprocessed_path));
     } else {
       args.push_back("-E");
       args.push_back("-o");

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -52,15 +52,18 @@ struct CompOpt
 };
 
 const CompOpt compopts[] = {
-  {"--Werror", TAKES_ARG | AFFECTS_COMP},              // nvcc
-  {"--analyze", TOO_HARD},                             // Clang
-  {"--compiler-bindir", AFFECTS_CPP | TAKES_ARG},      // nvcc
-  {"--compiler-options", AFFECTS_CPP | TAKES_ARG},     // nvcc
-  {"--config", TAKES_ARG},                             // Clang
-  {"--gcc-toolchain=", TAKES_CONCAT_ARG | TAKES_PATH}, // Clang
-  {"--libdevice-directory", AFFECTS_CPP | TAKES_ARG},  // nvcc
-  {"--output-directory", AFFECTS_CPP | TAKES_ARG},     // nvcc
+  {"--Werror", TAKES_ARG | AFFECTS_COMP},                           // nvcc
+  {"--analyze", TOO_HARD},                                          // Clang
+  {"--compiler-bindir", AFFECTS_CPP | TAKES_ARG},                   // nvcc
+  {"--compiler-options", AFFECTS_CPP | TAKES_ARG},                  // nvcc
+  {"--config", TAKES_ARG},                                          // Clang
+  {"--gcc-toolchain=", TAKES_CONCAT_ARG | TAKES_PATH},              // Clang
+  {"--include_path=", AFFECTS_CPP | TAKES_CONCAT_ARG | TAKES_PATH}, // TI
+  {"--libdevice-directory", AFFECTS_CPP | TAKES_ARG},               // nvcc
+  {"--output-directory", AFFECTS_CPP | TAKES_ARG},                  // nvcc
   {"--param", TAKES_ARG},
+  {"--preproc_dependency=", TAKES_CONCAT_ARG | TAKES_PATH}, // TI
+  {"--preproc_only", TOO_HARD},                             // TI
   {"--save-temps", TOO_HARD},
   {"--save-temps=cwd", TOO_HARD},
   {"--save-temps=obj", TOO_HARD},


### PR DESCRIPTION
This PR adds basic support for TI c6000 compiler.
With this change ccache is able to produce a direct hit, and fall back to preprocessor mode too. "Called for link" is not an issue as the TI linker is a separate executable (lnk6x).
