### PR TITLE
Fix regexp in direct.bash

### DIFF
--- a/test/suites/direct.bash
+++ b/test/suites/direct.bash
@@ -1227,7 +1227,7 @@ EOF
 
     manifest=`find $CCACHE_DIR -name '*M'`
     if [ -n "$manifest" ]; then
-        data="`$CCACHE --inspect $manifest | grep -E '/dev/(stdout|tty|sda|hda'`"
+        data="`$CCACHE --inspect $manifest | grep -E '/dev/(stdout|tty|sda|hda)'`"
         if [ -n "$data" ]; then
             test_failed "$manifest contained troublesome file(s): $data"
         fi


### PR DESCRIPTION
There was a missing closing paren.