### PR TITLE
Properly exclude false positive typos

### DIFF
--- a/misc/typos.toml
+++ b/misc/typos.toml
@@ -15,5 +15,6 @@ extend-ignore-re = [
     "thi\\\\\\\\rd",
     '"\$newer_file" -ot "\$older_file"',
     "tar -caf",
-    "[/-]Fo",
+    "[/-]Fo\\b",
+    "/FoN\\.",
 ]

--- a/misc/typos.toml
+++ b/misc/typos.toml
@@ -9,12 +9,13 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "clang-analyzer-optin",
-    "/dev/\\(stdout\\|tty\\|sda\\|hda\\)",
-    "in stdout tty sda hda;",
     "seve\\\\nth",
     "thi\\\\\\\\rd",
-    '"\$newer_file" -ot "\$older_file"',
+    " -ot ",
     "tar -caf",
     "[/-]Fo\\b",
     "/FoN\\.",
 ]
+
+[default.extend-words]
+"hda" = "hda"

--- a/misc/typos.toml
+++ b/misc/typos.toml
@@ -1,11 +1,19 @@
-[default.extend-words]
-caf = "caf"
-fo = "fo"
-hda = "hda"
-ot = "ot"
-seve = "seve"
-thi = "thi"
-wronly = "wronly"
-
 [files]
-extend-exclude = ["misc/codespell-allowlist.txt", "src/third_party"]
+extend-exclude = [
+    ".git/",
+    "misc/codespell-allowlist.txt",
+    "src/third_party/",
+]
+ignore-hidden = false
+
+[default]
+extend-ignore-re = [
+    "clang-analyzer-optin",
+    "/dev/\\(stdout\\|tty\\|sda\\|hda\\)",
+    "in stdout tty sda hda;",
+    "seve\\\\nth",
+    "thi\\\\\\\\rd",
+    '"\$newer_file" -ot "\$older_file"',
+    "tar -caf",
+    "[/-]Fo",
+]


### PR DESCRIPTION
Exclude false positives with context. So typos at other places will not be suppressed.

Latest `typos` does not detect any errors.
