### PR TITLE
Add flag to be able to remove cache debug files on hit

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -681,6 +681,13 @@ is `/home/user` and the object file is `build/output.o` then the debug log will
 be written to `/example/home/user/build/output.o.ccache-log`. See also
 _<<Cache debugging>>_.
 
+[#config_debug_hits]
+*debug_hits* (*CCACHE_DEBUGHITS*)::
+
+    If true, keep debug files for cache hits if the <<config_debug,debug mode>>
+    is enabled. If false, the files for hits are deleted - only misses are kept.
+    The default is true.
+
 [#config_debug_level]
 *debug_level* (*CCACHE_DEBUGLEVEL*)::
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -81,6 +81,7 @@ enum class ConfigItem {
   cpp_extension,
   debug,
   debug_dir,
+  debug_hits,
   debug_level,
   depend_mode,
   direct_mode,
@@ -137,6 +138,7 @@ const std::unordered_map<std::string, ConfigKeyTableEntry> k_config_key_table =
     {"cpp_extension", {ConfigItem::cpp_extension}},
     {"debug", {ConfigItem::debug}},
     {"debug_dir", {ConfigItem::debug_dir}},
+    {"debug_hits", {ConfigItem::debug_hits}},
     {"debug_level", {ConfigItem::debug_level}},
     {"depend_mode", {ConfigItem::depend_mode}},
     {"direct_mode", {ConfigItem::direct_mode}},
@@ -186,6 +188,7 @@ const std::unordered_map<std::string, std::string> k_env_variable_table = {
   {"CPP2", "run_second_cpp"},
   {"DEBUG", "debug"},
   {"DEBUGDIR", "debug_dir"},
+  {"DEBUGHITS", "debug_hits"},
   {"DEBUGLEVEL", "debug_level"},
   {"DEPEND", "depend_mode"},
   {"DIR", "cache_dir"},
@@ -788,6 +791,9 @@ Config::get_string_value(const std::string& key) const
   case ConfigItem::debug_dir:
     return m_debug_dir.string();
 
+  case ConfigItem::debug_hits:
+    return format_bool(m_debug_hits);
+
   case ConfigItem::debug_level:
     return FMT("{}", m_debug_level);
 
@@ -1027,6 +1033,10 @@ Config::set_item(const std::string& key,
 
   case ConfigItem::debug_dir:
     m_debug_dir = value;
+    break;
+
+  case ConfigItem::debug_hits:
+    m_debug_hits = parse_bool(value, env_var_key, negate);
     break;
 
   case ConfigItem::debug_level:

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -64,6 +64,7 @@ public:
   const std::string& cpp_extension() const;
   bool debug() const;
   const std::filesystem::path& debug_dir() const;
+  bool debug_hits() const;
   uint8_t debug_level() const;
   bool depend_mode() const;
   bool direct_mode() const;
@@ -179,6 +180,7 @@ private:
   std::string m_cpp_extension;
   bool m_debug = false;
   std::filesystem::path m_debug_dir;
+  bool m_debug_hits = true;
   uint8_t m_debug_level = 2;
   bool m_depend_mode = false;
   bool m_direct_mode = true;
@@ -305,6 +307,12 @@ inline const std::filesystem::path&
 Config::debug_dir() const
 {
   return m_debug_dir;
+}
+
+inline bool
+Config::debug_hits() const
+{
+  return m_debug_hits;
 }
 
 inline uint8_t

--- a/src/Context.hpp
+++ b/src/Context.hpp
@@ -57,6 +57,7 @@ public:
 
   ArgsInfo args_info;
   Config config;
+  bool hit;
 
   // Current working directory as returned by getcwd(3).
   std::string actual_cwd;

--- a/src/ccache.cpp
+++ b/src/ccache.cpp
@@ -2382,6 +2382,7 @@ cache_compilation(int argc, const char* const* argv)
                                                   : result.error().counters());
     const auto& counters = ctx.storage.local.get_statistics_updates();
 
+    ctx.hit = false;
     if (counters.get(Statistic::cache_miss) > 0) {
       if (!ctx.config.remote_only()) {
         ctx.storage.local.increment_statistic(Statistic::local_storage_miss);
@@ -2390,10 +2391,12 @@ cache_compilation(int argc, const char* const* argv)
         ctx.storage.local.increment_statistic(Statistic::remote_storage_miss);
       }
     } else if ((counters.get(Statistic::direct_cache_hit) > 0
-                || counters.get(Statistic::preprocessed_cache_hit) > 0)
-               && counters.get(Statistic::remote_storage_hit) > 0
-               && !ctx.config.remote_only()) {
-      ctx.storage.local.increment_statistic(Statistic::local_storage_miss);
+                || counters.get(Statistic::preprocessed_cache_hit) > 0)) {
+      if (counters.get(Statistic::remote_storage_hit) > 0
+          && !ctx.config.remote_only()) {
+        ctx.storage.local.increment_statistic(Statistic::local_storage_miss);
+      }
+      ctx.hit = true;
     }
 
     if (!result) {

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -379,6 +379,24 @@ fi
     done
 
     # -------------------------------------------------------------------------
+    TEST "CCACHE_DEBUGHITS"
+
+    unset CCACHE_LOGFILE
+    unset CCACHE_NODIRECT
+    $CCACHE_COMPILE -c test1.c
+    expect_stat cache_miss 1
+    CCACHE_DEBUG=1 CCACHE_NODEBUGHITS=1 $CCACHE_COMPILE -c test1.c
+    expect_stat direct_cache_hit 1
+    if [ -f test1.o.*.ccache-log ]; then
+        test_failed "<obj>.ccache-log present"
+    fi
+    for ext in text c p d; do
+        if [ -f test1.o.*.ccache-input-$ext ]; then
+            test_failed "<obj>.ccache-input-$ext present"
+        fi
+    done
+
+    # -------------------------------------------------------------------------
     TEST "CCACHE_DEBUG with too hard option"
 
     CCACHE_DEBUG=1 $CCACHE_COMPILE -c test1.c -save-temps

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -413,6 +413,31 @@ if $RUN_WIN_XFAIL;then
 fi
 
     # -------------------------------------------------------------------------
+    TEST "CCACHE_DEBUGLEVEL"
+
+    unset CCACHE_LOGFILE
+    unset CCACHE_NODIRECT
+    CCACHE_DEBUG=1 CCACHE_DEBUGLEVEL=1 $CCACHE_COMPILE -c test1.c
+    if [ ! -f test1.o.*.ccache-log ]; then
+        test_failed "<obj>.ccache-log missing"
+    fi
+    for ext in text c p d; do
+        if [ -f test1.o.*.ccache-input-$ext ]; then
+            test_failed "<obj>.ccache-input-$ext present"
+        fi
+    done
+    rm test1.o.*.ccache-log
+    CCACHE_DEBUG=1 CCACHE_NODEBUGHITS=1 CCACHE_DEBUGLEVEL=1 $CCACHE_COMPILE -c test1.c
+    if [ -f test1.o.*.ccache-log ]; then
+        test_failed "<obj>.ccache-log present"
+    fi
+    for ext in text c p d; do
+        if [ -f test1.o.*.ccache-input-$ext ]; then
+            test_failed "<obj>.ccache-input-$ext present"
+        fi
+    done
+
+    # -------------------------------------------------------------------------
     TEST "CCACHE_DISABLE"
 
     CCACHE_DISABLE=1 $CCACHE_COMPILE -c test1.c 2>/dev/null

--- a/unittest/test_Config.cpp
+++ b/unittest/test_Config.cpp
@@ -50,6 +50,7 @@ TEST_CASE("Config: default values")
   CHECK(config.cpp_extension().empty());
   CHECK(!config.debug());
   CHECK(config.debug_dir().empty());
+  CHECK(config.debug_hits());
   CHECK(config.debug_level() == 2);
   CHECK(!config.depend_mode());
   CHECK(config.direct_mode());
@@ -111,6 +112,7 @@ TEST_CASE("Config::update_from_file")
     "compression_level= 2\n"
     "cpp_extension = .foo\n"
     "debug_dir = $USER$/${USER}/.ccache_debug\n"
+    "debug_hits = true\n"
     "debug_level = 2\n"
     "depend_mode = true\n"
     "direct_mode = false\n"
@@ -154,6 +156,7 @@ TEST_CASE("Config::update_from_file")
   CHECK(config.compression_level() == 2);
   CHECK(config.cpp_extension() == ".foo");
   CHECK(config.debug_dir() == FMT("{0}$/{0}/.ccache_debug", user));
+  CHECK(config.debug_hits());
   CHECK(config.debug_level() == 2);
   CHECK(config.depend_mode());
   CHECK_FALSE(config.direct_mode());
@@ -398,6 +401,7 @@ TEST_CASE("Config::visit_items")
     "cpp_extension = ce\n"
     "debug = false\n"
     "debug_dir = /dd\n"
+    "debug_hits = true\n"
     "debug_level = 2\n"
     "depend_mode = true\n"
     "direct_mode = false\n"
@@ -460,6 +464,7 @@ TEST_CASE("Config::visit_items")
     "(test.conf) cpp_extension = ce",
     "(test.conf) debug = false",
     "(test.conf) debug_dir = /dd",
+    "(test.conf) debug_hits = true",
     "(test.conf) debug_level = 2",
     "(test.conf) depend_mode = true",
     "(test.conf) direct_mode = false",


### PR DESCRIPTION
Add a `debug_hits` flag, to be able to control which of the 5 cache debug files are kept.

If it is **true**, all are kept (like now). If it is **false**, then files for cache hit are deleted again.

Closes #1361