### PR TITLE
feat: implement `--print-stats-json`

### DIFF
--- a/src/core/Statistics.cpp
+++ b/src/core/Statistics.cpp
@@ -548,6 +548,32 @@ Statistics::format_machine_readable(const Config& config,
   return util::join(lines, "");
 }
 
+std::string
+Statistics::format_json(const Config& config,
+                        const util::TimePoint& last_updated) const
+{
+  std::vector<std::string> lines;
+
+  auto add_line = [&](auto id, auto value) {
+    lines.push_back(FMT("\"{}\": {}", id, value));
+  };
+
+  add_line("stats_updated_timestamp", last_updated.sec());
+
+  for (const auto& field : k_statistics_fields) {
+    if (!(field.flags & FLAG_NEVER)) {
+      add_line(field.id, m_counters.get(field.statistic));
+    }
+  }
+
+  add_line("max_cache_size_kibibyte", config.max_size() / 1024);
+  add_line("max_files_in_cache", config.max_files());
+
+  std::sort(lines.begin(), lines.end());
+  std::string result = "{" + util::join(lines, ",") + "}";
+  return result;
+}
+
 std::unordered_map<std::string, Statistic>
 Statistics::get_id_map()
 {

--- a/src/core/Statistics.hpp
+++ b/src/core/Statistics.hpp
@@ -50,6 +50,10 @@ public:
   format_machine_readable(const Config& config,
                           const util::TimePoint& last_updated) const;
 
+  // Format cache statistics in JSON format.
+  std::string format_json(const Config& config,
+                          const util::TimePoint& last_updated) const;
+
   const StatisticsCounters& counters() const;
 
   static std::unordered_map<std::string, Statistic> get_id_map();

--- a/src/core/mainoptions.cpp
+++ b/src/core/mainoptions.cpp
@@ -175,6 +175,8 @@ Options for scripting or debugging:
                                human-readable format
         --print-stats          print statistics counter IDs and corresponding
                                values in machine-parsable format
+        --print-stats-json     print statistics counter IDs and corresponding
+                               values in JSON format
 
 See also the manual on <https://ccache.dev/documentation.html>.
 )";
@@ -423,6 +425,7 @@ enum {
   HASH_FILE,
   INSPECT,
   PRINT_STATS,
+  PRINT_STATS_JSON,
   RECOMPRESS_THREADS,
   SHOW_LOG_STATS,
   TRIM_DIR,
@@ -452,6 +455,7 @@ const option long_options[] = {
   {"max-files", required_argument, nullptr, 'F'},
   {"max-size", required_argument, nullptr, 'M'},
   {"print-stats", no_argument, nullptr, PRINT_STATS},
+  {"print-stats-json", no_argument, nullptr, PRINT_STATS_JSON},
   {"recompress", required_argument, nullptr, 'X'},
   {"recompress-threads", required_argument, nullptr, RECOMPRESS_THREADS},
   {"set-config", required_argument, nullptr, 'o'},
@@ -644,6 +648,14 @@ process_main_options(int argc, const char* const* argv)
       Statistics statistics(counters);
       PRINT_RAW(stdout,
                 statistics.format_machine_readable(config, last_updated));
+      break;
+    }
+
+    case PRINT_STATS_JSON: {
+      const auto [counters, last_updated] =
+        storage::local::LocalStorage(config).get_all_statistics();
+      Statistics statistics(counters);
+      PRINT_RAW(stdout, statistics.format_json(config, last_updated));
       break;
     }
 


### PR DESCRIPTION
This variant of `--print-stats` outputs the statistics as a one line json object.

I did a fair share of ad-hoc conversion of the regular "--print-stats" output, suffering the startup time of Python, thinking "this would be so easy at the source" ...

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
