### PR TITLE
feat: add `--print-log-stats`

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -276,6 +276,11 @@ directory to a certain size, use `CCACHE_MAXSIZE=_SIZE_ ccache -c`.
     the file content. This option is only useful when debugging ccache and its
     behavior.
 
+*--print-log-stats*::
+
+    Print statistics counters from the stats log in machine-parseable
+    (tab-separated) format. See <<config_stats_log,*stats_log*>>.
+
 *--print-stats*::
 
     Print statistics counter IDs and corresponding values in machine-parsable

--- a/src/core/mainoptions.cpp
+++ b/src/core/mainoptions.cpp
@@ -173,6 +173,9 @@ Options for scripting or debugging:
                                PATH
         --inspect PATH         print result/manifest file at PATH in
                                human-readable format
+        --print-log-stats      print statistics counter IDs and corresponding
+                               values from the stats log in machine-parseable
+                               format
         --print-stats          print statistics counter IDs and corresponding
                                values in machine-parsable format
 
@@ -422,6 +425,7 @@ enum {
   EXTRACT_RESULT,
   HASH_FILE,
   INSPECT,
+  PRINT_LOG_STATS,
   PRINT_STATS,
   RECOMPRESS_THREADS,
   SHOW_LOG_STATS,
@@ -451,6 +455,7 @@ const option long_options[] = {
   {"inspect", required_argument, nullptr, INSPECT},
   {"max-files", required_argument, nullptr, 'F'},
   {"max-size", required_argument, nullptr, 'M'},
+  {"print-log-stats", no_argument, nullptr, PRINT_LOG_STATS},
   {"print-stats", no_argument, nullptr, PRINT_STATS},
   {"recompress", required_argument, nullptr, 'X'},
   {"recompress-threads", required_argument, nullptr, RECOMPRESS_THREADS},
@@ -730,6 +735,17 @@ process_main_options(int argc, const char* const* argv)
       PRINT_RAW(
         stdout,
         statistics.format_human_readable(config, timestamp, verbosity, true));
+      break;
+    }
+
+    case PRINT_LOG_STATS: {
+      if (config.stats_log().empty()) {
+        throw Fatal("No stats log has been configured");
+      }
+      Statistics statistics(StatsLog(config.stats_log()).read());
+      const auto timestamp =
+        DirEntry(config.stats_log(), DirEntry::LogOnError::yes).mtime();
+      PRINT_RAW(stdout, statistics.format_machine_readable(config, timestamp));
       break;
     }
 


### PR DESCRIPTION
This adds a "machine readable" variant of `--show-log-stats`, similar to `--print-stats` as a variant of `--show-stats`.


See https://github.com/ccache/ccache/discussions/1379 and https://github.com/ccache/ccache/pull/1380.
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
