### PR TITLE
feat: add `--print-stats` format selection, JSON format

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -258,6 +258,18 @@ directory to a certain size, use `CCACHE_MAXSIZE=_SIZE_ ccache -c`.
     working directory. This option is only useful when debugging ccache and its
     behavior.
 
+*--format* _FORMAT_::
+
+    Specify format for `--print-log-stats` and `--print-stats`. Possible values
+    are:
++
+--
+*tab*::
+    Tab separated. This is the default.
+*json*::
+    JSON formatted.
+--
+
 *-k* _KEY_, *--get-config* _KEY_::
 
     Print the value of configuration option _KEY_. See _<<Configuration>>_ for
@@ -279,12 +291,13 @@ directory to a certain size, use `CCACHE_MAXSIZE=_SIZE_ ccache -c`.
 *--print-log-stats*::
 
     Print statistics counters from the stats log in machine-parseable
-    (tab-separated) format. See <<config_stats_log,*stats_log*>>.
+    (tab-separated or JSON) format. See <<config_stats_log,*stats_log*>> and
+    `--format`.
 
 *--print-stats*::
 
     Print statistics counter IDs and corresponding values in machine-parsable
-    (tab-separated) format.
+    (tab-separated or JSON) format. See `--format`.
 
 
 

--- a/src/core/Statistic.hpp
+++ b/src/core/Statistic.hpp
@@ -84,4 +84,8 @@ enum class Statistic {
   END = 84
 };
 
+enum class StatisticFormat {
+  Tab,
+};
+
 } // namespace core

--- a/src/core/Statistic.hpp
+++ b/src/core/Statistic.hpp
@@ -86,6 +86,7 @@ enum class Statistic {
 
 enum class StatisticFormat {
   Tab,
+  Json,
 };
 
 } // namespace core

--- a/src/core/Statistics.cpp
+++ b/src/core/Statistics.cpp
@@ -585,7 +585,7 @@ Statistics::format_json(const Config& config,
   add_line("max_files_in_cache", config.max_files());
 
   std::sort(lines.begin(), lines.end());
-  std::string result = "{" + util::join(lines, ",") + "}";
+  std::string result = "{\n  " + util::join(lines, ",\n  ") + "\n}\n";
   return result;
 }
 

--- a/src/core/Statistics.cpp
+++ b/src/core/Statistics.cpp
@@ -525,7 +525,20 @@ Statistics::format_human_readable(const Config& config,
 
 std::string
 Statistics::format_machine_readable(const Config& config,
-                                    const util::TimePoint& last_updated) const
+                                    const util::TimePoint& last_updated,
+                                    const StatisticFormat format) const
+{
+  switch (format) {
+  case StatisticFormat::Tab:
+    /* fall through */
+  default:
+    return Statistics::format_tab_separated(config, last_updated);
+  }
+}
+
+std::string
+Statistics::format_tab_separated(const Config& config,
+                                 const util::TimePoint& last_updated) const
 {
   std::vector<std::string> lines;
 

--- a/src/core/Statistics.hpp
+++ b/src/core/Statistics.hpp
@@ -65,6 +65,9 @@ private:
   // Format cache statistics in tab-separated format.
   std::string format_tab_separated(const Config& config,
                                    const util::TimePoint& last_updated) const;
+  // Format cache statistics in JSON format.
+  std::string format_json(const Config& config,
+                          const util::TimePoint& last_updated) const;
 };
 
 // --- Inline implementations ---

--- a/src/core/Statistics.hpp
+++ b/src/core/Statistics.hpp
@@ -46,9 +46,9 @@ public:
                                     bool from_log) const;
 
   // Format cache statistics in machine-readable format.
-  std::string
-  format_machine_readable(const Config& config,
-                          const util::TimePoint& last_updated) const;
+  std::string format_machine_readable(const Config& config,
+                                      const util::TimePoint& last_updated,
+                                      const StatisticFormat format) const;
 
   const StatisticsCounters& counters() const;
 
@@ -62,6 +62,9 @@ private:
   uint64_t count_stats(unsigned flags) const;
   std::vector<std::pair<std::string, uint64_t>> get_stats(unsigned flags,
                                                           bool all) const;
+  // Format cache statistics in tab-separated format.
+  std::string format_tab_separated(const Config& config,
+                                   const util::TimePoint& last_updated) const;
 };
 
 // --- Inline implementations ---

--- a/src/core/mainoptions.cpp
+++ b/src/core/mainoptions.cpp
@@ -168,7 +168,7 @@ Options for scripting or debugging:
                                PATH
         --extract-result PATH  extract file data stored in result file at PATH
                                to the current working directory
-    -f, --format FORMAT        specify format for --print-log-stats and
+        --format FORMAT        specify format for --print-log-stats and
                                --print-stats (tab, json); default: tab
     -k, --get-config KEY       print the value of configuration key KEY
         --hash-file PATH       print the hash (160 bit BLAKE3) of the file at
@@ -425,6 +425,7 @@ enum {
   EVICT_NAMESPACE,
   EVICT_OLDER_THAN,
   EXTRACT_RESULT,
+  FORMAT,
   HASH_FILE,
   INSPECT,
   PRINT_LOG_STATS,
@@ -438,7 +439,7 @@ enum {
   TRIM_RECOMPRESS_THREADS,
 };
 
-const char options_string[] = "cCd:f:k:hF:M:po:svVxX:z";
+const char options_string[] = "cCd:k:hF:M:po:svVxX:z";
 const option long_options[] = {
   {"checksum-file", required_argument, nullptr, CHECKSUM_FILE},
   {"cleanup", no_argument, nullptr, 'c'},
@@ -451,7 +452,7 @@ const option long_options[] = {
   {"evict-namespace", required_argument, nullptr, EVICT_NAMESPACE},
   {"evict-older-than", required_argument, nullptr, EVICT_OLDER_THAN},
   {"extract-result", required_argument, nullptr, EXTRACT_RESULT},
-  {"format", required_argument, nullptr, 'f'},
+  {"format", required_argument, nullptr, FORMAT},
   {"get-config", required_argument, nullptr, 'k'},
   {"hash-file", required_argument, nullptr, HASH_FILE},
   {"help", no_argument, nullptr, 'h'},
@@ -512,7 +513,7 @@ process_main_options(int argc, const char* const* argv)
     case 'd': // --dir
       util::setenv("CCACHE_DIR", arg);
       break;
-    case 'f': // --format
+    case FORMAT:
       if (arg == "tab") {
         format = StatisticFormat::Tab;
       } else if (arg == "json") {
@@ -583,7 +584,7 @@ process_main_options(int argc, const char* const* argv)
     switch (c) {
     case CONFIG_PATH:
     case 'd': // --dir
-    case 'f': // --format
+    case FORMAT:
     case RECOMPRESS_THREADS:
     case TRIM_MAX_SIZE:
     case TRIM_METHOD:

--- a/src/core/mainoptions.cpp
+++ b/src/core/mainoptions.cpp
@@ -169,7 +169,7 @@ Options for scripting or debugging:
         --extract-result PATH  extract file data stored in result file at PATH
                                to the current working directory
     -f, --format FORMAT        specify format for --print-log-stats and
-                               --print-stats (tab); default: tab
+                               --print-stats (tab, json); default: tab
     -k, --get-config KEY       print the value of configuration key KEY
         --hash-file PATH       print the hash (160 bit BLAKE3) of the file at
                                PATH
@@ -515,6 +515,8 @@ process_main_options(int argc, const char* const* argv)
     case 'f': // --format
       if (arg == "tab") {
         format = StatisticFormat::Tab;
+      } else if (arg == "json") {
+        format = StatisticFormat::Json;
       } else {
         PRINT(stderr, "Error: unknown format \"{}\"\n", arg);
         return EXIT_FAILURE;


### PR DESCRIPTION
This PR adds infrastructure to have selectable output format for `--print-stats`/`--print-log-stats`, and adds JSON format in addition to the previous (now default) tab separated format.

*edit* this is based on #1381

See #1379, #1380, #1381.
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
