### PR TITLE
Support for MSVC /Yc option

### DIFF
--- a/src/ArgsInfo.hpp
+++ b/src/ArgsInfo.hpp
@@ -93,6 +93,9 @@ struct ArgsInfo
   // (--serialize-diagnostics)?
   bool generating_diagnostics = false;
 
+  // Are we generating a pch file (msvc -Yc)?
+  bool generating_pch = false;
+
   // Whether to strip color codes from diagnostic messages on output.
   bool strip_diagnostics_colors = false;
 

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -95,7 +95,7 @@ const CompOpt compopts[] = {
   {"-Xcompiler", AFFECTS_CPP | TAKES_ARG}, // nvcc
   {"-Xlinker", TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},
   {"-Xpreprocessor", AFFECTS_CPP | TOO_HARD_DIRECT | TAKES_ARG},
-  {"-Yc", TAKES_ARG | TOO_HARD},                                    // msvc
+  {"-Yc", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
   {"-Yu", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
   {"-all_load", AFFECTS_COMP},
   {"-analyze", TOO_HARD}, // Clang

--- a/src/core/Result.cpp
+++ b/src/core/Result.cpp
@@ -148,6 +148,9 @@ file_type_to_string(FileType type)
 
   case FileType::assembler_listing:
     return ".al";
+
+  case FileType::included_pch_file:
+    return ".pch";
   }
 
   return k_unknown_file_type;

--- a/src/core/Result.hpp
+++ b/src/core/Result.hpp
@@ -81,6 +81,9 @@ enum class FileType : UnderlyingFileTypeInt {
 
   // Assembler listing file from -Wa,-a=file.
   assembler_listing = 9,
+
+  // PCH file created by msvc additionally to the obj file
+  included_pch_file = 10,
 };
 
 const char* file_type_to_string(FileType type);

--- a/src/core/ResultRetriever.cpp
+++ b/src/core/ResultRetriever.cpp
@@ -199,6 +199,9 @@ ResultRetriever::get_dest_path(FileType file_type) const
 
   case FileType::assembler_listing:
     return m_ctx.args_info.output_al;
+
+  case FileType::included_pch_file:
+    return m_ctx.args_info.included_pch_file;
   }
 
   return {};

--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -735,6 +735,49 @@ TEST_CASE("MSVC options"
   CHECK(result.compiler_args.to_string() == "cl.exe /foobar -c");
 }
 
+TEST_CASE("MSVC PCH options")
+{
+  TestContext test_context;
+  Context ctx;
+  ctx.config.set_compiler_type(CompilerType::msvc);
+  util::write_file("foo.cpp", "");
+  util::write_file("pch.h", "");
+  util::write_file("pch.cpp", "");
+
+  SUBCASE("Create PCH")
+  {
+    ctx.orig_args = Args::from_string(
+      "cl.exe /Ycpch.h /Fppch.cpp.pch /FIpch.h /Fopch.cpp.obj /c pch.cpp");
+    const ProcessArgsResult result = process_args(ctx);
+    REQUIRE(!result.error);
+    CHECK(ctx.args_info.generating_pch);
+    CHECK(ctx.args_info.included_pch_file == "pch.cpp.pch");
+    CHECK(ctx.args_info.output_obj == "pch.cpp.obj");
+    CHECK(result.preprocessor_args.to_string()
+          == "cl.exe /Ycpch.h /Fppch.cpp.pch /FIpch.h");
+    CHECK(result.compiler_args.to_string()
+          == "cl.exe /Ycpch.h /Fppch.cpp.pch /FIpch.h -c");
+  }
+
+  util::write_file("pch.cpp.pch", "");
+  ctx.config.update_from_map({{"sloppiness", "pch_defines,time_macros"}});
+
+  SUBCASE("Consume PCH")
+  {
+    ctx.orig_args = Args::from_string(
+      "cl.exe /Yupch.h /Fppch.cpp.pch /FIpch.h /Fofoo.cpp.obj /c foo.cpp");
+    const ProcessArgsResult result = process_args(ctx);
+    REQUIRE(!result.error);
+    CHECK(!ctx.args_info.generating_pch);
+    CHECK(ctx.args_info.included_pch_file == "pch.cpp.pch");
+    CHECK(ctx.args_info.output_obj == "foo.cpp.obj");
+    CHECK(result.preprocessor_args.to_string()
+          == "cl.exe /Yupch.h /Fppch.cpp.pch /FIpch.h");
+    CHECK(result.compiler_args.to_string()
+          == "cl.exe /Yupch.h /Fppch.cpp.pch /FIpch.h -c");
+  }
+}
+
 TEST_CASE("MSVC debug information format options")
 {
   TestContext test_context;


### PR DESCRIPTION
Fixes #1383 
This implements the /Yc (Create precompiled header) option of MSVC by caching the generated obj and pch files.
For me, this results in direct cache hits when testing with my demo repo: https://github.com/clemenswasser/ccache_pch_msvc_demo
```console
> ccache -s
Cacheable calls:      2 /   2 (100.0%)
  Hits:               2 /   2 (100.0%)
```
The PR is currently marked as draft as it is currently missing any tests, etc. and is just a quickly hacked implementation.