### PR TITLE
msys2 patch: lock mechanism uses file instead of symlink.

### DIFF
--- a/unittest/test_Util.cpp
+++ b/unittest/test_Util.cpp
@@ -102,7 +102,7 @@ TEST_CASE("Util::make_relative_path")
 
   const std::string cwd = util::actual_cwd();
   const std::string actual_cwd = FMT("{}/d", cwd);
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
   const std::string apparent_cwd = actual_cwd;
 #else
   const std::string apparent_cwd = FMT("{}/s", cwd);
@@ -114,7 +114,6 @@ TEST_CASE("Util::make_relative_path")
 #endif
   REQUIRE(fs::current_path("d"));
   util::setenv("PWD", apparent_cwd);
-
   SUBCASE("No base directory")
   {
     CHECK(make_relative_path("", "/a", "/a", "/a/x") == "/a/x");
@@ -198,7 +197,7 @@ TEST_CASE("Util::normalize_abstract_absolute_path")
 
 TEST_CASE("Util::normalize_concrete_absolute_path")
 {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__CYGWIN__)
   TestContext test_context;
 
   util::write_file("file", "");


### PR DESCRIPTION
MSYS2 will not let you create a symlink to a nonexistent file, only to an already existing file. To overcome this issue we use files, and write content on it. 

For Cygwin/MSYS2, the patch leverages POSIX `open` with the flags `O_WRONLY | O_CREAT | O_EXCL`, effectively creating an exclusive lock file. As suggested by @jrosdahl , thank you so much for the suggestion. 
This still does not pass the test suite, but makes ccache usable.
I look forward for you review.

See issue #1415

