### PR TITLE
ci: disable building test on macos binaries

### DIFF
--- a/ci/build-macos-binary
+++ b/ci/build-macos-binary
@@ -12,6 +12,7 @@ build() {
         -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" \
         -DCMAKE_OSX_ARCHITECTURES="$1" \
         -DCMAKE_SYSTEM_PROCESSOR="$1" \
+        -DENABLE_TESTING=OFF \
         ..
     cmake --build .
     cd ..


### PR DESCRIPTION
We don't run the tests when building macOS universal binaries as its covered elsewhere so we can save some compile time by removing test builds.
