### PR TITLE
feat: use sendfile(2) for file copying

### DIFF
--- a/cmake/GenerateConfigurationFile.cmake
+++ b/cmake/GenerateConfigurationFile.cmake
@@ -7,6 +7,7 @@ set(include_files
     sys/file.h
     sys/ioctl.h
     sys/mman.h
+    sys/sendfile.h
     sys/utime.h
     sys/wait.h
     syslog.h

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -87,6 +87,9 @@
 // Define if you have the <sys/mman.h> header file.
 #cmakedefine HAVE_SYS_MMAN_H
 
+// Define if you have the <sys/sendfile.h> header file.
+#cmakedefine HAVE_SYS_SENDFILE_H 
+
 // Define if you have the <sys/utime.h> header file.
 #cmakedefine HAVE_SYS_UTIME_H
 

--- a/unittest/test_util_file.cpp
+++ b/unittest/test_util_file.cpp
@@ -71,23 +71,26 @@ TEST_CASE("util::likely_size_on_disk")
   CHECK(util::likely_size_on_disk(4097) == 8192);
 }
 
-TEST_CASE("util::read_file and util::write_file, text data")
+TEST_CASE("util::read_file util::write_file and util::copy_file, text data")
 {
   TestContext test_context;
 
   REQUIRE(util::write_file("test", "foo\nbar\n"));
-  auto data = util::read_file<std::string>("test");
+  CHECK(util::copy_file("test", "test2"));
+  auto data = util::read_file<std::string>("test2");
   REQUIRE(data);
   CHECK(*data == "foo\nbar\n");
 
   REQUIRE(util::write_file("test", "foo\r\nbar\r\n"));
-  data = util::read_file<std::string>("test");
+  CHECK(util::copy_file("test", "test2", util::ViaTmpFile::yes));
+  data = util::read_file<std::string>("test2");
   REQUIRE(data);
   CHECK(*data == "foo\r\nbar\r\n");
 
   // Newline handling
   REQUIRE(util::write_file("test", "foo\r\nbar\n"));
-  auto bin_data = util::read_file<std::vector<uint8_t>>("test");
+  CHECK(util::copy_file("test", "test2"));
+  auto bin_data = util::read_file<std::vector<uint8_t>>("test2");
   REQUIRE(bin_data);
 #ifdef _WIN32
   const std::string expected_bin_data = "foo\r\r\nbar\r\n";
@@ -119,7 +122,7 @@ TEST_CASE("util::read_file and util::write_file, text data")
   CHECK(result.error() == "No such file or directory");
 }
 
-TEST_CASE("util::read_file and util::write_file, binary data")
+TEST_CASE("util::read_file, util::write_file and util::copy_file, binary data")
 {
   TestContext test_context;
 
@@ -129,7 +132,8 @@ TEST_CASE("util::read_file and util::write_file, binary data")
   }
 
   CHECK(util::write_file("test", expected));
-  auto actual = util::read_file<std::vector<uint8_t>>("test");
+  CHECK(util::copy_file("test", "test2", util::ViaTmpFile::yes));
+  auto actual = util::read_file<std::vector<uint8_t>>("test2");
   REQUIRE(actual);
   CHECK(*actual == expected);
 


### PR DESCRIPTION
Use sendfile for file copying as it avoids copying the data to user-space and back to kernel space.
