### PR TITLE
ci: update macos images used

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,14 +78,6 @@ jobs:
             compiler: gcc
             version: "13"
 
-          - os: macOS-11
-            compiler: xcode
-            version: "11.7"
-
-          - os: macOS-11
-            compiler: xcode
-            version: "12.5.1"
-
           - os: macOS-12
             compiler: xcode
             version: "13.4.1"
@@ -93,6 +85,14 @@ jobs:
           - os: macOS-12
             compiler: xcode
             version: "14.2"
+
+          - os: macOS-13
+            compiler: xcode
+            version: "15.0.1"
+
+          - os: macOS-14
+            compiler: xcode
+            version: "15.3"
     steps:
       - name: Install dependencies on Linux
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
Updates macos images used. macOS-14 is M1 arm64. Macos11 has been deprecated and will be removed in june