### PR TITLE
fix: Handle -Yc without filepath for msvc

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -1090,7 +1090,7 @@ process_option_arg(const Context& ctx,
     return Statistic::none;
   }
 
-  if (compopt_takes_path(arg)) {
+  if (compopt_takes_arg(arg) && compopt_takes_path(arg)) {
     if (i == args.size() - 1) {
       LOG("Missing argument to {}", args[i]);
       return Statistic::bad_compiler_arguments;

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -97,7 +97,7 @@ const CompOpt compopts[] = {
   {"-Xcompiler", AFFECTS_CPP | TAKES_ARG}, // nvcc
   {"-Xlinker", TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},
   {"-Xpreprocessor", AFFECTS_CPP | TAKES_ARG},
-  {"-Yc", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
+  {"-Yc", AFFECTS_CPP | TAKES_CONCAT_ARG | TAKES_PATH},             // msvc
   {"-Yu", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
   {"-all_load", AFFECTS_COMP},
   {"-analyze", TOO_HARD}, // Clang


### PR DESCRIPTION
This PR further fixes the #1384. Fixes the case when the `/Yc` option is without the filepath and the `/Fppathname` is also defined.

The `/Yc` can be passed in two ways with and w/o the filepath. When it's passed w/o the filepath it must take the value of the `/Fp` option and if the `/Fp` option isn't defined then the resulting .pch file must have the same base name as the base source file with appended `.pch` extension (this case isn't handled correctly by ccache).

The `/Yc` option doesn't support passing a filepath with the space between like `/Yc filepath`. Because of this the `TAKES_ARG` must be removed. All occurrences of the [`compopt_takes_path()`](https://github.com/ccache/ccache/blob/911b899c6b51c3eb24e8b488361746ec590d2055/src/ccache/compopt.cpp#L279) can't be invoked for the `/Yc` or `/Ycfilepath` options.

Here you can fastly check all occurrences: [`argprocessing.cpp#529`](https://github.com/ccache/ccache/blob/911b899c6b51c3eb24e8b488361746ec590d2055/src/ccache/argprocessing.cpp#L529), [`argprocessing.cpp#1154`](https://github.com/ccache/ccache/blob/911b899c6b51c3eb24e8b488361746ec590d2055/src/ccache/argprocessing.cpp#L1154), [`ccache.cpp#1636`](https://github.com/ccache/ccache/blob/911b899c6b51c3eb24e8b488361746ec590d2055/src/ccache/ccache.cpp#L1636), [`ccache.cpp#1725`](https://github.com/ccache/ccache/blob/911b899c6b51c3eb24e8b488361746ec590d2055/src/ccache/ccache.cpp#L1725), [`ccache.cpp#L1865`](https://github.com/ccache/ccache/blob/911b899c6b51c3eb24e8b488361746ec590d2055/src/ccache/ccache.cpp#L1865)

Especially this `if()` block [`argprocessing.cpp#1154`](https://github.com/ccache/ccache/blob/911b899c6b51c3eb24e8b488361746ec590d2055/src/ccache/argprocessing.cpp#L1154) can't be invoked during arguments processing when the `/Yc` was passed __w/o__ the filepath but other `if()` blocks look important as well.

I have also added a new unittest for this case: "MSVC PCH options with empty -Yc" and also tested it manually on my example project. Just now, I have also tested it on a big project with 200 TU with qmake and cmake build systems with msvc and also clang-cl with msvc compilers with 100% cache hits (PCH enabled and /Zi replaced with /Z7).