### PR TITLE
fix: Handle -Yc without -Fp and -Fo for msvc

### DIFF
--- a/src/ccache/ArgsInfo.hpp
+++ b/src/ccache/ArgsInfo.hpp
@@ -70,6 +70,9 @@ struct ArgsInfo
   // Assembler listing file.
   std::string output_al;
 
+  // The given PCH filepath being compiled to (by -Fp option).
+  std::string orig_included_pch_file;
+
   // The .gch/.pch/.pth file or directory used for compilation.
   std::string included_pch_file;
 


### PR DESCRIPTION
This PR depends on the previous one #1448.

It allows passing the `-Yc` option without the `-Fp` option and also without the `-Fo` option.

It sets the PCH filename from the base source file (`args_info.input_file`) and appends the `.pch` extension. This case is described in the [`/Yc`](https://learn.microsoft.com/en-us/cpp/build/reference/yc-create-precompiled-header-file?view=msvc-170) option documentation.

Similar logic is used to detect the `/Fo` filename, practically no changes were needed for this, all logic is already done [here](https://github.com/ccache/ccache/blob/master/src/ccache/argprocessing.cpp#L1413-L1417), only one change that was needed was to add the `get_default_pch_file_extension()` function that returns `.pch` for msvc like compilers.

The next addition is to return `Statistic::could_not_use_precompiled_header` if the `-Fp` contains a folder path, in this case, the PCH filepath (especially filename) is generated based on the major version of the Visual Studio toolset like `folder\vcversion0.pch` (this major toolset version replaces 0). It's not worth the effort to implement this.
I don't know if returning the `Statistic::bad_compiler_arguments` or `Statistic::unsupported_compiler_option`would be better here.
Adding a new `args_info.orig_included_pch_file` data member can't be avoided because the original value is changed [here](https://github.com/ccache/ccache/blob/master/src/ccache/argprocessing.cpp#L173).

The last change is to move the `args_info.generating_pch = true;` from [here](https://github.com/ccache/ccache/blob/master/src/ccache/argprocessing.cpp#L1130-L1132) into the `detect_pch()`. The reason is that it was invoked unnecessarily several times for every option and the initial reason why it was not defined inside the `detect_pch()` in the initial/original PR was, that the `detect_pch()` didn't have access to the `args_info` instance (I think).