### PR TITLE
perf: Use posix_spawn when hashing

### DIFF
--- a/cmake/GenerateConfigurationFile.cmake
+++ b/cmake/GenerateConfigurationFile.cmake
@@ -4,6 +4,7 @@ set(include_files
     dirent.h
     linux/fs.h
     pwd.h
+    spawn.h
     sys/clonefile.h
     sys/file.h
     sys/ioctl.h

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -81,6 +81,9 @@
 // Define if you have the <pwd.h> header file.
 #cmakedefine HAVE_PWD_H
 
+// Define if you have the <spawn.h> header file.
+#cmakedefine HAVE_SPAWN_H
+
 // Define if you have the <sys/clonefile.h> header file.
 #cmakedefine HAVE_SYS_CLONEFILE_H
 


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->

This should improve performance on all OSes. I thought I would convert hashing first and then `execute()` next, since it's slightly more complicated.

One question I have is whether there should be error handling on the `posix_spawn_file_actions_add*` functions, these seem very unlikely to fail (similar to `close` or `dup2` calls).
