### PR TITLE
fix: TAKES_/CONCAT_ARG for msvc options

### DIFF
--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -74,7 +74,7 @@ const CompOpt compopts[] = {
   {"-F", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-FI", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
   {"-FU", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
-  {"-Fp", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
+  {"-Fp", AFFECTS_CPP | TAKES_CONCAT_ARG | TAKES_PATH},             // msvc
   {"-G", TAKES_ARG},
   {"-I", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-L", TAKES_ARG},
@@ -97,8 +97,8 @@ const CompOpt compopts[] = {
   {"-Xcompiler", AFFECTS_CPP | TAKES_ARG}, // nvcc
   {"-Xlinker", TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP},
   {"-Xpreprocessor", AFFECTS_CPP | TAKES_ARG},
-  {"-Yc", AFFECTS_CPP | TAKES_CONCAT_ARG | TAKES_PATH},             // msvc
-  {"-Yu", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
+  {"-Yc", AFFECTS_CPP | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
+  {"-Yu", AFFECTS_CPP | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
   {"-all_load", AFFECTS_COMP},
   {"-analyze", TOO_HARD}, // Clang
   {"-arch", TAKES_ARG},


### PR DESCRIPTION
/Fp and /Yu doesn't allow space between option and option value.

Fixes #1452