### PR TITLE
feat: Add argument handling for Emscripten's --em-config

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -524,18 +524,6 @@ process_option_arg(const Context& ctx,
     }
   }
 
-  // emscriptcen's --em-config requires an argument.
-  if (arg == "--em-config") {
-    if (i == args.size() - 1) {
-      LOG("Missing argument to {}", args[i]);
-      return Statistic::bad_compiler_arguments;
-    }
-    state.common_args.push_back(args[i]);
-    ++i;
-    state.common_args.push_back(args[i]);
-    return Statistic::none;
-  }
-
   // Handle options that should not be passed to the preprocessor.
   if (compopt_affects_compiler_output(arg)
       || (i + 1 < args.size() && arg == "-Xclang"

--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -524,6 +524,18 @@ process_option_arg(const Context& ctx,
     }
   }
 
+  // emscriptcen's --em-config requires an argument.
+  if (arg == "--em-config") {
+    if (i == args.size() - 1) {
+      LOG("Missing argument to {}", args[i]);
+      return Statistic::bad_compiler_arguments;
+    }
+    state.common_args.push_back(args[i]);
+    ++i;
+    state.common_args.push_back(args[i]);
+    return Statistic::none;
+  }
+
   // Handle options that should not be passed to the preprocessor.
   if (compopt_affects_compiler_output(arg)
       || (i + 1 < args.size() && arg == "-Xclang"

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -55,6 +55,7 @@ const CompOpt compopts[] = {
   {"--compiler-bindir", AFFECTS_CPP | TAKES_ARG},      // nvcc
   {"--compiler-options", AFFECTS_CPP | TAKES_ARG},     // nvcc
   {"--config", TAKES_ARG},                             // Clang
+{"--em-config", TAKES_ARG},                            // emcc
   {"--gcc-toolchain=", TAKES_CONCAT_ARG | TAKES_PATH}, // Clang
   {"--include", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"--libdevice-directory", AFFECTS_CPP | TAKES_ARG}, // nvcc

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -55,7 +55,7 @@ const CompOpt compopts[] = {
   {"--compiler-bindir", AFFECTS_CPP | TAKES_ARG},      // nvcc
   {"--compiler-options", AFFECTS_CPP | TAKES_ARG},     // nvcc
   {"--config", TAKES_ARG},                             // Clang
-{"--em-config", TAKES_ARG},                            // emcc
+  {"--em-config", TAKES_ARG},                          // emcc
   {"--gcc-toolchain=", TAKES_CONCAT_ARG | TAKES_PATH}, // Clang
   {"--include", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"--libdevice-directory", AFFECTS_CPP | TAKES_ARG}, // nvcc


### PR DESCRIPTION
The arguments for the `--em-config` option for Emscripten were not being processed correctly, causing ccache to incorrectly interpret the following argument as an input file. This commit changes the argument processing function to correctly handle `--em-config` along with the required subsequent argument, improving compatibility with Emscripten's command line interface.

Fixes #1457