### PR TITLE
fix: removed unused headers

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -36,7 +36,6 @@
 #  include <unistd.h>
 #endif
 
-#include <cassert>
 #include <vector>
 
 namespace fs = util::filesystem;

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -70,10 +70,7 @@
 #endif
 
 #include <algorithm>
-#include <cmath>
 #include <cstring>
-#include <limits>
-#include <memory>
 #include <unordered_map>
 
 namespace fs = util::filesystem;


### PR DESCRIPTION
These headers look unused I fastly looked over whole files for assert(), shared/unique_ptr<>, make_unique/shared<>, std::numeric_limits<>, and few other functions from cmath, and these files don't contain any, also checked #if macros for WIN32, Linux, and APPLE. (recompiled on Win and Linux gcc/clang, CI should catch this on any problem).