### PR TITLE
fix: Msvc /Zc:preprocessor warning

### DIFF
--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -59,10 +59,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^GNU|(Apple)?Clang$" AND NOT MSVC)
 
   include(StdAtomic)
   include(StdFilesystem)
-elseif(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "^Clang$")
-  target_compile_options(
-    standard_settings
-    INTERFACE /Zc:preprocessor /Zc:__cplusplus
+elseif(MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(standard_settings INTERFACE
+      /Zc:__cplusplus
+      $<$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.25>:/Zc:preprocessor>
   )
 endif()
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -51,8 +51,10 @@ list(APPEND source_files ${headers})
 
 add_executable(unittest ${source_files})
 
-if(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "^Clang$")
-  # Turn off /Zc:preprocessor for this test because it triggers a bug in some older Windows 10 SDK headers.
+# Turn off /Zc:preprocessor for this test because it triggers a bug in some older Windows 10 SDK headers.
+if(MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.25" AND
+    CMAKE_SYSTEM_VERSION VERSION_LESS "10.0.22621")
   set_source_files_properties(test_util_DirEntry.cpp PROPERTIES COMPILE_FLAGS /Zc:preprocessor-)
 endif()
 


### PR DESCRIPTION
Don't add the `/Zc:preprocessor-` compiler flag when it's not needed, to avoid the following warning: `D9025 : overriding '/Zc:preprocessor' with '/Zc:preprocessor-`

The latest Windows SDK `v10.0.22621` compiles fine with conforming preprocessor enabled, the bug was in older SDK-s like `<=10.0.20348.0`.

Also, add the /Zc:preprocessor for msvc `>=v19.25`, it didn't exist before this version (it existed as `/experimental:preprocessor` before), like is described [here](https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-170).

I tried to recompile ccache with older SDK-s `10.0.18362` and `10.0.20348.0`, and I didn't get any new compile errors or warnings without this `/Zc:preprocessor-` option, [here](https://developercommunity.visualstudio.com/t/older-winsdk-headers-are-incompatible-with-zcprepr/1593479) are described some problems with v10.0.20348.0 SDK, but it compiles fine for me.

I'm pretty sure I have compiled and linked against older SDK-es, I checked everything, INCLUDE, LIB env. variables like `gci env: | where value -match 10.0. | fl`, and also CMAKE_SYSTEM_VERSION or also CMAKE_RC_COMPILER uses rc.exe from the older selected SDK like:
```
CMAKE_MT=C:/Program Files (x86)/Windows Kits/10/bin/10.0.20348.0/x64/mt.exe
CMAKE_RC_COMPILER=C:/Program Files (x86)/Windows Kits/10/bin/10.0.20348.0/x64/rc.exe
CMAKE_SYSTEM_VERSION=10.0.20348.0
```

Nevertheless, I'm proposing to **not set** this `/Zc:preprocessor-` for `>=10.0.22621`, so it will be set for `<10.0.22621` only (even if these older SDK-s compile fine), just to be safe, I don't care about older SDK-s 😁. It can still be set eg. to `10.0.20348.0`.

Now I also tried to compile with old msvc compiler and it issues this warning for every TU:
```
[80/168] Building CXX object src\ccache\CMakeFiles\ccache_framework.dir\argprocessing.cpp.obj
cl : Command line warning D9002 : ignoring unknown option '/Zc:preprocessor'
```