### PR TITLE
build: Fix name of CppHttplib library

### DIFF
--- a/cmake/FindCppHttplib.cmake
+++ b/cmake/FindCppHttplib.cmake
@@ -12,7 +12,11 @@ else()
     if(NOT "${CMAKE_MATCH_0}" STREQUAL "" AND "${_cpphttplib_version_string}" VERSION_GREATER_EQUAL "${CppHttplib_FIND_VERSION}")
       # Some dists like Fedora package cpp-httplib as a single header while some
       # dists like Debian package it as a traditional library.
-      find_library(CPPHTTPLIB_LIBRARY cpp-httplib)
+      find_library(CPPHTTPLIB_LIBRARY httplib)
+      if(NOT CPPHTTPLIB_LIBRARY)
+        find_library(CPPHTTPLIB_LIBRARY cpp-httplib)
+      endif()
+
       if(CPPHTTPLIB_LIBRARY)
         message(STATUS "Using system CppHttplib (${CPPHTTPLIB_LIBRARY})")
         add_library(dep_cpphttplib UNKNOWN IMPORTED)


### PR DESCRIPTION
On Gentoo, the library name is 'httplib', not 'cpp-httplib'.

--

Note that I'm kind of submitting this as a POC patch. I'm not sure if the library name really is cpp-httplib or not on other distros. We're _not_ renaming it in Gentoo as far as I can tell, we're using upstream's CMake build (https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-cpp/cpp-httplib/cpp-httplib-0.15.3.ebuild).

If it really is cpp-httplib on other distros, some fallback will be needed instead. I can do that if desired.