### PR TITLE
fix: Add the --compile option to be compliant with nvcc

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -591,7 +591,7 @@ process_option_arg(const Context& ctx,
   }
 
   // We must have -c.
-  if (arg == "-c") {
+  if (arg == "-c" || arg == "--compile") {
     state.found_c_opt = true;
     return Statistic::none;
   }


### PR DESCRIPTION
The nvcc (CUDA) compiler has a extra option compliant with -c: --compile. https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#supported-phases

So ccache should see the --compile option as the -c option (especially because the CUDA MVS plugin use it!)

