### PR TITLE
fix: use bash for running script command

### DIFF
--- a/test/suites/color_diagnostics.bash
+++ b/test/suites/color_diagnostics.bash
@@ -79,6 +79,8 @@ color_diagnostics_generate_permutations() {
 }
 
 color_diagnostics_run_on_pty() {
+    # command uses bash syntax, make sure that script uses the bash shell to run
+    SHELL=$BASH \
     script --return --quiet --command "unset GCC_COLORS; CCACHE_DIR='$CCACHE_DIR' ${2:?}" /dev/null </dev/null >"${1:?}"
 
     # script returns early on some platforms (leaving a child process living for


### PR DESCRIPTION
The script program will try to run the --command parameter with the login shell,
rather than the currently running test shell (bash).

So if your login shell is set to a csh variant instead of a sh variant, you will get syntax errors from `CCACHE_DIR=$CCACHE_DIR`

Just set `SHELL=$BASH`:

```
ENVIRONMENT
       The following environment variable is utilized by script:

       SHELL  If  the variable SHELL exists, the shell forked by script will be that shell.  If SHELL is not set, the
              Bourne shell is assumed.  (Most shells set this variable automatically).
```
