### PR TITLE
Add topscc support

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -245,6 +245,8 @@ parse_compiler_type(const std::string& value)
     return CompilerType::gcc;
   } else if (value == "nvcc") {
     return CompilerType::nvcc;
+  } else if (value == "topscc") {
+    return CompilerType::topscc;
   } else if (value == "other") {
     return CompilerType::other;
   } else if (value == "pump") {
@@ -453,6 +455,7 @@ compiler_type_to_string(CompilerType compiler_type)
     CASE(clang);
     CASE(gcc);
     CASE(nvcc);
+    CASE(topscc);
     CASE(other);
     CASE(pump);
   }

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -31,7 +31,7 @@
 #include <string>
 #include <unordered_map>
 
-enum class CompilerType { auto_guess, clang, gcc, nvcc, other, pump };
+enum class CompilerType { auto_guess, clang, gcc, nvcc, topscc, other, pump };
 
 std::string compiler_type_to_string(CompilerType compiler_type);
 

--- a/src/compopt.cpp
+++ b/src/compopt.cpp
@@ -121,6 +121,8 @@ const CompOpt compopts[] = {
   {"-iquote", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-isysroot", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-isystem", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
+  {"--tops-device-lib", AFFECTS_COMP | TAKES_ARG | TAKES_CONCAT_ARG}, // topscc
+  {"--tops-device-lib-path", AFFECTS_COMP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // topscc
   {"-ivfsoverlay", TAKES_ARG},
   {"-iwithprefix", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-iwithprefixbefore",

--- a/src/storage/Storage.cpp
+++ b/src/storage/Storage.cpp
@@ -61,11 +61,12 @@ std::string
 get_features()
 {
   std::vector<std::string> features;
-  features.reserve(k_secondary_storage_implementations.size());
+  features.reserve(k_secondary_storage_implementations.size()+1);
   std::transform(k_secondary_storage_implementations.begin(),
                  k_secondary_storage_implementations.end(),
                  std::back_inserter(features),
                  [](auto& entry) { return FMT("{}-storage", entry.first); });
+  features.push_back("topscc-support");
   std::sort(features.begin(), features.end());
   return util::join(features, " ");
 }


### PR DESCRIPTION
feat: add topscc support

TopsCC is a groundbreaking heterogeneous compiler that leverages the robust LLVM framework, proudly brought to you by Enflame-Tech. For a deeper dive into its capabilities and features, visit the official website: [Enflame-Tech Software](https://www.enflame-tech.com/software/topsrider).

Similar to NVIDIA's nvcc, TopsCC is adept at compiling a single source file that encompasses both host code and kernel code. This streamlined process ensures seamless integration and execution.

Furthermore, TopsCC extends its support by allowing the use of additional kernel libraries for linking purposes. Utilize the `--tops-device-lib-path` option to specify the link path and `--tops-device-lib` to denote the libraries needed. This flexibility caters to a broader range of development needs and enhances the overall utility of the compiler.

