### PR TITLE
feat: Add ability to send arbitrary http headers to http storage

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -1309,6 +1309,9 @@ values.
 --
 +
 The default is *subdirs*.
+* *header*: Add the key=value pair to the HTTP headers of the request. For example:
+   `+header=Content-Type=application/octet-stream+` adds
+   "Content-Type: application/octet-stream" to the http headers of the request.
 * *operation-timeout*: Timeout (in ms) for HTTP requests. The default is 10000.
 
 


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
This change adds the ability to send arbitrary http headers to the http backend storage. There are two main use cases:
1. An http server may require certain headers in order to process files correctly. For example, a server might require "content-type: application/octet-stream" to handle binary data.
2. It could be useful to collect metadata, such as the git commit id of branch being built, or the merge-base. This could be used to optimize the backend storage and/or collect metrics on usage.