### PR TITLE
chore: Use ASCII chars

### DIFF
--- a/src/ccache/storage/remote/redisstorage.cpp
+++ b/src/ccache/storage/remote/redisstorage.cpp
@@ -32,7 +32,7 @@
 #  include <sys/utime.h> // for timeval
 #endif
 
-// Ignore "ISO C++ forbids flexible array member ‘buf’" warning from -Wpedantic.
+// Ignore "ISO C++ forbids flexible array member 'buf'" warning from -Wpedantic.
 #ifdef __GNUC__
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wpedantic"


### PR DESCRIPTION
MSVC uses locale encoding by default. The UTF-8 chars cause
```
warning C4819: The file contains a character that cannot be represented in the current code page (936).
Save the file in Unicode format to prevent data loss.
```