### PR TITLE
feat: Option absolute_paths_in_stderr also rewrites relative paths in MSVC diagnostics messages

### DIFF
--- a/src/ccache/core/common.cpp
+++ b/src/ccache/core/common.cpp
@@ -110,8 +110,8 @@ rewrite_stderr_to_absolute_paths(std::string_view text)
       result.append(csi_seq.data(), csi_seq.length());
       line = line.substr(csi_seq.length());
     }
-    size_t path_end = line.find(':');
-    if (path_end == std::string_view::npos) {
+    size_t path_end = get_diagnostics_path_length(line);
+    if (path_end == 0) {
       result.append(line.data(), line.length());
     } else {
       fs::path path(line.substr(0, path_end));

--- a/src/ccache/core/common.hpp
+++ b/src/ccache/core/common.hpp
@@ -33,11 +33,14 @@ void ensure_dir_exists(const std::filesystem::path& dir);
 std::filesystem::path make_relative_path(const Context& ctx,
                                          const std::filesystem::path& path);
 
-// Rewrite path to absolute path in `text` in the following two cases, where X
+// Rewrite path to absolute path in `text` in the following cases, where X
 // may be optional ANSI CSI sequences:
 //
 //     X<path>[:1:2]X: ...
 //     In file included from X<path>[:1:2]X:
+//     X<path>(line[,column])[ ]: ...
+//
+// See get_diagnostics_path_length().
 std::string rewrite_stderr_to_absolute_paths(std::string_view text);
 
 // Send `text` to file descriptor `fd` (typically stdout or stderr, which

--- a/src/ccache/core/common.hpp
+++ b/src/ccache/core/common.hpp
@@ -50,4 +50,10 @@ void send_to_console(const Context& ctx, std::string_view text, int fd);
 // Returns a copy of string with the specified ANSI CSI sequences removed.
 [[nodiscard]] std::string strip_ansi_csi_seqs(std::string_view string);
 
+// Get the length of paths in compiler diagnostics messages in following forms:
+// 1. <path>:
+// 2. <path>(line[,column]):    // MSVC
+// 3. <path>(line[,column]) :   // MSVC
+std::size_t get_diagnostics_path_length(std::string_view line);
+
 } // namespace core

--- a/unittest/test_core_common.cpp
+++ b/unittest/test_core_common.cpp
@@ -83,4 +83,21 @@ TEST_CASE("core::strip_ansi_csi_seqs")
   CHECK(core::strip_ansi_csi_seqs(input) == "Normal, bold, red, bold green.\n");
 }
 
+TEST_CASE("core::get_diagnostics_path_length")
+{
+  CHECK(core::get_diagnostics_path_length("a:1:") == 1);
+  CHECK(core::get_diagnostics_path_length("a(1):") == 1);
+  CHECK(core::get_diagnostics_path_length("a(1) :") == 1);
+  CHECK(core::get_diagnostics_path_length("a(1,2):") == 1);
+  CHECK(core::get_diagnostics_path_length("a(1,2) :") == 1);
+
+#ifdef _WIN32
+  CHECK(core::get_diagnostics_path_length("C:\\a:1:") == 4);
+  CHECK(core::get_diagnostics_path_length("C:\\a(1):") == 4);
+  CHECK(core::get_diagnostics_path_length("C:\\a(1) :") == 4);
+  CHECK(core::get_diagnostics_path_length("C:\\a(1,2):") == 4);
+  CHECK(core::get_diagnostics_path_length("C:\\a(1,2) :") == 4);
+#endif
+}
+
 TEST_SUITE_END();

--- a/unittest/test_core_common.cpp
+++ b/unittest/test_core_common.cpp
@@ -54,7 +54,16 @@ TEST_CASE("core::rewrite_stderr_to_absolute_paths")
 
   std::string input =
     "a:1:2\n"
+    "a(3):\n"
+    "a(3) :\n"
+    "a(3,4):\n"
+    "a(3,4) :\n"
+    "existing\n"
     "existing:3:4\n"
+    "existing(3):\n"
+    "existing(3) :\n"
+    "existing(3,4):\n"
+    "existing(3,4) :\n"
     "c:5:6\n"
     "\x1b[01m\x1b[Kexisting:\x1b[m\x1b[K: foo\n"
     "\x1b[01m\x1b[Kexisting:47:11:\x1b[m\x1b[K: foo\n"
@@ -62,7 +71,16 @@ TEST_CASE("core::rewrite_stderr_to_absolute_paths")
     "In file included from \x1b[01m\x1b[Kexisting:47:11:\x1b[m\x1b[K: foo\n";
   std::string expected = FMT(
     "a:1:2\n"
+    "a(3):\n"
+    "a(3) :\n"
+    "a(3,4):\n"
+    "a(3,4) :\n"
+    "existing\n"
     "{0}:3:4\n"
+    "{0}(3):\n"
+    "{0}(3) :\n"
+    "{0}(3,4):\n"
+    "{0}(3,4) :\n"
     "c:5:6\n"
     "\x1b[01m\x1b[K{0}:\x1b[m\x1b[K: foo\n"
     "\x1b[01m\x1b[K{0}:47:11:\x1b[m\x1b[K: foo\n"


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
