### PR TITLE
fix(http-storage): Make sure 'keep-alive' can be overridden as expected

### DIFF
--- a/src/ccache/storage/remote/httpstorage.cpp
+++ b/src/ccache/storage/remote/httpstorage.cpp
@@ -119,6 +119,8 @@ HttpStorageBackend::HttpStorageBackend(
     m_http_client.set_basic_auth(std::string(user), std::string(*password));
   }
 
+  m_http_client.set_keep_alive(true);
+
   auto connect_timeout = k_default_connect_timeout;
   auto operation_timeout = k_default_operation_timeout;
 
@@ -159,7 +161,6 @@ HttpStorageBackend::HttpStorageBackend(
   m_http_client.set_connection_timeout(connect_timeout);
   m_http_client.set_read_timeout(operation_timeout);
   m_http_client.set_write_timeout(operation_timeout);
-  m_http_client.set_keep_alive(true);
   m_http_client.set_default_headers(default_headers);
 }
 


### PR DESCRIPTION
The changes introduced in dfcdb68 made it impossible to disable HTTP keep-alive
by setting the 'keep-alive' attribute in the backend string accordingly: The
default of 'true' is applied after parsing of the attributes, overriding the
value configured by the user (if any). Rectify this.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
