### PR TITLE
feat: Implement atfile_format config option to control rsp file format

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -991,6 +991,23 @@ NOTE: In previous ccache versions this option was called *secondary_storage*
     If true, ccache will write results to remote storage even for local storage
     cache hits. The default is false.
 
+[#config_response_file_format]
+*response_file_format* (*CCACHE_RESPONSE_FILE_FORMAT*)::
+
+    Ccache normally guesses the response file format based on the compiler type. The
+    *response_file_format* option lets you force the response file format. This can
+    be useful if the compiler supports both posix and windows response file quoting.
+    Possible values are:
++
+--
+*auto*::
+    Guess one of the formats below based on the compiler type. This is the default.
+*gcc*::
+    Posix quoting behavior.
+*msvc*::
+    Windows quoting behavior.
+--
+
 [#config_run_second_cpp]
 *run_second_cpp* (*CCACHE_CPP2* or *CCACHE_NOCPP2*, see _<<Boolean values>>_ above)::
 

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -995,16 +995,16 @@ NOTE: In previous ccache versions this option was called *secondary_storage*
 *response_file_format* (*CCACHE_RESPONSE_FILE_FORMAT*)::
 
     Ccache normally guesses the response file format based on the compiler type. The
-    *response_file_format* option lets you force the response file format. This can
-    be useful if the compiler supports both posix and windows response file quoting.
-    Possible values are:
+    *response_file_format* option lets you force the response file quoting behavior.
+    This can be useful if the compiler supports both posix and windows response file
+    quoting. Possible values are:
 +
 --
 *auto*::
     Guess one of the formats below based on the compiler type. This is the default.
-*gcc*::
+*posix*::
     Posix quoting behavior.
-*msvc*::
+*windows*::
     Windows quoting behavior.
 --
 

--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -400,10 +400,7 @@ process_option_arg(const Context& ctx,
     if (argpath[-1] == '-') {
       ++argpath;
     }
-    auto file_args = Args::from_atfile(argpath,
-                                       config.is_compiler_group_msvc()
-                                         ? Args::AtFileFormat::msvc
-                                         : Args::AtFileFormat::gcc);
+    auto file_args = Args::from_atfile(argpath, config.atfile_format());
     if (!file_args) {
       LOG("Couldn't read arg file {}", argpath);
       return Statistic::bad_compiler_arguments;
@@ -426,7 +423,7 @@ process_option_arg(const Context& ctx,
     // Argument is a comma-separated list of files.
     auto paths = util::split_into_strings(args[i], ",");
     for (auto it = paths.rbegin(); it != paths.rend(); ++it) {
-      auto file_args = Args::from_atfile(*it);
+      auto file_args = Args::from_atfile(*it, AtFileFormat::gcc);
       if (!file_args) {
         LOG("Couldn't read CUDA options file {}", *it);
         return Statistic::bad_compiler_arguments;

--- a/src/ccache/args.cpp
+++ b/src/ccache/args.cpp
@@ -18,7 +18,9 @@
 
 #include "args.hpp"
 
+#include <ccache/config.hpp>
 #include <ccache/core/exceptions.hpp>
+#include <ccache/util/assertions.hpp>
 #include <ccache/util/file.hpp>
 #include <ccache/util/logging.hpp>
 #include <ccache/util/string.hpp>
@@ -48,6 +50,8 @@ Args::from_string(std::string_view command)
 std::optional<Args>
 Args::from_atfile(const std::string& filename, AtFileFormat format)
 {
+  ASSERT(format != AtFileFormat::guess_from_compiler);
+
   const auto argtext = util::read_file<std::string>(filename);
   if (!argtext) {
     LOG("Failed to read atfile {}: {}", filename, argtext.error());

--- a/src/ccache/args.cpp
+++ b/src/ccache/args.cpp
@@ -72,6 +72,8 @@ Args::from_atfile(const std::string& filename, AtFileFormat format)
     switch (*pos) {
     case '\\':
       switch (format) {
+      default:
+        break;
       case AtFileFormat::gcc:
         pos++;
         if (*pos == '\0') {

--- a/src/ccache/args.cpp
+++ b/src/ccache/args.cpp
@@ -72,7 +72,8 @@ Args::from_atfile(const std::string& filename, AtFileFormat format)
     switch (*pos) {
     case '\\':
       switch (format) {
-      default:
+      case AtFileFormat::auto_guess:
+        ASSERT(false); // Can't happen
         break;
       case AtFileFormat::gcc:
         pos++;

--- a/src/ccache/args.cpp
+++ b/src/ccache/args.cpp
@@ -50,7 +50,7 @@ Args::from_string(std::string_view command)
 std::optional<Args>
 Args::from_atfile(const std::string& filename, AtFileFormat format)
 {
-  ASSERT(format != AtFileFormat::guess_from_compiler);
+  ASSERT(format != AtFileFormat::auto_guess);
 
   const auto argtext = util::read_file<std::string>(filename);
   if (!argtext) {

--- a/src/ccache/args.hpp
+++ b/src/ccache/args.hpp
@@ -25,14 +25,11 @@
 #include <string_view>
 #include <vector>
 
+enum class AtFileFormat;
+
 class Args
 {
 public:
-  enum class AtFileFormat {
-    gcc,  // '\'' and '"' quote, '\\' escapes any character
-    msvc, // '"' quotes, '\\' escapes only '"' and '\\'
-  };
-
   Args() = default;
   Args(const Args& other) = default;
   Args(Args&& other) noexcept;
@@ -41,8 +38,7 @@ public:
   static Args from_string(std::string_view command);
 
   static std::optional<Args>
-  from_atfile(const std::string& filename,
-              AtFileFormat format = AtFileFormat::gcc);
+  from_atfile(const std::string& filename, AtFileFormat format);
 
   Args& operator=(const Args& other) = default;
   Args& operator=(Args&& other) noexcept;

--- a/src/ccache/args.hpp
+++ b/src/ccache/args.hpp
@@ -37,8 +37,8 @@ public:
   static Args from_argv(int argc, const char* const* argv);
   static Args from_string(std::string_view command);
 
-  static std::optional<Args>
-  from_atfile(const std::string& filename, AtFileFormat format);
+  static std::optional<Args> from_atfile(const std::string& filename,
+                                         AtFileFormat format);
 
   Args& operator=(const Args& other) = default;
   Args& operator=(Args&& other) noexcept;

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -228,9 +228,9 @@ const std::unordered_map<std::string, std::string> k_env_variable_table = {
 AtFileFormat
 parse_response_file_format(const std::string& value)
 {
-  if (value == "msvc") {
+  if (value == "windows") {
     return AtFileFormat::msvc;
-  } else if (value == "gcc") {
+  } else if (value == "posix") {
     return AtFileFormat::gcc;
   } else {
     return AtFileFormat::auto_guess;
@@ -544,9 +544,9 @@ atfile_format_to_string(AtFileFormat atfile_format)
   case AtFileFormat::auto_guess:
     return "auto";
   case AtFileFormat::gcc:
-    return "gcc";
+    return "posix";
   case AtFileFormat::msvc:
-    return "msvc";
+    return "windows";
   }
 
   ASSERT(false);

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -233,7 +233,7 @@ parse_atfile_format(const std::string& value)
   } else if (value == "gcc") {
     return AtFileFormat::gcc;
   } else {
-    throw core::Error(FMT("invalid value for atfile format: \"{}\"", value));
+    return AtFileFormat::auto_guess;
   }
 }
 
@@ -541,8 +541,8 @@ std::string
 atfile_format_to_string(AtFileFormat atfile_format)
 {
   switch (atfile_format) {
-  case AtFileFormat::guess_from_compiler:
-    return "guess_from_compiler";
+  case AtFileFormat::auto_guess:
+    return "auto";
   case AtFileFormat::gcc:
     return "gcc";
   case AtFileFormat::msvc:

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -71,7 +71,6 @@ namespace {
 
 enum class ConfigItem {
   absolute_paths_in_stderr,
-  atfile_format,
   base_dir,
   cache_dir,
   compiler,
@@ -109,6 +108,7 @@ enum class ConfigItem {
   remote_only,
   remote_storage,
   reshare,
+  response_file_format,
   run_second_cpp,
   sloppiness,
   stats,
@@ -128,7 +128,6 @@ struct ConfigKeyTableEntry
 const std::unordered_map<std::string, ConfigKeyTableEntry> k_config_key_table =
   {
     {"absolute_paths_in_stderr", {ConfigItem::absolute_paths_in_stderr}},
-    {"atfile_format", {ConfigItem::atfile_format}},
     {"base_dir", {ConfigItem::base_dir}},
     {"cache_dir", {ConfigItem::cache_dir}},
     {"compiler", {ConfigItem::compiler}},
@@ -166,6 +165,7 @@ const std::unordered_map<std::string, ConfigKeyTableEntry> k_config_key_table =
     {"remote_only", {ConfigItem::remote_only}},
     {"remote_storage", {ConfigItem::remote_storage}},
     {"reshare", {ConfigItem::reshare}},
+    {"response_file_format", {ConfigItem::response_file_format}},
     {"run_second_cpp", {ConfigItem::run_second_cpp}},
     {"secondary_storage", {ConfigItem::remote_storage, "remote_storage"}},
     {"sloppiness", {ConfigItem::sloppiness}},
@@ -177,7 +177,6 @@ const std::unordered_map<std::string, ConfigKeyTableEntry> k_config_key_table =
 
 const std::unordered_map<std::string, std::string> k_env_variable_table = {
   {"ABSSTDERR", "absolute_paths_in_stderr"},
-  {"ATFILE_FORMAT", "atfile_format"},
   {"BASEDIR", "base_dir"},
   {"CC", "compiler"}, // Alias for CCACHE_COMPILER
   {"COMMENTS", "keep_comments_cpp"},
@@ -217,6 +216,7 @@ const std::unordered_map<std::string, std::string> k_env_variable_table = {
   {"REMOTE_ONLY", "remote_only"},
   {"REMOTE_STORAGE", "remote_storage"},
   {"RESHARE", "reshare"},
+  {"RESPONSE_FILE_FORMAT", "response_file_format"},
   {"SECONDARY_STORAGE", "remote_storage"}, // Alias for CCACHE_REMOTE_STORAGE
   {"SLOPPINESS", "sloppiness"},
   {"STATS", "stats"},
@@ -226,7 +226,7 @@ const std::unordered_map<std::string, std::string> k_env_variable_table = {
 };
 
 AtFileFormat
-parse_atfile_format(const std::string& value)
+parse_response_file_format(const std::string& value)
 {
   if (value == "msvc") {
     return AtFileFormat::msvc;
@@ -785,9 +785,6 @@ Config::get_string_value(const std::string& key) const
   case ConfigItem::absolute_paths_in_stderr:
     return format_bool(m_absolute_paths_in_stderr);
 
-  case ConfigItem::atfile_format:
-    return atfile_format_to_string(m_atfile_format);
-
   case ConfigItem::base_dir:
     return util::pstr(m_base_dir);
 
@@ -906,6 +903,9 @@ Config::get_string_value(const std::string& key) const
   case ConfigItem::reshare:
     return format_bool(m_reshare);
 
+  case ConfigItem::response_file_format:
+    return atfile_format_to_string(m_atfile_format);
+
   case ConfigItem::run_second_cpp:
     return format_bool(m_run_second_cpp);
 
@@ -1012,10 +1012,6 @@ Config::set_item(const std::string& key,
   switch (it->second.item) {
   case ConfigItem::absolute_paths_in_stderr:
     m_absolute_paths_in_stderr = parse_bool(value, env_var_key, negate);
-    break;
-
-  case ConfigItem::atfile_format:
-    m_atfile_format = parse_atfile_format(value);
     break;
 
   case ConfigItem::base_dir:
@@ -1175,6 +1171,10 @@ Config::set_item(const std::string& key,
 
   case ConfigItem::reshare:
     m_reshare = parse_bool(value, env_var_key, negate);
+    break;
+
+  case ConfigItem::response_file_format:
+    m_atfile_format = parse_response_file_format(value);
     break;
 
   case ConfigItem::run_second_cpp:

--- a/src/ccache/config.hpp
+++ b/src/ccache/config.hpp
@@ -43,6 +43,12 @@ enum class CompilerType {
   other
 };
 
+enum class AtFileFormat {
+  gcc,  // '\'' and '"' quote, '\\' escapes any character
+  msvc, // '"' quotes, '\\' escapes only '"' and '\\'
+  guess_from_compiler,
+};
+
 std::string compiler_type_to_string(CompilerType compiler_type);
 
 class Config : util::NonCopyable
@@ -53,6 +59,7 @@ public:
   void read(const std::vector<std::string>& cmdline_config_settings = {});
 
   bool absolute_paths_in_stderr() const;
+  AtFileFormat atfile_format() const;
   const std::filesystem::path& base_dir() const;
   const std::filesystem::path& cache_dir() const;
   const std::string& compiler() const;
@@ -168,6 +175,7 @@ private:
   std::filesystem::path m_system_config_path;
 
   bool m_absolute_paths_in_stderr = false;
+  AtFileFormat m_atfile_format = AtFileFormat::guess_from_compiler;
   std::filesystem::path m_base_dir;
   std::filesystem::path m_cache_dir;
   std::string m_compiler;
@@ -234,6 +242,20 @@ inline bool
 Config::absolute_paths_in_stderr() const
 {
   return m_absolute_paths_in_stderr;
+}
+
+inline AtFileFormat
+Config::atfile_format() const
+{
+  if (m_atfile_format != AtFileFormat::guess_from_compiler) {
+    return m_atfile_format;
+  }
+
+  if (is_compiler_group_msvc()) {
+    return AtFileFormat::msvc;
+  }
+
+  return AtFileFormat::gcc;
 }
 
 inline const std::filesystem::path&

--- a/src/ccache/config.hpp
+++ b/src/ccache/config.hpp
@@ -46,7 +46,7 @@ enum class CompilerType {
 enum class AtFileFormat {
   gcc,  // '\'' and '"' quote, '\\' escapes any character
   msvc, // '"' quotes, '\\' escapes only '"' and '\\'
-  guess_from_compiler,
+  auto_guess,
 };
 
 std::string compiler_type_to_string(CompilerType compiler_type);
@@ -175,7 +175,7 @@ private:
   std::filesystem::path m_system_config_path;
 
   bool m_absolute_paths_in_stderr = false;
-  AtFileFormat m_atfile_format = AtFileFormat::guess_from_compiler;
+  AtFileFormat m_atfile_format = AtFileFormat::auto_guess;
   std::filesystem::path m_base_dir;
   std::filesystem::path m_cache_dir;
   std::string m_compiler;
@@ -247,7 +247,7 @@ Config::absolute_paths_in_stderr() const
 inline AtFileFormat
 Config::atfile_format() const
 {
-  if (m_atfile_format != AtFileFormat::guess_from_compiler) {
+  if (m_atfile_format != AtFileFormat::auto_guess) {
     return m_atfile_format;
   }
 

--- a/unittest/test_config.cpp
+++ b/unittest/test_config.cpp
@@ -308,6 +308,51 @@ TEST_CASE("Config::update_from_environment")
   CHECK(!config.compression());
 }
 
+TEST_CASE("Config:atfile_format")
+{
+  Config config;
+
+  SUBCASE("from config gcc")
+  {
+    util::write_file("ccache.conf", "atfile_format = gcc");
+    CHECK(config.update_from_file("ccache.conf"));
+
+    CHECK(config.atfile_format() == AtFileFormat::gcc);
+  }
+
+  SUBCASE("from config msvc")
+  {
+    util::write_file("ccache.conf", "atfile_format = msvc");
+    CHECK(config.update_from_file("ccache.conf"));
+
+    CHECK(config.atfile_format() == AtFileFormat::msvc);
+  }
+
+  SUBCASE("from config msvc with clang compiler")
+  {
+    util::write_file("ccache.conf", "atfile_format = msvc\ncompiler_type = clang");
+    CHECK(config.update_from_file("ccache.conf"));
+
+    CHECK(config.atfile_format() == AtFileFormat::msvc);
+  }
+
+  SUBCASE("guess from compiler gcc")
+  {
+    util::write_file("ccache.conf", "compiler_type = clang");
+    CHECK(config.update_from_file("ccache.conf"));
+
+    CHECK(config.atfile_format() == AtFileFormat::gcc);
+  }
+
+  SUBCASE("guess from compiler msvc")
+  {
+    util::write_file("ccache.conf", "compiler_type = msvc");
+    CHECK(config.update_from_file("ccache.conf"));
+
+    CHECK(config.atfile_format() == AtFileFormat::msvc);
+  }
+}
+
 TEST_CASE("Config::set_value_in_file")
 {
   TestContext test_context;
@@ -389,6 +434,7 @@ TEST_CASE("Config::visit_items")
   util::write_file(
     "test.conf",
     "absolute_paths_in_stderr = true\n"
+    "atfile_format = gcc\n"
 #ifndef _WIN32
     "base_dir = /bd\n"
 #else
@@ -451,6 +497,7 @@ TEST_CASE("Config::visit_items")
 
   std::vector<std::string> expected = {
     "(test.conf) absolute_paths_in_stderr = true",
+    "(test.conf) atfile_format = gcc",
 #ifndef _WIN32
     "(test.conf) base_dir = /bd",
 #else

--- a/unittest/test_config.cpp
+++ b/unittest/test_config.cpp
@@ -308,13 +308,13 @@ TEST_CASE("Config::update_from_environment")
   CHECK(!config.compression());
 }
 
-TEST_CASE("Config::atfile_format")
+TEST_CASE("Config::response_file_format")
 {
   Config config;
 
   SUBCASE("from config gcc")
   {
-    util::write_file("ccache.conf", "atfile_format = gcc");
+    util::write_file("ccache.conf", "response_file_format = gcc");
     CHECK(config.update_from_file("ccache.conf"));
 
     CHECK(config.atfile_format() == AtFileFormat::gcc);
@@ -322,7 +322,7 @@ TEST_CASE("Config::atfile_format")
 
   SUBCASE("from config msvc")
   {
-    util::write_file("ccache.conf", "atfile_format = msvc");
+    util::write_file("ccache.conf", "response_file_format = msvc");
     CHECK(config.update_from_file("ccache.conf"));
 
     CHECK(config.atfile_format() == AtFileFormat::msvc);
@@ -331,7 +331,7 @@ TEST_CASE("Config::atfile_format")
   SUBCASE("from config msvc with clang compiler")
   {
     util::write_file("ccache.conf",
-                     "atfile_format = msvc\ncompiler_type = clang");
+                     "response_file_format = msvc\ncompiler_type = clang");
     CHECK(config.update_from_file("ccache.conf"));
 
     CHECK(config.atfile_format() == AtFileFormat::msvc);
@@ -435,7 +435,6 @@ TEST_CASE("Config::visit_items")
   util::write_file(
     "test.conf",
     "absolute_paths_in_stderr = true\n"
-    "atfile_format = gcc\n"
 #ifndef _WIN32
     "base_dir = /bd\n"
 #else
@@ -477,6 +476,7 @@ TEST_CASE("Config::visit_items")
     "remote_only = true\n"
     "remote_storage = rs\n"
     "reshare = true\n"
+    "response_file_format = gcc\n"
     "run_second_cpp = false\n"
     "sloppiness = include_file_mtime, include_file_ctime, time_macros,"
     " file_stat_matches, file_stat_matches_ctime, pch_defines, system_headers,"
@@ -498,7 +498,6 @@ TEST_CASE("Config::visit_items")
 
   std::vector<std::string> expected = {
     "(test.conf) absolute_paths_in_stderr = true",
-    "(test.conf) atfile_format = gcc",
 #ifndef _WIN32
     "(test.conf) base_dir = /bd",
 #else
@@ -540,6 +539,7 @@ TEST_CASE("Config::visit_items")
     "(test.conf) remote_only = true",
     "(test.conf) remote_storage = rs",
     "(test.conf) reshare = true",
+    "(test.conf) response_file_format = gcc",
     "(test.conf) run_second_cpp = false",
     "(test.conf) sloppiness = clang_index_store, file_stat_matches,"
     " file_stat_matches_ctime, gcno_cwd, include_file_ctime,"

--- a/unittest/test_config.cpp
+++ b/unittest/test_config.cpp
@@ -308,7 +308,7 @@ TEST_CASE("Config::update_from_environment")
   CHECK(!config.compression());
 }
 
-TEST_CASE("Config:atfile_format")
+TEST_CASE("Config::atfile_format")
 {
   Config config;
 

--- a/unittest/test_config.cpp
+++ b/unittest/test_config.cpp
@@ -314,7 +314,7 @@ TEST_CASE("Config::response_file_format")
 
   SUBCASE("from config gcc")
   {
-    util::write_file("ccache.conf", "response_file_format = gcc");
+    util::write_file("ccache.conf", "response_file_format = posix");
     CHECK(config.update_from_file("ccache.conf"));
 
     CHECK(config.atfile_format() == AtFileFormat::gcc);
@@ -322,7 +322,7 @@ TEST_CASE("Config::response_file_format")
 
   SUBCASE("from config msvc")
   {
-    util::write_file("ccache.conf", "response_file_format = msvc");
+    util::write_file("ccache.conf", "response_file_format = windows");
     CHECK(config.update_from_file("ccache.conf"));
 
     CHECK(config.atfile_format() == AtFileFormat::msvc);
@@ -331,7 +331,7 @@ TEST_CASE("Config::response_file_format")
   SUBCASE("from config msvc with clang compiler")
   {
     util::write_file("ccache.conf",
-                     "response_file_format = msvc\ncompiler_type = clang");
+                     "response_file_format = windows\ncompiler_type = clang");
     CHECK(config.update_from_file("ccache.conf"));
 
     CHECK(config.atfile_format() == AtFileFormat::msvc);
@@ -476,7 +476,7 @@ TEST_CASE("Config::visit_items")
     "remote_only = true\n"
     "remote_storage = rs\n"
     "reshare = true\n"
-    "response_file_format = gcc\n"
+    "response_file_format = posix\n"
     "run_second_cpp = false\n"
     "sloppiness = include_file_mtime, include_file_ctime, time_macros,"
     " file_stat_matches, file_stat_matches_ctime, pch_defines, system_headers,"
@@ -539,7 +539,7 @@ TEST_CASE("Config::visit_items")
     "(test.conf) remote_only = true",
     "(test.conf) remote_storage = rs",
     "(test.conf) reshare = true",
-    "(test.conf) response_file_format = gcc",
+    "(test.conf) response_file_format = posix",
     "(test.conf) run_second_cpp = false",
     "(test.conf) sloppiness = clang_index_store, file_stat_matches,"
     " file_stat_matches_ctime, gcno_cwd, include_file_ctime,"

--- a/unittest/test_config.cpp
+++ b/unittest/test_config.cpp
@@ -330,7 +330,8 @@ TEST_CASE("Config:atfile_format")
 
   SUBCASE("from config msvc with clang compiler")
   {
-    util::write_file("ccache.conf", "atfile_format = msvc\ncompiler_type = clang");
+    util::write_file("ccache.conf",
+                     "atfile_format = msvc\ncompiler_type = clang");
     CHECK(config.update_from_file("ccache.conf"));
 
     CHECK(config.atfile_format() == AtFileFormat::msvc);


### PR DESCRIPTION
This PR implements a feature to fix a ccache issue we ran into.
Currently when a response file is seen on the command line the quoting behaviour is determined by the compiler type.
clang supports both windows and posix quoting via the `--rsp-quoting=[windows|posix]` option.

Due to NDA restrictions I cannot say what vendor we are using which is also why I cannot add a new compiler_type to special case this vendor's fork of clang.
We are building using a vendor clang to cross-compile to the vendor platform on windows. 
This vendor clang is effectively hardcoded with `--rsp-quoting=windows`.
The vendor MSBuild tasks emit response files with only windows quoting behaviour.

For everything else including the driver mode this vendor clang is clang, behaves like clang and uses clang options. It does not use the cl driver mode so clang-cl is not an option here to get ccache to assume `msvc` rsp format.

We need a way to tell ccache to treat response files as `msvc` even though we are using clang.
