### PR TITLE
Make tests pass in 2038

### DIFF
--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -284,8 +284,9 @@ fi
     # -------------------------------------------------------------------------
     TEST "Too new source file"
 
+    futuretimestamp=$(expr 1 + $(date -u +%Y))01030000
     touch new.c
-    touch -t 203801010000 new.c
+    touch -t $futuretimestamp new.c
 
     $CCACHE_COMPILE -c new.c
     expect_stat modified_input_file 1
@@ -304,7 +305,7 @@ EOF
     cat <<EOF >new.h
 int test;
 EOF
-    touch -t 203801010000 new.h
+    touch -t $futuretimestamp new.h
 
     $CCACHE_COMPILE -c new.c
     expect_stat modified_input_file 1
@@ -318,7 +319,7 @@ EOF
     TEST "Too new source file ignored if sloppy"
 
     touch new.c
-    touch -t 203801010000 new.c
+    touch -t $futuretimestamp new.c
 
     CCACHE_SLOPPINESS="$DEFAULT_SLOPPINESS include_file_mtime" $CCACHE_COMPILE -c new.c
     expect_stat cache_miss 1


### PR DESCRIPTION
Make tests pass in 2038
    
Fixes #1524
    
we use relative future timestamps to keep systems with 32-bit time_t working until 2037 (this should give them 1 year advance warning that they need to fix something).
    
Use the 3rd of January of the following year to ensure that it is in the future, even when starting a second before new year.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
