### PR TITLE
fix: Pass -fprofile-abs-path through to gcc

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -900,6 +900,7 @@ process_option_arg(const Context& ctx,
       // the actual CWD in the .gcno file.
       state.hash_actual_cwd = true;
     }
+    state.common_args.push_back(args[i]);
     return Statistic::none;
   }
 


### PR DESCRIPTION
When caching support for -fprofile-abs-path was added, the argument was omitted from the gcc commandline.

Fixes: 195011ad1b1f ("feat: Add support for GCC -fprofile-abs-path option")