### PR TITLE
feat: Add support for Intel's LLVM-based compilers

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -612,8 +612,8 @@ _<<Using ccache with other compiler wrappers>>_.
     GCC-based compiler.
 *icl*::
     Intel compiler on Windows.
-*icx*::
-    Intel LLVM-based compiler on Windows.
+*icx/icx-cl*::
+    Intel LLVM-based MSVC-compatible compiler on Windows.
 *msvc*::
     Microsoft Visual C++ (MSVC).
 *nvcc*::

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -612,6 +612,8 @@ _<<Using ccache with other compiler wrappers>>_.
     GCC-based compiler.
 *icl*::
     Intel compiler on Windows.
+*icx*::
+    Intel LLVM-based compiler on Windows.
 *msvc*::
     Microsoft Visual C++ (MSVC).
 *nvcc*::

--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -612,7 +612,9 @@ _<<Using ccache with other compiler wrappers>>_.
     GCC-based compiler.
 *icl*::
     Intel compiler on Windows.
-*icx/icx-cl*::
+*icx*::
+    Intel LLVM-based compiler.
+*icx-cl*::
     Intel LLVM-based MSVC-compatible compiler on Windows.
 *msvc*::
     Microsoft Visual C++ (MSVC).

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -325,7 +325,8 @@ do_guess_compiler(const fs::path& path)
     return CompilerType::nvcc;
   } else if (name == "icl") {
     return CompilerType::icl;
-  } else if (name == "icx") {
+  } else if (name == "icx"
+             || name == "icx-cl") {
     return CompilerType::icx;
   } else if (name == "cl") {
     return CompilerType::msvc;

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -325,8 +325,10 @@ do_guess_compiler(const fs::path& path)
     return CompilerType::nvcc;
   } else if (name == "icl") {
     return CompilerType::icl;
-  } else if (name == "icx" || name == "icx-cl") {
+  } else if (name == "icx") {
     return CompilerType::icx;
+  } else if (name == "icx-cl") {
+    return CompilerType::icx_cl;
   } else if (name == "cl") {
     return CompilerType::msvc;
   } else {

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -325,8 +325,7 @@ do_guess_compiler(const fs::path& path)
     return CompilerType::nvcc;
   } else if (name == "icl") {
     return CompilerType::icl;
-  } else if (name == "icx"
-             || name == "icx-cl") {
+  } else if (name == "icx" || name == "icx-cl") {
     return CompilerType::icx;
   } else if (name == "cl") {
     return CompilerType::msvc;

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -325,6 +325,8 @@ do_guess_compiler(const fs::path& path)
     return CompilerType::nvcc;
   } else if (name == "icl") {
     return CompilerType::icl;
+  } else if (name == "icx") {
+    return CompilerType::icx;
   } else if (name == "cl") {
     return CompilerType::msvc;
   } else {

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -290,7 +290,8 @@ parse_compiler_type(const std::string& value)
     return CompilerType::gcc;
   } else if (value == "icl") {
     return CompilerType::icl;
-  } else if (value == "icx") {
+  } else if (value == "icx"
+             || value == "icx-cl") {
     return CompilerType::icx;
   } else if (value == "msvc") {
     return CompilerType::msvc;

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -290,6 +290,8 @@ parse_compiler_type(const std::string& value)
     return CompilerType::gcc;
   } else if (value == "icl") {
     return CompilerType::icl;
+  } else if (value == "icx") {
+    return CompilerType::icx;
   } else if (value == "msvc") {
     return CompilerType::msvc;
   } else if (value == "nvcc") {
@@ -575,6 +577,7 @@ compiler_type_to_string(CompilerType compiler_type)
     CASE(clang);
     CASE(gcc);
     CASE(icl);
+    CASE(icx);
     CASE(msvc);
     CASE(nvcc);
     CASE(other);

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -290,8 +290,10 @@ parse_compiler_type(const std::string& value)
     return CompilerType::gcc;
   } else if (value == "icl") {
     return CompilerType::icl;
-  } else if (value == "icx" || value == "icx-cl") {
+  } else if (value == "icx") {
     return CompilerType::icx;
+  } else if (value == "icx-cl") {
+    return CompilerType::icx_cl;
   } else if (value == "msvc") {
     return CompilerType::msvc;
   } else if (value == "nvcc") {
@@ -573,6 +575,8 @@ compiler_type_to_string(CompilerType compiler_type)
     return "auto";
   case CompilerType::clang_cl:
     return "clang-cl";
+  case CompilerType::icx_cl:
+    return "icx-cl";
 
     CASE(clang);
     CASE(gcc);

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -290,8 +290,7 @@ parse_compiler_type(const std::string& value)
     return CompilerType::gcc;
   } else if (value == "icl") {
     return CompilerType::icl;
-  } else if (value == "icx"
-             || value == "icx-cl") {
+  } else if (value == "icx" || value == "icx-cl") {
     return CompilerType::icx;
   } else if (value == "msvc") {
     return CompilerType::msvc;

--- a/src/ccache/config.hpp
+++ b/src/ccache/config.hpp
@@ -104,7 +104,7 @@ public:
   // Return true for Clang and clang-cl.
   bool is_compiler_group_clang() const;
 
-  // Return true for MSVC (cl.exe), clang-cl, icl, and icx.
+  // Return true for MSVC (cl.exe), clang-cl, icl, icx and icx-cl.
   bool is_compiler_group_msvc() const;
 
   util::SizeUnitPrefixType size_unit_prefix_type() const;

--- a/src/ccache/config.hpp
+++ b/src/ccache/config.hpp
@@ -41,6 +41,7 @@ enum class CompilerType {
   gcc,
   icl,
   icx,
+  icx_cl,
   msvc,
   nvcc,
   other
@@ -101,10 +102,10 @@ public:
   const std::filesystem::path& temporary_dir() const;
   std::optional<mode_t> umask() const;
 
-  // Return true for Clang and clang-cl.
+  // Return true for Clang, clang-cl and icx (not on Windows).
   bool is_compiler_group_clang() const;
 
-  // Return true for MSVC (cl.exe), clang-cl, icl, icx and icx-cl.
+  // Return true for MSVC (cl.exe), clang-cl, icl, icx-cl, and icx (on Windows).
   bool is_compiler_group_msvc() const;
 
   util::SizeUnitPrefixType size_unit_prefix_type() const;
@@ -287,6 +288,9 @@ inline bool
 Config::is_compiler_group_clang() const
 {
   return m_compiler_type == CompilerType::clang
+#ifndef _WIN32
+         || m_compiler_type == CompilerType::icx
+#endif
          || m_compiler_type == CompilerType::clang_cl;
 }
 
@@ -296,7 +300,10 @@ Config::is_compiler_group_msvc() const
   return m_compiler_type == CompilerType::msvc
          || m_compiler_type == CompilerType::clang_cl
          || m_compiler_type == CompilerType::icl
-         || m_compiler_type == CompilerType::icx;
+#ifdef _WIN32
+         || m_compiler_type == CompilerType::icx
+#endif
+         || m_compiler_type == CompilerType::icx_cl;
 }
 
 inline bool

--- a/src/ccache/config.hpp
+++ b/src/ccache/config.hpp
@@ -40,6 +40,7 @@ enum class CompilerType {
   clang_cl,
   gcc,
   icl,
+  icx,
   msvc,
   nvcc,
   other
@@ -103,7 +104,7 @@ public:
   // Return true for Clang and clang-cl.
   bool is_compiler_group_clang() const;
 
-  // Return true for MSVC (cl.exe), clang-cl, and icl.
+  // Return true for MSVC (cl.exe), clang-cl, icl, and icx.
   bool is_compiler_group_msvc() const;
 
   util::SizeUnitPrefixType size_unit_prefix_type() const;
@@ -294,7 +295,8 @@ Config::is_compiler_group_msvc() const
 {
   return m_compiler_type == CompilerType::msvc
          || m_compiler_type == CompilerType::clang_cl
-         || m_compiler_type == CompilerType::icl;
+         || m_compiler_type == CompilerType::icl
+         || m_compiler_type == CompilerType::icx;
 }
 
 inline bool


### PR DESCRIPTION
Intel's LLVM-based compilers are `icx` and `icx-cl`. Add support for them [based](https://github.com/ccache/ccache/pull/1100) on the changes that added support for Intel's legacy compiler, `icl`.

I noticed this because I was trying to use `ccache` with `icx` on Windows and it wasn't working. 

I didn't add a new enum for `icx-cl` because it can be treated exactly the same as `icx`.

Manually verified basic functionality.