### PR TITLE
Refresh dockerfiles.

### DIFF
--- a/dockerfiles/alpine-3.11/Dockerfile
+++ b/dockerfiles/alpine-3.11/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.11
+ARG BASE_IMAGE=alpine:3.11
+FROM ${BASE_IMAGE} AS build
 
 RUN apk add --no-cache \
         bash \

--- a/dockerfiles/alpine-3.15/Dockerfile
+++ b/dockerfiles/alpine-3.15/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.15
+ARG BASE_IMAGE=alpine:3.15
+FROM ${BASE_IMAGE} AS build
 
 RUN apk add --no-cache \
         bash \

--- a/dockerfiles/debian-11/Dockerfile
+++ b/dockerfiles/debian-11/Dockerfile
@@ -1,5 +1,7 @@
-FROM debian:11
+ARG BASE_IMAGE=debian:11
+FROM ${BASE_IMAGE} AS build
 
+ARG GCC_APT="gcc-multilib"
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         bash \
@@ -8,7 +10,7 @@ RUN apt-get update \
         clang \
         cmake \
         elfutils \
-        gcc-multilib \
+        ${GCC_APT} \
         libhiredis-dev \
         libzstd-dev \
         python3 \

--- a/dockerfiles/debian-12/Dockerfile
+++ b/dockerfiles/debian-12/Dockerfile
@@ -1,20 +1,15 @@
-ARG BASE_IMAGE=ubuntu:20.04
+ARG BASE_IMAGE=debian:12
 FROM ${BASE_IMAGE} AS build
 
-# Non-interactive: do not set up timezone settings.
-ARG GCC_APT="gcc-multilib"
 RUN apt-get update \
- && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
-        asciidoctor \
+ && apt-get install -y --no-install-recommends \
         bash \
         build-essential \
         ccache \
         clang \
         cmake \
-        docbook-xml \
-        docbook-xsl \
         elfutils \
-        ${GCC_APT} \
+        gcc \
         libhiredis-dev \
         libzstd-dev \
         python3 \

--- a/dockerfiles/fedora-36/Dockerfile
+++ b/dockerfiles/fedora-36/Dockerfile
@@ -1,4 +1,5 @@
-FROM fedora:36
+ARG BASE_IMAGE=fedora:36
+FROM ${BASE_IMAGE} AS build
 
 RUN dnf install -y \
         autoconf \
@@ -11,6 +12,7 @@ RUN dnf install -y \
         findutils \
         gcc \
         gcc-c++ \
+        libstdc++-static \
         hiredis-devel \
         libzstd-devel \
         make \

--- a/dockerfiles/fedora-40/Dockerfile
+++ b/dockerfiles/fedora-40/Dockerfile
@@ -1,4 +1,5 @@
-FROM fedora:40
+ARG BASE_IMAGE=fedora:40
+FROM ${BASE_IMAGE} AS build
 
 RUN dnf install -y \
         blake3-devel \
@@ -14,6 +15,7 @@ RUN dnf install -y \
         fmt-devel \
         gcc \
         gcc-c++ \
+        libstdc++-static \
         hiredis-devel \
         less \
         libzstd-devel \

--- a/dockerfiles/ubuntu-22.04/Dockerfile
+++ b/dockerfiles/ubuntu-22.04/Dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:22.04
+ARG BASE_IMAGE=ubuntu:22.04
+FROM ${BASE_IMAGE} AS build
 
 # Non-interactive: do not set up timezone settings.
+ARG GCC_APT="gcc-multilib"
 RUN apt-get update \
  && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
         asciidoctor \
@@ -12,7 +14,7 @@ RUN apt-get update \
         docbook-xml \
         docbook-xsl \
         elfutils \
-        gcc-multilib \
+        ${GCC_APT} \
         gcc-12 \
         g++-12 \
         libhiredis-dev \

--- a/dockerfiles/ubuntu-24.04/Dockerfile
+++ b/dockerfiles/ubuntu-24.04/Dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:24.04
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE} AS build
 
 # Non-interactive: do not set up timezone settings.
+ARG GCC_APT="gcc-multilib"
 RUN apt-get update \
  && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
         asciidoctor \
@@ -12,7 +14,7 @@ RUN apt-get update \
         docbook-xml \
         docbook-xsl \
         elfutils \
-        gcc-multilib \
+        ${GCC_APT} \
         g++-13 \
         g++-14 \
         libhiredis-dev \


### PR DESCRIPTION
This change refreshes dockerfiles, so that they actually work. This includes:

- Fix: E: Package 'gcc-multilib' has no installation candidate in ubuntu*.
- CentOS images are EOLed.
- Add Debian 12.

It also includes a change to allow BASE_IMAGE to be overridden, this is just a convenience hook for cases when someone wants to use some other version of the base image (or add ccache into an existing custom image that is derived from those).

It also add name to a layer, so again it's easy to extend and build upon, since someone who uses this image is probably just going to pull one or few binaries and throw out the rest.