### PR TITLE
Recognize `.cmd` as a valid program suffix on Windows

### DIFF
--- a/src/ccache/util/path.cpp
+++ b/src/ccache/util/path.cpp
@@ -37,7 +37,7 @@ std::string
 add_exe_suffix(const std::string& program)
 {
   std::string ext = util::to_lowercase(fs::path(program).extension().string());
-  if (ext == ".exe" || ext == ".bat" || ext == ".sh") {
+  if (ext == ".exe" || ext == ".bat" || ext == ".cmd" || ext == ".sh") {
     return program;
   } else {
     return program + ".exe";

--- a/src/ccache/util/path.hpp
+++ b/src/ccache/util/path.hpp
@@ -31,8 +31,8 @@ namespace util {
 
 // --- Interface ---
 
-// Add ".exe" suffix to `program` if it doesn't already end with ".exe", ".bat"
-// or ".sh".
+// Add ".exe" suffix to `program` if it doesn't already end with ".exe", ".bat",
+// ".cmd" or ".sh".
 std::string add_exe_suffix(const std::string& program);
 
 // Return a new path with `extension` added to `path` (keeping any existing


### PR DESCRIPTION
Some compiler wrapper scripts on Windows use the `.cmd` extension. However, ccache currently fails to recognize these scripts:
```
$ ccache C:\Users\leemu\AppData\Local\Temp\.xmake\241225\zigcc\c++.cmd
ccache: error: execute_noreturn of C:\Users\leemu\AppData\Local\Temp\.xmake\241225\zigcc\c++.cmd failed: No such file or directory
```
In contrast, running the script directly works as expected:
```
$ C:\Users\leemu\AppData\Local\Temp\.xmake\241225\zigcc\c++.cmd
zig: error: no input files
```