### PR TITLE
docs: Fix description of icx-cl

### DIFF
--- a/doc/MANUAL.adoc
+++ b/doc/MANUAL.adoc
@@ -615,7 +615,7 @@ _<<Using ccache with other compiler wrappers>>_.
 *icx*::
     Intel LLVM-based compiler.
 *icx-cl*::
-    Intel LLVM-based MSVC-compatible compiler on Windows.
+    Intel LLVM-based MSVC-compatible compiler.
 *msvc*::
     Microsoft Visual C++ (MSVC).
 *nvcc*::


### PR DESCRIPTION
`icx-cl` is available on Linux experimentally, so remove the statement that it is Windows only. It is still MSVC-compatible when used on Linux, so no code changes are required.