### PR TITLE
fix: correctly call sha256sum on macOS

### DIFF
--- a/misc/clang-format
+++ b/misc/clang-format
@@ -54,7 +54,7 @@ if [ ! -x "$clang_format_exe" ]; then
 
     if ! command -v sha256sum >/dev/null; then
         echo "Warning: sha256sum not found, not verifying clang-format integrity" >&2
-    elif ! echo "$checksum $clang_format_exe.tmp" | sha256sum --status -c; then
+    elif ! echo "$checksum $clang_format_exe.tmp" | sha256sum --status -c -; then
         echo "Error: Bad checksum of downloaded clang-format" >&2
         exit 1
     fi


### PR DESCRIPTION
sha256sum requires explicitly using `-` as the input file on macOS.

Fixes https://github.com/ccache/ccache/issues/1542.
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
