### PR TITLE
enhance: Support relative paths necessary for react-native builds in different directories

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -1120,6 +1120,11 @@ process_option_arg(const Context& ctx,
     return Statistic::none;
   }
 
+  if (util::starts_with(arg, "-fbuild-session-file")
+      && !(config.sloppiness().contains(core::Sloppy::time_macros))) {
+    args_info.build_session_file = arg.substr(arg.find('=') + 1);
+  }
+
   if (config.sloppiness().contains(core::Sloppy::clang_index_store)
       && arg == "-index-store-path") {
     // Xcode 9 or later calls Clang with this option. The given path includes a

--- a/src/ccache/argsinfo.hpp
+++ b/src/ccache/argsinfo.hpp
@@ -164,4 +164,7 @@ struct ArgsInfo
   // Compilation directory as passed in -ffile-compilation-dir or
   // -fdebug-compilation-dir.
   std::string compilation_dir;
+
+  // Build session file as passed in -fbuild-session-file.
+  std::filesystem::path build_session_file;
 };

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -1688,6 +1688,14 @@ hash_common_info(const Context& ctx, const Args& args, Hash& hash)
     }
   }
 
+  if (!(ctx.args_info.build_session_file.empty())) {
+    // When using -fbuild-session-file, the actual mtime needs to be
+    // added to the hash to prevent false positive cache hits if the
+    // mtime of the file changes.
+    hash.hash_delimiter("-fbuild-session-file mtime");
+    hash.hash(DirEntry(ctx.args_info.build_session_file).mtime().nsec());
+  }
+
   if (!ctx.config.extra_files_to_hash().empty()) {
     for (const auto& path :
          util::split_path_list(ctx.config.extra_files_to_hash())) {

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -124,7 +124,10 @@ const CompOpt compopts[] = {
   {"-emit-pth", AFFECTS_COMP},         // Clang
   {"-external:I",
    AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH}, // msvc
+  {"-fbuild-session-file=", TAKES_CONCAT_ARG | TAKES_PATH},
   {"-fmodule-header", TOO_HARD},
+  {"-fmodule-map-file=", TAKES_CONCAT_ARG | TAKES_PATH},
+  {"-fmodules-cache-path=", TAKES_CONCAT_ARG | TAKES_PATH},
   {"-fmodules-ts", TOO_HARD},
   {"-fno-working-directory", AFFECTS_CPP},
   {"-fplugin=libcc1plugin", TOO_HARD}, // interaction with GDB
@@ -147,7 +150,7 @@ const CompOpt compopts[] = {
   {"-iquote", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-isysroot", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-isystem", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
-  {"-ivfsoverlay", TAKES_ARG},
+  {"-ivfsoverlay", TAKES_ARG | TAKES_PATH},
   {"-ivfsstatcache", TAKES_ARG},
   {"-iwithprefix", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-iwithprefixbefore",

--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -317,6 +317,95 @@ TEST_CASE(
   CHECK(result->preprocessor_args[2] == "foo");
 }
 
+TEST_CASE("fbuild_session_file_should_be_rewritten_if_basedir_is_used")
+{
+  TestContext test_context;
+
+  Context ctx;
+
+  util::write_file("foo.c", "");
+  ctx.config.set_base_dir(get_root());
+  std::string arg_string =
+    FMT("cc -fbuild-session-file={}/foo/bar -c foo.c", ctx.actual_cwd);
+  ctx.orig_args = Args::from_string(arg_string);
+
+  const auto result = process_args(ctx);
+  CHECK(result);
+#ifdef _WIN32
+  CHECK(result->preprocessor_args[1] == "-fbuild-session-file=foo\\bar");
+#else
+  CHECK(result->preprocessor_args[1] == "-fbuild-session-file=foo/bar");
+#endif
+}
+
+TEST_CASE(
+  "ivfsoverlay_with_separate_argument_should_be_rewritten_if_basedir_is_used")
+{
+  TestContext test_context;
+
+  Context ctx;
+  ctx.config.update_from_map({{"sloppiness", "ivfsoverlay"}});
+
+  util::write_file("foo.c", "");
+  ctx.config.set_base_dir(get_root());
+  std::string arg_string =
+    FMT("cc -ivfsoverlay {}/foo -c foo.c", ctx.actual_cwd);
+  ctx.orig_args = Args::from_string(arg_string);
+
+  const auto result = process_args(ctx);
+  CHECK(result);
+  CHECK(result->preprocessor_args[1] == "-ivfsoverlay");
+  CHECK(result->preprocessor_args[2] == "foo");
+}
+
+TEST_CASE(
+  "fmodules_cache_path_with_separate_argument_should_be_rewritten_if_basedir_"
+  "is_used")
+{
+  TestContext test_context;
+
+  Context ctx;
+  ctx.config.update_from_map({{"sloppiness", "modules"}});
+
+  util::write_file("foo.c", "");
+  ctx.config.set_base_dir(get_root());
+  std::string arg_string =
+    FMT("cc -fmodules-cache-path={}/foo/bar -c foo.c", ctx.actual_cwd);
+  ctx.orig_args = Args::from_string(arg_string);
+
+  const auto result = process_args(ctx);
+  CHECK(result);
+#ifdef _WIN32
+  CHECK(result->preprocessor_args[1] == "-fmodules-cache-path=foo\\bar");
+#else
+  CHECK(result->preprocessor_args[1] == "-fmodules-cache-path=foo/bar");
+#endif
+}
+
+TEST_CASE(
+  "fmodules_map_file_with_separate_argument_should_be_rewritten_if_basedir_"
+  "is_used")
+{
+  TestContext test_context;
+
+  Context ctx;
+  ctx.config.update_from_map({{"sloppiness", "modules"}});
+
+  util::write_file("foo.c", "");
+  ctx.config.set_base_dir(get_root());
+  std::string arg_string =
+    FMT("cc -fmodule-map-file={}/foo/bar -c foo.c", ctx.actual_cwd);
+  ctx.orig_args = Args::from_string(arg_string);
+
+  const auto result = process_args(ctx);
+  CHECK(result);
+#ifdef _WIN32
+  CHECK(result->preprocessor_args[1] == "-fmodule-map-file=foo\\bar");
+#else
+  CHECK(result->preprocessor_args[1] == "-fmodule-map-file=foo/bar");
+#endif
+}
+
 TEST_CASE("MF_flag_with_immediate_argument_should_work_as_last_argument")
 {
   TestContext test_context;


### PR DESCRIPTION
Follow up PR from the discussion here: https://github.com/ccache/ccache/discussions/1566

Essentially, when building React Native under different directories, some flags are being used that are not made relative by ccache, thus caching doesn't work at all.

To resolve this I made the following change:
- Add `make_relative_path` calls for: ivfsoverlay, fmodules-cache-path & fbuild-session-file
- Add unit tests for the flags above as well as a e2e test for fbuild-session-file

Opening this as a draft PR while I'm running some more local tests, would still appreciate any and all feedback though.