### PR TITLE
fix: do not use --offload-compress when preprocessing

### DIFF
--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -59,6 +59,7 @@ const CompOpt compopts[] = {
   {"--gcc-toolchain=", TAKES_CONCAT_ARG | TAKES_PATH}, // Clang
   {"--include", AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"--libdevice-directory", AFFECTS_CPP | TAKES_ARG}, // nvcc
+  {"--offload-compress", AFFECTS_COMP},               // Clang
   {"--output-directory", AFFECTS_CPP | TAKES_ARG},    // nvcc
   {"--param", TAKES_ARG},
   {"--save-temps", TOO_HARD},


### PR DESCRIPTION
Clang has a feature where it can compress compiler products such as object files, and this includes when it is just called to preprocess the input file.

Ccache expects to be able to process the output of the preprocessor and is not expecting a compressed binary file. Obvious symptoms are apparently random data in log messages, but ccache appears to produce random results.

The fix is to remove any "--offload-compress" options using the existing facilities when preprocessing.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
