### PR TITLE
fix: LocalStorage::move_to_wanted_cache_level renamed raw files incorrectly, without recalculating full hash filename with new prefix (#1570)

### DIFF
--- a/src/ccache/storage/local/localstorage.cpp
+++ b/src/ccache/storage/local/localstorage.cpp
@@ -656,7 +656,7 @@ LocalStorage::put_raw_files(
     old_dir_entry.refresh();
     try {
       clone_hard_link_or_copy_file(source_path, dest_path, true);
-      m_added_raw_files.push_back(dest_path);
+      m_added_raw_files.push_back(AddedRawFile{file_number, dest_path});
     } catch (core::Error& e) {
       LOG("Failed to store {} as raw file {}: {}",
           source_path,
@@ -1082,9 +1082,8 @@ LocalStorage::move_to_wanted_cache_level(const StatisticsCounters& counters,
     // to rename is OK.
     LOG("Moving {} to {}", cache_file_path, wanted_path);
     fs::rename(cache_file_path, wanted_path);
-    for (const auto& raw_file : m_added_raw_files) {
-      fs::rename(raw_file,
-                 FMT("{}/{}", wanted_path.parent_path(), raw_file.filename()));
+    for (auto [file_number, dest_path] : m_added_raw_files) {
+      fs::rename(dest_path, get_raw_file_path(wanted_path, file_number));
     }
   }
 }

--- a/src/ccache/storage/local/localstorage.hpp
+++ b/src/ccache/storage/local/localstorage.hpp
@@ -138,7 +138,12 @@ private:
   // a statistics file in the finalize method.
   core::StatisticsCounters m_counter_updates;
 
-  std::vector<std::filesystem::path> m_added_raw_files;
+  struct AddedRawFile
+  {
+    uint8_t file_number;
+    std::filesystem::path dest_path;
+  };
+  std::vector<AddedRawFile> m_added_raw_files;
   bool m_stored_data = false;
 
   struct LookUpCacheFileResult


### PR DESCRIPTION
### How to reproduce ###
1. Use hardlink and local storage to get raw files
2. Have enough files to surpass the 2K file limit in subdir
3. Create any new file in cache

### Actual behavior ###
The following files were created:
```
ccache/3/a/6/egahqp3b885sbmkb0t7eo365egbcm0R
ccache/3/a/6/6egahqp3b885sbmkb0t7eo365egbcm00W
```
Note the prefix "6" for the raw file, which should be removed as it is now in the subdir name.

On a new compile of the same file, the result file is reloaded, but it fails to find the raw file, triggering a recompile.
```
[2025-02-25T10:28:18.478066 12520] Retrieved 3a6egahqp3b885sbmkb0t7eo365egbcm0 from local storage (ccache/3/a/6/egahqp3b885sbmkb0t7eo365egbcm0R)
[2025-02-25T10:28:18.478233 12520] Reading raw entry #0 .o (482688 bytes)
[2025-02-25T10:28:18.478382 12520] Failed to lstat ccache/3/a/6/egahqp3b885sbmkb0t7eo365egbcm00W: No such file or directory
[2025-02-25T10:28:18.478419 12520] Failed to get result from 3a6egahqp3b885sbmkb0t7eo365egbcm0: Failed to stat ccache/3/a/6/egahqp3b885sbmkb0t7eo365egbcm00W: No such file or directory
```
The recompile actually saves the result in the correct path, because it reuses the previous result file path and hence `move_to_wanted_cache_level` does not run, but this still required 2 full compiles instead of one.

After a partial cleanup, the files are sometimes moved again, and the bug happens over and over for the same files.