### PR TITLE
ENH: Ignore the line number information in the preprocessed file to a…

### DIFF
--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -578,9 +578,8 @@ process_preprocessed_file(Context& ctx, Hash& hash, const fs::path& path)
       }
 
       while (q < end && *q != '"' && *q != '\n') {
-        //replace line num to '0' avoid hash change
-        if(*q > '0' && *q <= '9')
-        {
+        // replace line num to '0' avoid hash change
+        if (*q > '0' && *q <= '9') {
           *q = '0';
         }
         q++;


### PR DESCRIPTION
1. Adding blank lines or unused macro definitions in header files can cause ccache misses, whereas a preprocess hit is expected.
2. By analyzing the ccache-input-text file, it is found that the compiler's preprocess output contains new lines or changes in line numbers, resulting in mismatched hashes for the preprocessed file and thus causing preprocess misses.
3. When calculating the hash of the preprocessed file, is it possible to ignore line numbers, blank lines, etc., in order to improve ccache hit rate? This is especially important for low-level software modules (when new features are added to low-level module but are not widely used yet, we don't want this to impact the build speed of many upper-layer modules).
4. I have a simple PR. Please let me know your thoughts.

## How to reproduce
```
// hello.c
#include <stdio.h>
#include "hello.h"

int main() {
    printf("%s  %s \n", __FUNCTION__, HELLO_WORLD);
    return 0;
}

// hello.h
#define HELLO_WORLD "Hello,  World!"

// add  new blank line or unused macro definitions here

#define NEW_ATTR() \
{ \
    .data = 100, \
    .type = 200, \
    .size = 300, \
}

void hello(void);
```

Environment
ccache version 4.9.1
