### PR TITLE
Unify almalinux support, fix build issue and add almalinux-9 dockerfile

### DIFF
--- a/dockerfiles/almalinux-8/Dockerfile
+++ b/dockerfiles/almalinux-8/Dockerfile
@@ -17,6 +17,8 @@ RUN dnf install -y dnf-plugins-core \
         fmt-devel \
         gcc \
         gcc-c++ \
+        libstdc++-devel \
+        libstdc++-static \
         hiredis-devel \
         less \
         libzstd-devel \

--- a/dockerfiles/almalinux-9/Dockerfile
+++ b/dockerfiles/almalinux-9/Dockerfile
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE=almalinux:9
+FROM ${BASE_IMAGE} AS build
+
+RUN dnf install -y dnf-plugins-core \
+ && dnf config-manager --set-enabled crb \
+ && dnf install -y epel-release \
+ && dnf install -y \
+        blake3-devel \
+        ccache \
+        clang \
+        cmake \
+        cpp-httplib-devel \
+        diffutils \
+        doctest-devel \
+        elfutils \
+        expected-devel \
+        fmt-devel \
+        gcc \
+        gcc-c++ \
+        libstdc++-devel \
+        libstdc++-static \
+        hiredis-devel \
+        less \
+        libzstd-devel \
+        make \
+        ninja-build \
+        perl \
+        python3 \
+        redis \
+        xxhash-devel \
+ && dnf autoremove -y \
+ && dnf clean all

--- a/misc/test-some-systems
+++ b/misc/test-some-systems
@@ -36,6 +36,9 @@ build() {
 build almalinux-8  gcc    g++     gcc     -D DEPS=DOWNLOAD
 build almalinux-8  clang  clang++ clang   -D DEPS=DOWNLOAD
 
+build almalinux-9  gcc    g++     gcc     -D DEPS=DOWNLOAD
+build almalinux-9  clang  clang++ clang   -D DEPS=DOWNLOAD
+
 build alpine-3.21  gcc    g++     gcc     -D DEPS=DOWNLOAD
 build alpine-3.21  clang  clang++ clang   -D DEPS=DOWNLOAD
 

--- a/misc/test-some-systems
+++ b/misc/test-some-systems
@@ -33,8 +33,8 @@ build() {
 
 #     NAME         CC     CXX     TEST_CC CMAKE_PARAMS
 
-build alma-8       gcc    g++     gcc     -D DEPS=DOWNLOAD
-build alma-8       clang  clang++ clang   -D DEPS=DOWNLOAD
+build almalinux-8  gcc    g++     gcc     -D DEPS=DOWNLOAD
+build almalinux-8  clang  clang++ clang   -D DEPS=DOWNLOAD
 
 build alpine-3.21  gcc    g++     gcc     -D DEPS=DOWNLOAD
 build alpine-3.21  clang  clang++ clang   -D DEPS=DOWNLOAD


### PR DESCRIPTION
Hi, this is continuation of my effort to provide a multi-architecture pre-built ccache images for number of architectures and linux variants. After syncing my code with the latest master I found that almalinux has been added, however the name used diverges from the official image tag, thereby causing auto-discovery process to fail. 

After fixing that I found that the dependency list is incomplete, causing build to fail.

Last but not least, recently we've started to publish several pre-built pypi packages, which by convention is based on manylinux images, which in turn is based upon almalinux-9 for the latest revision of the manylinux "standard". The said images are successfully used to reduce build times for at least one such project now.