### PR TITLE
Link libatomic statically when STATIC_LINK is set

### DIFF
--- a/cmake/StdAtomic.cmake
+++ b/cmake/StdAtomic.cmake
@@ -1,5 +1,7 @@
 # Check if std::atomic needs -latomic
 
+set(LIBATOMIC_STATIC_PATH "" CACHE PATH "Directory containing static libatomic.a")
+
 include(CheckCXXSourceCompiles)
 
 set(
@@ -24,6 +26,17 @@ if(NOT std_atomic_without_libatomic)
   if(NOT std_atomic_with_libatomic)
     message(FATAL_ERROR "Toolchain doesn't support std::atomic with nor without -latomic")
   else()
-    target_link_libraries(standard_settings INTERFACE atomic)
+    if(STATIC_LINK)
+      find_library(ATOMIC_STATIC NAMES libatomic.a PATHS /usr/lib /usr/local/lib ${LIBATOMIC_STATIC_PATH} NO_DEFAULT_PATH)
+      if(ATOMIC_STATIC)
+        message(STATUS "Linking static libatomic: ${ATOMIC_STATIC}")
+        target_link_libraries(standard_settings INTERFACE ${ATOMIC_STATIC})
+      else()
+        message(WARNING "STATIC_LINK is set but static libatomic not found; falling back to -latomic")
+        target_link_libraries(standard_settings INTERFACE atomic)
+      endif()
+    else()
+      target_link_libraries(standard_settings INTERFACE atomic)
+    endif()
   endif()
 endif()


### PR DESCRIPTION
This patch is needed in order to link libatomic statically on debian arm/v5, where libatomic.a is required but it's hidden under subdirectory and is not visible to the normal linking process even with -static. This causes "static" ccache to depend on libatomic.so.

This option allows me to pass down location of the libatomic.a such as here: https://github.com/sobomax/ccache/blob/d12d99883661b766dc89c16766bdfac1b437295a/misc/get-arch-buildargs#L36

With this I have successfully implemented self-caching mechanism where ccache from a previous image build along with the previous cache set is used to speed-up build of the next revision. What is interesting, however is that effectiveness of this mechanism depends wildly between supported distros even for the same toolchain flavor/version between 0 and 100%.