### PR TITLE
fix: using ccache and clang to compile CUDA code on Windows results empty preprocess file

### DIFF
--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -1379,7 +1379,8 @@ get_result_key_from_cpp(Context& ctx, Args& args, Hash& hash)
   // When Clang runs in verbose mode, it outputs command details to stdout,
   // which can corrupt the output of precompiled CUDA files. Therefore, caching
   // is disabled in this scenario. (Is there a better approach to handle this?)
-  const bool is_clang_cu = ctx.config.is_compiler_group_clang()
+  const bool is_clang_cu = (ctx.config.is_compiler_group_clang()
+                            && !ctx.config.is_compiler_group_msvc())
                            && (ctx.args_info.actual_language == "cu"
                                || ctx.args_info.actual_language == "cuda")
                            && !get_clang_cu_enable_verbose_mode(args);


### PR DESCRIPTION

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
