### PR TITLE
ci: Enable tests in the msys2 mingw64+clang configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -190,7 +190,7 @@ jobs:
 
           - sys: mingw64
             compiler: clang
-            extra_cmake_params: -DENABLE_TESTING=OFF # clang currently triggers warnings with doctest
+            extra_cmake_params: -DCMAKE_CXX_FLAGS=-Wno-deprecated # doctest issue #900
             os: windows-2025
 
           - sys: clangarm64


### PR DESCRIPTION
Instead of disabling tests altogether, pass the -Wno-deprecated option, working around https://github.com/doctest/doctest/issues/900 in a different fashion.

