### PR TITLE
build(blake3): Don't use NEON on aarch64_be

### DIFF
--- a/src/third_party/blake3/CMakeLists.txt
+++ b/src/third_party/blake3/CMakeLists.txt
@@ -115,13 +115,15 @@ _add_blake3_source_if_enabled(sse41 "" "-msse4.1" "_mm_test_all_ones(_mm_set1_ep
 _add_blake3_source_if_enabled(avx2 "/arch:AVX2" "-mavx2" "_mm256_abs_epi8(_mm256_set1_epi32(42))")
 _add_blake3_source_if_enabled(avx512 "/arch:AVX512" "-mavx512f -mavx512vl" "_mm256_abs_epi64(_mm256_set1_epi32(42))")
 
-# Neon is always available on AArch64
+# Neon is always available on AArch64, but blake3_neon.c only supports little-endian
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   # https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
   check_c_source_compiles(
     [=[
       #include <arm_neon.h>
+      #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
       int main() { vdupq_n_s32(42); return 0; }
+      #endif
     ]=]
     HAVE_NEON)
   if(HAVE_NEON)


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->

This fixes the build on aarch64 big-endian, by correctly falling back to the generic implementation.

Note: The upstream CMakeLists.txt looks completely different, which is why I didn't send the patch upstream first.