### PR TITLE
tests windows: Handle GetVolumePathName errors, prevent access violation

### DIFF
--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -48,10 +48,11 @@ get_root()
 #ifndef _WIN32
   return "/";
 #else
-  char volume[4]; // "C:\"
-  GetVolumePathName(
-    util::pstr(*fs::current_path()).c_str(), volume, sizeof(volume));
-  return volume;
+  auto cwd = fs::current_path();
+  if (!cwd) {
+    FAIL("get_root failed: ", cwd.error());
+  }
+  return cwd->root_path().generic_u8string();
 #endif
 }
 


### PR DESCRIPTION
For example GetVolumePathName returns `F:/git_projects` on my computer which does not fit in a char[4]. As a result GetVolumePathName returns an error and a std::string is initialized from uninitialized memory which may not contain a '\0' resulting in out of bounds memory reads.
