### PR TITLE
read_file windows: Fix access violation

### DIFF
--- a/src/ccache/util/file.cpp
+++ b/src/ccache/util/file.cpp
@@ -387,8 +387,8 @@ read_file(const fs::path& path, size_t size_hint)
         return result;
       }
 
-      std::wstring result_as_u16((result.size() / 2) + 1, '\0');
-      result_as_u16 = reinterpret_cast<const wchar_t*>(result.c_str());
+      std::wstring result_as_u16(
+        reinterpret_cast<const wchar_t*>(result.data()), result.size() / 2);
       const int size = WideCharToMultiByte(CP_UTF8,
                                            WC_ERR_INVALID_CHARS,
                                            result_as_u16.c_str(),


### PR DESCRIPTION
When interpreting a char* string that is null terminated as wchar* string it is not guaranteed that the wchar* string is also null terminated. A char[3] string/memeory region with the content ['a', '\0', '\0', 100] interpreted as wchar* has no ending null character resulting in out of bounds memory reads when trying to construct a std::wstring from it.
