### PR TITLE
Reconcile max-size suffixes in documentation

### DIFF
--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -878,8 +878,8 @@ file in `/etc/rsyslog.d`:
 *max_size* (*CCACHE_MAXSIZE*)::
 
     This option specifies the maximum size of the cache. Use 0 for no limit. The
-    default value is 5GiB. Available suffixes: k, M, G, T (decimal) and Ki, Mi,
-    Gi, Ti (binary). The default suffix is GiB. See also
+    default value is 5GiB. Available suffixes: kB, MB, GB, TB (decimal) and KiB, MiB,
+    GiB, TiB (binary). The default suffix is GiB. See also
     _<<Cache size management>>_.
 
 [#config_msvc_dep_prefix]


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->

`-max-size` option was using explicit suffixes and in some other places shorter versions were used. Replaced them all with explicit versions to make it more intuitive (no need to remember default suffix) and consistent.

<img width="1029" height="171" alt="image" src="https://github.com/user-attachments/assets/30680d70-a7d4-4967-8ccf-92b036068065" />

Also found an issue with `max_size` description stating that default suffix is `G` (meaning `GB`) and default value is `5G`. While actual default suffix is `Gi` and default value is `5GiB`.

