### PR TITLE
ci: Fix skipped `profiling_clang` test caused by missing `clang` and `llvm-profdata`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -137,7 +137,23 @@ jobs:
             echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
             echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
 
-            sudo apt-get install -y clang-${{ matrix.version }} g++-multilib lld-${{ matrix.version }}
+            sudo apt-get install -y \
+              clang-${{ matrix.version }} \
+              g++-multilib \
+              lld-${{ matrix.version }} \
+              llvm-${{ matrix.version }}
+
+            if [ "${{ matrix.os }}" = "ubuntu-24.04" ]; then
+              sudo apt-get install -y libclang-rt-${{ matrix.version }}-dev
+            fi
+
+            for binary_name in clang llvm-profdata; do
+              TARGET_PATH=$(which "${binary_name}-${{ matrix.version }}")
+              PREFIX=$(dirname "${TARGET_PATH}")
+
+              sudo update-alternatives --install "${PREFIX}/${binary_name}" "${binary_name}" "${TARGET_PATH}" 20
+              sudo update-alternatives --set "${binary_name}" "${TARGET_PATH}"
+            done
           fi
 
           case "${{ matrix.os }}" in


### PR DESCRIPTION
Currently, the `profiling_clang` test is always skipped on CI:
For example (https://github.com/ccache/ccache/actions/runs/18356450599/job/52289651097):
```
Complete job name: ubuntu-24.04-clang-18
[...]
The following tests did not run:
[...]
	 30 - test.profiling_clang (Skipped)
```
This test requires the `llvm-profdata' binary to be installed on the OS.
 
See also https://github.com/ccache/ccache/pull/1642