### PR TITLE
docs: Fix `install.md` links after renaming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -279,7 +279,7 @@ jobs:
         with:
           name: docs
           path: |
-            doc/INSTALL.md
+            doc/install.md
             GPL-3.0.txt
             install
             README.md

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ General information
 * [Main web site](https://ccache.dev)
 * [Supported platforms, compilers and languages](https://ccache.dev/platform-compiler-language-support.html)
 * [Documentation](https://ccache.dev/documentation.html)
-* [Installation instructions](https://github.com/ccache/ccache/blob/master/doc/INSTALL.md)
+* [Installation instructions](https://github.com/ccache/ccache/blob/master/doc/install.md)
 * [Release notes](https://ccache.dev/releasenotes.html)
 * [Credits and history](https://ccache.dev/credits.html)
 * [License and copyright](https://ccache.dev/license.html)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -11,7 +11,7 @@ if(OFFLINE)
 endif()
 
 # How to locate/retrieve dependencies. See the Dependencies section in
-# doc/INSTALL.md.
+# doc/install.md.
 set(DEPS AUTO CACHE STRING "How to retrieve third party dependencies")
 set_property(CACHE DEPS PROPERTY STRINGS AUTO DOWNLOAD LOCAL)
 


### PR DESCRIPTION
Some links to `docs/install.md` are outdated after the file was renamed (c55a6ac).