### PR TITLE
Handle absolute path in `-fsanitize-blacklist=`

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -964,8 +964,10 @@ process_option_arg(const Context& ctx,
   }
 
   if (util::starts_with(arg, "-fsanitize-blacklist=")) {
-    args_info.sanitize_blacklists.emplace_back(args[i].substr(21));
-    state.add_common_arg(args[i]);
+    auto path = std::string_view(args[i]).substr(21);
+    args_info.sanitize_blacklists.emplace_back(path);
+    auto relpath = core::make_relative_path(ctx, path);
+    state.add_common_arg(FMT("-fsanitize-blacklist={}", relpath));
     return Statistic::none;
   }
 

--- a/test/suites/sanitize_blacklist.bash
+++ b/test/suites/sanitize_blacklist.bash
@@ -11,6 +11,10 @@ SUITE_sanitize_blacklist_SETUP() {
     echo "fun:foo" >blacklist.txt
     echo "fun_1:foo" >blacklist2.txt
 
+    mkdir -p dir1/ dir2/
+    cp blacklist.txt dir1/blacklist.txt
+    cp blacklist.txt dir2/blacklist.txt
+
     unset CCACHE_NODIRECT
 }
 
@@ -41,6 +45,35 @@ SUITE_sanitize_blacklist() {
     expect_stat direct_cache_hit 2
     expect_stat cache_miss 2
     expect_stat files_in_cache 4
+
+    # -------------------------------------------------------------------------
+    TEST "base_dir OK"
+
+    basedir1="$(pwd)/dir1"
+    basedir2="$(pwd)/dir2"
+
+    basedir=$basedir1
+    cd $basedir
+
+    $COMPILER -c -fsanitize-blacklist=blacklist.txt ../test1.c
+
+    CCACHE_BASEDIR="${basedir}" $CCACHE_COMPILE -c -fsanitize-blacklist=$basedir/blacklist.txt ../test1.c
+    expect_stat direct_cache_hit 0
+    expect_stat cache_miss 1
+    expect_stat files_in_cache 2
+
+    CCACHE_BASEDIR="${basedir}" $CCACHE_COMPILE -c -fsanitize-blacklist=$basedir/blacklist.txt ../test1.c
+    expect_stat direct_cache_hit 1
+    expect_stat cache_miss 1
+    expect_stat files_in_cache 2
+
+    basedir=$basedir2
+    cd $basedir
+
+    CCACHE_DEBUG=1 CCACHE_BASEDIR="${basedir}" $CCACHE_COMPILE -c -fsanitize-blacklist=$basedir/blacklist.txt ../test1.c
+    expect_stat direct_cache_hit 2
+    expect_stat cache_miss 1
+    expect_stat files_in_cache 2
 
     # -------------------------------------------------------------------------
     TEST "Unsuccessful compilation"


### PR DESCRIPTION
I was compiling https://github.com/llvm/llvm-project in a couple of different directories and realized ccache stopped working for me, when it previously had worked correctly by setting CCACHE_BASEDIR. I followed the debugging steps on the ccache docs and realized that the hashed invocation was different due to the different absolute path for the `-fsanitize-blacklist=` option, which LLVM [uses](https://github.com/llvm/llvm-project/blob/d49aa40fc703d061f48e520b9c1b63e6646c6907/llvm/cmake/modules/HandleLLVMOptions.cmake#L1118) when UBSAN is enabled.