### PR TITLE
chore: Update C++ standard in `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,4 +46,4 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 PackConstructorInitializers: Never
 PointerAlignment: Left
 SpaceAfterTemplateKeyword: false
-Standard: Cpp11
+Standard: c++17


### PR DESCRIPTION
Currently, the project uses the C++17 standard, but `clang-format` is still configured for C++11.