### PR TITLE
build(blake3): Assume aarch64 to be little-endian on CMake 3.18/3.19

### DIFF
--- a/src/third_party/blake3/CMakeLists.txt
+++ b/src/third_party/blake3/CMakeLists.txt
@@ -116,7 +116,9 @@ _add_blake3_source_if_enabled(avx2 "/arch:AVX2" "-mavx2" "_mm256_abs_epi8(_mm256
 _add_blake3_source_if_enabled(avx512 "/arch:AVX512" "-mavx512f -mavx512vl" "_mm256_abs_epi64(_mm256_set1_epi32(42))")
 
 # Neon is always available on AArch64, but blake3_neon.c only supports little-endian
-if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND CMAKE_C_BYTE_ORDER STREQUAL "LITTLE_ENDIAN")
+# Byte order detection requires CMake 3.20, we just assume little-endian on 3.18/3.19.
+if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND
+   (NOT DEFINED CMAKE_C_BYTE_ORDER OR CMAKE_C_BYTE_ORDER STREQUAL "LITTLE_ENDIAN"))
   # https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
   check_c_source_compiles(
     [=[


### PR DESCRIPTION
The recently introduced detection of big-endian AArch64 uses the CMAKE_C_BYTE_ORDER variable, which was introduced in 3.20, but ccache currently only requires CMake 3.18.

To avoid using an undefined variable, simply assume AArch64 to be little-endian on CMake versions that don't define the aforementioned variable. This is okay because big-endian AArch64 has few users and the subset of them that use CMake 3.18/3.19 is likely negligible.

Reported-by: @awawa-dev
Fixes: https://github.com/ccache/ccache/issues/1651

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->


---

Based on testing with Debian bullseye, which ships CMake 3.18, I was able to reproduce both a build failure and that this commit appears to fix it.

@awawa-dev, could you please test it in your setup as well?