### PR TITLE
feat: Cache -E preprocessing commands in direct/depend mode

### DIFF
--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -72,15 +72,17 @@ TEST_CASE("pass -fsyntax-only to compiler only")
   CHECK(result->compiler_args.to_string() == "cc -fsyntax-only -c");
 }
 
-TEST_CASE("dash_E_should_result_in_called_for_preprocessing")
+TEST_CASE("dash_E_should_be_cacheable")
 {
   TestContext test_context;
 
   Context ctx;
-  ctx.orig_args = Args::from_string("cc -c foo.c -E");
+  ctx.orig_args = Args::from_string("cc -E foo.c -o foo.i");
 
   REQUIRE(util::write_file("foo.c", ""));
-  CHECK(process_args(ctx).error() == Statistic::called_for_preprocessing);
+  const auto result = process_args(ctx);
+  REQUIRE(result);
+  CHECK(result->compiler_args.to_string().find("-E") != std::string::npos);
 }
 
 TEST_CASE("dash_M_should_be_unsupported")


### PR DESCRIPTION
Previously, -E commands would bail with called_for_preprocessing. Now they are cached when direct mode or depend mode is enabled, which is the default configuration.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
