### PR TITLE
fix: Do not rewrite -isysroot as relative path

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -1253,12 +1253,18 @@ process_option_arg(const Context& ctx,
     // Potentially rewrite path argument to relative path to get better hit
     // rate. A secondary effect is that paths in the standard error output
     // produced by the compiler will be normalized.
-    fs::path relpath = core::make_relative_path(ctx, args[i + next]);
+    fs::path rewritten_path;
+    if (compopt_takes_path_abs(arg)) {
+      // some paths should not be made relative (eg -isysroot)
+      rewritten_path = args[i + next];
+    } else {
+      rewritten_path = core::make_relative_path(ctx, args[i + next]);
+    }
     state.add_common_arg(args[i]);
     if (next == 2) {
       state.add_common_arg(args[i + 1]);
     }
-    state.add_common_arg(relpath);
+    state.add_common_arg(rewritten_path);
 
     i += next;
     return Statistic::none;
@@ -1283,8 +1289,14 @@ process_option_arg(const Context& ctx,
     const auto [option, path] = util::split_option_with_concat_path(arg);
     if (path && compopt_takes_concat_arg(option)
         && compopt_takes_path(option)) {
-      const auto relpath = core::make_relative_path(ctx, *path);
-      std::string new_option = FMT("{}{}", option, relpath);
+      fs::path rewritten_path;
+      if (compopt_takes_path_abs(option)) {
+        // some paths should not be made relative (eg -isysroot)
+        rewritten_path = *path;
+      } else {
+        rewritten_path = core::make_relative_path(ctx, *path);
+      }
+      std::string new_option = FMT("{}{}", option, rewritten_path);
       if (compopt_affects_cpp_output(option)) {
         state.add_common_arg(std::move(new_option));
       } else {

--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -1193,6 +1193,12 @@ process_option_arg(const Context& ctx,
     return Statistic::none;
   }
 
+  if (arg == "--relocatable-pch") {
+    args_info.relocatable_pch = true;
+    state.add_common_arg(args[i]);
+    return Statistic::none;
+  }
+
   if (arg == "-fpch-preprocess") {
     state.found_fpch_preprocess = true;
     state.add_common_arg(args[i]);

--- a/src/ccache/argsinfo.hpp
+++ b/src/ccache/argsinfo.hpp
@@ -150,6 +150,9 @@ struct ArgsInfo
   // header it generates.
   bool fno_pch_timestamp = false;
 
+  // Whether Clang is given the relocatable pch argument.
+  bool relocatable_pch = false;
+
   // Files referenced by -fsanitize-blacklist options.
   std::vector<std::filesystem::path> sanitize_blacklists;
 

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -2194,6 +2194,18 @@ hash_argument(const Context& ctx,
     return {};
   }
 
+  // When invoked with --relocatable-pch, rewrite "-isysroot" entry in cache
+  // to be relative.
+  if (ctx.args_info.relocatable_pch) {
+    if (const auto [option, path] = get_option_and_value("-isysroot", args, i);
+        option && path) {
+      hash.hash_delimiter("arg");
+      hash.hash("-isysroot");
+      hash.hash(core::make_relative_path(ctx, *path));
+      return {};
+    }
+  }
+
   if (util::starts_with(args[i], "-frandom-seed=")
       && ctx.config.sloppiness().contains(core::Sloppy::random_seed)) {
     LOG("Ignoring {} since random_seed sloppiness is requested", args[i]);

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -36,12 +36,16 @@ int TAKES_CONCAT_ARG = 1 << 3;
 // used.
 int TAKES_PATH = 1 << 4;
 
+// The argument to the option is a path that should not be rewritten if
+// base_dir is used.
+int TAKES_PATH_ABS = 1 << 5;
+
 // The option only affects preprocessing; not included in the input hash in
 // preprocessor mode.
-int AFFECTS_CPP = 1 << 5;
+int AFFECTS_CPP = 1 << 6;
 
 // The option only affects compilation; not passed to the preprocessor.
-int AFFECTS_COMP = 1 << 6;
+int AFFECTS_COMP = 1 << 7;
 
 struct CompOpt
 {
@@ -151,7 +155,8 @@ const CompOpt compopts[] = {
   {"-install_name",           TAKES_ARG                                              }, // Darwin linker option
   {"-iprefix",                AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-iquote",                 AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
-  {"-isysroot",               AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
+  {"-isysroot",
+   AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH | TAKES_PATH_ABS          },
   {"-isystem",                AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH},
   {"-ivfsoverlay",            TAKES_ARG | TAKES_PATH                                 },
   {"-ivfsstatcache",          TAKES_ARG                                              },
@@ -282,6 +287,13 @@ compopt_takes_path(std::string_view option)
 {
   const CompOpt* co = find(option);
   return co && (co->type & TAKES_PATH);
+}
+
+bool
+compopt_takes_path_abs(std::string_view option)
+{
+  const CompOpt* co = find(option);
+  return co && (co->type & TAKES_PATH_ABS);
 }
 
 bool

--- a/src/ccache/compopt.hpp
+++ b/src/ccache/compopt.hpp
@@ -28,6 +28,7 @@ bool compopt_affects_compiler_output(std::string_view option);
 bool compopt_too_hard(std::string_view option);
 bool compopt_too_hard_for_direct_mode(std::string_view option);
 bool compopt_takes_path(std::string_view option);
+bool compopt_takes_path_abs(std::string_view option);
 bool compopt_takes_arg(std::string_view option);
 bool compopt_takes_concat_arg(std::string_view option);
 bool compopt_prefix_affects_cpp_output(std::string_view option);

--- a/test/suites/basedir.bash
+++ b/test/suites/basedir.bash
@@ -509,6 +509,7 @@ fi
     fi
 
     # Check that we do not get a cache hit: -isysroot is different
+    # Note: see similar test in pch.bash, we cache relative -isysroot when using --relocatable-pch
     cd ../dir2
     CCACHE_BASEDIR="$(pwd)" $CCACHE_COMPILE -isysroot "$(pwd)/sysroot" -I"$(pwd)/include" -c src/test.c
     expect_stat direct_cache_hit 0

--- a/test/suites/basedir.bash
+++ b/test/suites/basedir.bash
@@ -493,4 +493,24 @@ fi
     expect_stat cache_miss 1
     expect_contains test.d test.o:
     expect_content_pattern test.d "test.o:*"
+
+    # -------------------------------------------------------------------------
+    TEST "-isysroot with basedir"
+
+    mkdir -p dir1/sysroot dir2/sysroot
+
+    cd dir1
+    CCACHE_DEBUG=1 CCACHE_BASEDIR="$(pwd)" $CCACHE_COMPILE -isysroot "$(pwd)/sysroot" -I"$(pwd)/include" -c src/test.c
+    expect_stat direct_cache_hit 0
+    expect_stat direct_cache_miss 1
+    # Check that the absolute path is passed to the compiler (not rewritten to relative)
+    if ! grep -q "Executing.*-isysroot $(pwd)/sysroot" test.o.*.ccache-log; then
+        test_failed "-isysroot path was rewritten to relative (should stay absolute)"
+    fi
+
+    # Check that we do not get a cache hit: -isysroot is different
+    cd ../dir2
+    CCACHE_BASEDIR="$(pwd)" $CCACHE_COMPILE -isysroot "$(pwd)/sysroot" -I"$(pwd)/include" -c src/test.c
+    expect_stat direct_cache_hit 0
+    expect_stat direct_cache_miss 2
 }

--- a/test/suites/pch.bash
+++ b/test/suites/pch.bash
@@ -2,7 +2,7 @@ SUITE_pch_PROBE() {
     touch pch.h empty.c
     mkdir dir
 
-    if ! $COMPILER $SYSROOT -fpch-preprocess pch.h 2>/dev/null \
+    if ! $COMPILER $SYSROOT -fpch-preprocess pch.h -o pch.h.gch 2>/dev/null \
             || [ ! -f pch.h.gch ]; then
         echo "compiler ($($COMPILER --version | head -n 1)) doesn't support precompiled headers"
     fi
@@ -246,7 +246,7 @@ fi
     # -------------------------------------------------------------------------
     TEST "Use .gch, -include, PCH_EXTSUM=1"
 
-    $COMPILER $SYSROOT -c pch.h
+    $COMPILER $SYSROOT -c pch.h -o pch.h.gch
     backdate pch.h.gch
 
     echo "original checksum" > pch.h.gch.sum

--- a/unittest/test_compopt.cpp
+++ b/unittest/test_compopt.cpp
@@ -74,6 +74,12 @@ TEST_CASE("compopt_takes_path")
   CHECK(!compopt_takes_path("-L"));
 }
 
+TEST_CASE("compopt_takes_path_abs")
+{
+  CHECK(compopt_takes_path_abs("-isysroot"));
+  CHECK(!compopt_takes_path_abs("-I"));
+}
+
 TEST_CASE("compopt_takes_arg")
 {
   CHECK(compopt_takes_arg("-Xlinker"));


### PR DESCRIPTION
Here is an attempt to solve #1322 with one of the proposed approaches from the thread.

To reduce risk, I thought about restricting this behavior to invocations with `--relocatable-pch` but it would probably lead to bigger changes as `hash_argument` is collecting everything in one pass.

Fixes #1322