### PR TITLE
feat: Track C23 #embed directive files for cache invalidation

### DIFF
--- a/src/ccache/CMakeLists.txt
+++ b/src/ccache/CMakeLists.txt
@@ -11,6 +11,7 @@ set(
   hashutil.cpp
   language.cpp
   progressbar.cpp
+  sourcescanner.cpp
   version.cpp
 )
 

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -465,9 +465,7 @@ remember_include_file(Context& ctx,
       if (ret.contains(HashSourceCode::error)) {
         return tl::unexpected(Statistic::bad_input_file);
       }
-      if (ret.contains(HashSourceCode::found_time)
-          || ret.contains(HashSourceCode::found_embed)
-          || ret.contains(HashSourceCode::found_incbin)) {
+      if (should_disable_direct_mode(ctx, ret)) {
         LOG("Disabling direct mode");
         ctx.config.set_direct_mode(false);
       }
@@ -2329,9 +2327,7 @@ get_manifest_key(Context& ctx, Hash& hash)
   if (ret.contains(HashSourceCode::error)) {
     return tl::unexpected(Statistic::internal_error);
   }
-  if (ret.contains(HashSourceCode::found_time)
-      || ret.contains(HashSourceCode::found_embed)
-      || ret.contains(HashSourceCode::found_incbin)) {
+  if (should_disable_direct_mode(ctx, ret)) {
     LOG("Disabling direct mode");
     ctx.config.set_direct_mode(false);
     return {};

--- a/src/ccache/core/manifest.cpp
+++ b/src/ccache/core/manifest.cpp
@@ -427,7 +427,9 @@ Manifest::result_matches(
         LOG("Failed hashing {}", path);
         return false;
       }
-      if (ret.contains(HashSourceCode::found_time)) {
+      if (ret.contains(HashSourceCode::found_time)
+          || ret.contains(HashSourceCode::found_embed)
+          || ret.contains(HashSourceCode::found_incbin)) {
         // hash_source_code_file has already logged.
         return false;
       }

--- a/src/ccache/core/manifest.cpp
+++ b/src/ccache/core/manifest.cpp
@@ -427,9 +427,7 @@ Manifest::result_matches(
         LOG("Failed hashing {}", path);
         return false;
       }
-      if (ret.contains(HashSourceCode::found_time)
-          || ret.contains(HashSourceCode::found_embed)
-          || ret.contains(HashSourceCode::found_incbin)) {
+      if (should_disable_direct_mode(ctx, ret)) {
         // hash_source_code_file has already logged.
         return false;
       }

--- a/src/ccache/hashutil.cpp
+++ b/src/ccache/hashutil.cpp
@@ -276,7 +276,12 @@ hash_source_code_file(const Context& ctx,
     LOG("Found .incbin in {}", path);
   }
 
-  if (!check_temporal_macros || result.empty()) {
+  const bool contains_temporal_macro =
+    result.contains(HashSourceCode::found_time)
+    || result.contains(HashSourceCode::found_date)
+    || result.contains(HashSourceCode::found_timestamp);
+
+  if (!check_temporal_macros || !contains_temporal_macro) {
     return result;
   }
 

--- a/src/ccache/hashutil.cpp
+++ b/src/ccache/hashutil.cpp
@@ -346,6 +346,16 @@ hash_source_code_file(const Context& ctx,
 }
 
 bool
+should_disable_direct_mode(const Context& ctx,
+                           const HashSourceCodeResult& result)
+{
+  return result.contains(HashSourceCode::found_time)
+         || result.contains(HashSourceCode::found_embed)
+         || (result.contains(HashSourceCode::found_incbin)
+             && !ctx.config.sloppiness().contains(core::Sloppy::incbin));
+}
+
+bool
 hash_binary_file(const Context& ctx,
                  Hash::Digest& digest,
                  const fs::path& path,

--- a/src/ccache/hashutil.cpp
+++ b/src/ccache/hashutil.cpp
@@ -23,6 +23,7 @@
 #include <ccache/core/exceptions.hpp>
 #include <ccache/execute.hpp>
 #include <ccache/macroskip.hpp>
+#include <ccache/sourcescanner.hpp>
 #include <ccache/util/args.hpp>
 #include <ccache/util/cpu.hpp>
 #include <ccache/util/direntry.hpp>
@@ -168,16 +169,41 @@ check_for_temporal_macros_avx2(std::string_view str)
 #endif
 
 HashSourceCodeResult
+check_for_source_directives(std::string_view str)
+{
+  HashSourceCodeResult result;
+
+  if (!sourcescanner::scan_for_embed_directives(str).empty()) {
+    result.insert(HashSourceCode::found_embed);
+  }
+
+  if (sourcescanner::contains_incbin_directive(str)) {
+    result.insert(HashSourceCode::found_incbin);
+  }
+
+  return result;
+}
+
+HashSourceCodeResult
 do_hash_file(const Context& ctx,
              Hash::Digest& digest,
              const fs::path& path,
              size_t size_hint,
-             bool check_temporal_macros)
+             bool check_temporal_macros,
+             bool check_source_directives)
 {
 #ifdef INODE_CACHE_SUPPORTED
-  const InodeCache::ContentType content_type =
-    check_temporal_macros ? InodeCache::ContentType::checked_for_temporal_macros
-                          : InodeCache::ContentType::raw;
+  InodeCache::ContentType content_type;
+  if (check_source_directives && check_temporal_macros) {
+    content_type =
+      InodeCache::ContentType::checked_for_temporal_macros_and_directives;
+  } else if (check_source_directives) {
+    content_type = InodeCache::ContentType::checked_for_source_directives;
+  } else if (check_temporal_macros) {
+    content_type = InodeCache::ContentType::checked_for_temporal_macros;
+  } else {
+    content_type = InodeCache::ContentType::raw;
+  }
   if (ctx.config.inode_cache()) {
     const auto result = ctx.inode_cache.get(path, content_type);
     if (result) {
@@ -196,8 +222,12 @@ do_hash_file(const Context& ctx,
   }
 
   HashSourceCodeResult result;
+  const auto view = util::to_string_view(*data);
   if (check_temporal_macros) {
-    result.insert(check_for_temporal_macros(util::to_string_view(*data)));
+    result.insert(check_for_temporal_macros(view));
+  }
+  if (check_source_directives) {
+    result.insert(check_for_source_directives(view));
   }
 
   Hash hash;
@@ -233,10 +263,20 @@ hash_source_code_file(const Context& ctx,
   const bool check_temporal_macros =
     !ctx.config.sloppiness().contains(core::Sloppy::time_macros);
   auto result =
-    do_hash_file(ctx, digest, path, size_hint, check_temporal_macros);
+    do_hash_file(ctx, digest, path, size_hint, check_temporal_macros, true);
 
-  if (!check_temporal_macros || result.empty()
-      || result.contains(HashSourceCode::error)) {
+  if (result.contains(HashSourceCode::error)) {
+    return result;
+  }
+
+  if (result.contains(HashSourceCode::found_embed)) {
+    LOG("Found #embed in {}", path);
+  }
+  if (result.contains(HashSourceCode::found_incbin)) {
+    LOG("Found .incbin in {}", path);
+  }
+
+  if (!check_temporal_macros || result.empty()) {
     return result;
   }
 
@@ -311,7 +351,7 @@ hash_binary_file(const Context& ctx,
                  const fs::path& path,
                  size_t size_hint)
 {
-  return do_hash_file(ctx, digest, path, size_hint, false).empty();
+  return do_hash_file(ctx, digest, path, size_hint, false, false).empty();
 }
 
 bool

--- a/src/ccache/hashutil.cpp
+++ b/src/ccache/hashutil.cpp
@@ -173,7 +173,7 @@ check_for_source_directives(std::string_view str)
 {
   HashSourceCodeResult result;
 
-  if (!sourcescanner::scan_for_embed_directives(str).empty()) {
+  if (sourcescanner::contains_embed_directive(str)) {
     result.insert(HashSourceCode::found_embed);
   }
 

--- a/src/ccache/hashutil.hpp
+++ b/src/ccache/hashutil.hpp
@@ -35,11 +35,13 @@ enum class HashSourceCode {
   found_date = 1U << 1,
   found_time = 1U << 2,
   found_timestamp = 1U << 3,
+  found_embed = 1U << 4,
+  found_incbin = 1U << 5,
 };
 
 using HashSourceCodeResult = util::BitSet<HashSourceCode>;
 
-// Search for tokens (described in HashSourceCode) in `str`.
+// Search for temporal macros in `str`.
 HashSourceCodeResult check_for_temporal_macros(std::string_view str);
 
 // Hash a source code file using the inode cache if enabled.

--- a/src/ccache/hashutil.hpp
+++ b/src/ccache/hashutil.hpp
@@ -50,6 +50,10 @@ HashSourceCodeResult hash_source_code_file(const Context& ctx,
                                            const std::filesystem::path& path,
                                            size_t size_hint = 0);
 
+// Return true if direct mode should be disabled for this scan result.
+bool should_disable_direct_mode(const Context& ctx,
+                                const HashSourceCodeResult& result);
+
 // Hash a binary file (using the inode cache if enabled) and put its digest in
 // `digest`
 //

--- a/src/ccache/inodecache.cpp
+++ b/src/ccache/inodecache.cpp
@@ -105,6 +105,14 @@ static_assert(
 static_assert(
   static_cast<int>(InodeCache::ContentType::checked_for_temporal_macros) == 1,
   "Numeric value is part of key, increment version number if changed.");
+static_assert(
+  static_cast<int>(InodeCache::ContentType::checked_for_source_directives) == 2,
+  "Numeric value is part of key, increment version number if changed.");
+static_assert(
+  static_cast<int>(
+    InodeCache::ContentType::checked_for_temporal_macros_and_directives)
+    == 3,
+  "Numeric value is part of key, increment version number if changed.");
 
 bool
 fd_is_on_known_to_work_file_system(int fd)

--- a/src/ccache/inodecache.hpp
+++ b/src/ccache/inodecache.hpp
@@ -48,6 +48,10 @@ public:
     // The file was checked for temporal macros (see check_for_temporal_macros
     // in hashutil).
     checked_for_temporal_macros = 1,
+    // The file was checked for #embed and .incbin directives.
+    checked_for_source_directives = 2,
+    // The file was checked for temporal macros as well as #embed and .incbin.
+    checked_for_temporal_macros_and_directives = 3,
   };
 
   // `min_age` specifies how old a file must be to be put in the cache. The

--- a/src/ccache/sourcescanner.cpp
+++ b/src/ccache/sourcescanner.cpp
@@ -67,11 +67,9 @@ skip_whitespace_and_continuations(const char* p, const char* end)
   return p;
 }
 
-std::vector<EmbedDirective>
-scan_for_embed_directives(std::string_view source)
+bool
+contains_embed_directive(std::string_view source)
 {
-  std::vector<EmbedDirective> result;
-
   const char* p = source.data();
   const char* const end = p + source.size();
 
@@ -112,14 +110,10 @@ scan_for_embed_directives(std::string_view source)
     // See: https://en.cppreference.com/w/c/preprocessor/embed
     char open_delim = *p;
     char close_delim;
-    bool is_system;
-
     if (open_delim == '"') {
       close_delim = '"';
-      is_system = false;
     } else if (open_delim == '<') {
       close_delim = '>';
-      is_system = true;
     } else {
       p = skip_to_next_line(p, end);
       continue;
@@ -134,16 +128,15 @@ scan_for_embed_directives(std::string_view source)
     }
 
     if (p < end && *p == close_delim) {
-      std::string path(path_start, p - path_start);
-      if (!path.empty()) {
-        result.push_back({std::move(path), is_system});
+      if (p > path_start) {
+        return true;
       }
     }
 
     p = skip_to_next_line(p, end);
   }
 
-  return result;
+  return false;
 }
 
 bool

--- a/src/ccache/sourcescanner.cpp
+++ b/src/ccache/sourcescanner.cpp
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 Joel Rosdahl and other contributors
+//
+// See doc/authors.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "sourcescanner.hpp"
+
+#include <cctype>
+#include <cstring>
+
+namespace sourcescanner {
+
+static const char*
+skip_to_next_line(const char* p, const char* end)
+{
+  while (p < end && *p != '\n') {
+    ++p;
+  }
+  return p < end ? p + 1 : p;
+}
+
+static const char*
+skip_horizontal_whitespace(const char* p, const char* end)
+{
+  while (p < end && (*p == ' ' || *p == '\t')) {
+    ++p;
+  }
+  return p;
+}
+
+static const char*
+skip_line_continuation(const char* p, const char* end)
+{
+  if (p + 1 < end && *p == '\\' && (p[1] == '\n' || p[1] == '\r')) {
+    p += 2;
+    if (p < end && p[-1] == '\r' && *p == '\n') {
+      ++p;
+    }
+  }
+  return p;
+}
+
+static const char*
+skip_whitespace_and_continuations(const char* p, const char* end)
+{
+  while (p < end) {
+    const char* prev = p;
+    p = skip_horizontal_whitespace(p, end);
+    p = skip_line_continuation(p, end);
+    if (p == prev) {
+      break;
+    }
+  }
+  return p;
+}
+
+std::vector<EmbedDirective>
+scan_for_embed_directives(std::string_view source)
+{
+  std::vector<EmbedDirective> result;
+
+  const char* p = source.data();
+  const char* const end = p + source.size();
+
+  while (p < end) {
+    // Look for '#' at the start of a line
+    if (*p != '#') {
+      p = skip_to_next_line(p, end);
+      continue;
+    }
+
+    ++p;
+    p = skip_whitespace_and_continuations(p, end);
+
+    // Check for "embed" keyword
+    if (p + 5 > end || std::strncmp(p, "embed", 5) != 0) {
+      p = skip_to_next_line(p, end);
+      continue;
+    }
+
+    // Ensure "embed" is not part of a longer identifier (e.g. #embedded).
+    // Required because we're doing text matching, not tokenization.
+    const char* after_embed = p + 5;
+    if (after_embed < end
+        && (std::isalnum(static_cast<unsigned char>(*after_embed))
+            || *after_embed == '_')) {
+      p = skip_to_next_line(p, end);
+      continue;
+    }
+
+    p = skip_whitespace_and_continuations(after_embed, end);
+    if (p >= end) {
+      break;
+    }
+
+    // C23 6.10.2: #embed has two forms like #include:
+    //   #embed "q-char-sequence"  (quoted)
+    //   #embed <h-char-sequence>  (system)
+    // See: https://en.cppreference.com/w/c/preprocessor/embed
+    char open_delim = *p;
+    char close_delim;
+    bool is_system;
+
+    if (open_delim == '"') {
+      close_delim = '"';
+      is_system = false;
+    } else if (open_delim == '<') {
+      close_delim = '>';
+      is_system = true;
+    } else {
+      p = skip_to_next_line(p, end);
+      continue;
+    }
+
+    ++p;
+    const char* path_start = p;
+
+    // Extract path until closing delimiter or newline.
+    while (p < end && *p != close_delim && *p != '\n') {
+      ++p;
+    }
+
+    if (p < end && *p == close_delim) {
+      std::string path(path_start, p - path_start);
+      if (!path.empty()) {
+        result.push_back({std::move(path), is_system});
+      }
+    }
+
+    p = skip_to_next_line(p, end);
+  }
+
+  return result;
+}
+
+} // namespace sourcescanner

--- a/src/ccache/sourcescanner.cpp
+++ b/src/ccache/sourcescanner.cpp
@@ -146,4 +146,24 @@ scan_for_embed_directives(std::string_view source)
   return result;
 }
 
+bool
+contains_incbin_directive(std::string_view source)
+{
+  const char* begin = source.data();
+  const char* const end = begin + source.size();
+  static constexpr std::string_view incbin_directive = ".incbin";
+  size_t pos = 0;
+  while ((pos = source.find(incbin_directive, pos)) != std::string_view::npos) {
+    const char* next = begin + pos + incbin_directive.size();
+    const char* i = skip_horizontal_whitespace(next, end);
+    if (i < end
+        && (i[0] == '"' || (i[0] == '\\' && i + 1 < end && i[1] == '"'))) {
+      return true;
+    }
+    pos += incbin_directive.size();
+  }
+
+  return false;
+}
+
 } // namespace sourcescanner

--- a/src/ccache/sourcescanner.hpp
+++ b/src/ccache/sourcescanner.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 Joel Rosdahl and other contributors
+//
+// See doc/authors.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#pragma once
+
+#include <filesystem>
+#include <string_view>
+#include <vector>
+
+namespace sourcescanner {
+
+struct EmbedDirective
+{
+  std::string path;
+  bool is_system; // <...> vs "..."
+};
+
+// Scan source code for C23 #embed directives and return the referenced paths.
+// Handles quoted ("...") and system (<...>) includes, line continuations, and
+// embed parameters. Does not handle #embed inside comments or string literals;
+// false positives are acceptable for dependency tracking purposes.
+std::vector<EmbedDirective> scan_for_embed_directives(std::string_view source);
+
+} // namespace sourcescanner

--- a/src/ccache/sourcescanner.hpp
+++ b/src/ccache/sourcescanner.hpp
@@ -18,23 +18,12 @@
 
 #pragma once
 
-#include <filesystem>
 #include <string_view>
-#include <vector>
 
 namespace sourcescanner {
 
-struct EmbedDirective
-{
-  std::string path;
-  bool is_system; // <...> vs "..."
-};
-
-// Scan source code for C23 #embed directives and return the referenced paths.
-// Handles quoted ("...") and system (<...>) includes, line continuations, and
-// embed parameters. Does not handle #embed inside comments or string literals;
-// false positives are acceptable for dependency tracking purposes.
-std::vector<EmbedDirective> scan_for_embed_directives(std::string_view source);
+// Scan source code for C23 #embed directives.
+bool contains_embed_directive(std::string_view source);
 
 // Scan source code for an assembler .incbin directive.
 bool contains_incbin_directive(std::string_view source);

--- a/src/ccache/sourcescanner.hpp
+++ b/src/ccache/sourcescanner.hpp
@@ -36,4 +36,7 @@ struct EmbedDirective
 // false positives are acceptable for dependency tracking purposes.
 std::vector<EmbedDirective> scan_for_embed_directives(std::string_view source);
 
+// Scan source code for an assembler .incbin directive.
+bool contains_incbin_directive(std::string_view source);
+
 } // namespace sourcescanner

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
   test_depfile.cpp
   test_hash.cpp
   test_hashutil.cpp
+  test_sourcescanner.cpp
   test_storage_local_statsfile.cpp
   test_storage_local_util.cpp
   test_util_args.cpp

--- a/unittest/test_hashutil.cpp
+++ b/unittest/test_hashutil.cpp
@@ -18,6 +18,7 @@
 
 #include "testutil.hpp"
 
+#include <ccache/context.hpp>
 #include <ccache/hash.hpp>
 #include <ccache/hashutil.hpp>
 #include <ccache/util/file.hpp>
@@ -278,6 +279,30 @@ TEST_CASE("check_for_temporal_macros")
   for (size_t i = 0; i < no_temporal_at_avx_boundary.size() - 8; ++i) {
     CHECK(check(no_temporal_at_avx_boundary.substr(i)).empty());
   }
+}
+
+TEST_CASE("should_disable_direct_mode")
+{
+  Context ctx;
+
+  HashSourceCodeResult result;
+  CHECK_FALSE(should_disable_direct_mode(ctx, result));
+
+  result.insert(HashSourceCode::found_time);
+  CHECK(should_disable_direct_mode(ctx, result));
+
+  result = HashSourceCodeResult();
+  result.insert(HashSourceCode::found_embed);
+  CHECK(should_disable_direct_mode(ctx, result));
+
+  result = HashSourceCodeResult();
+  result.insert(HashSourceCode::found_incbin);
+  CHECK(should_disable_direct_mode(ctx, result));
+
+  ctx.config.update_from_map({
+    {"sloppiness", "incbin"}
+  });
+  CHECK_FALSE(should_disable_direct_mode(ctx, result));
 }
 
 TEST_SUITE_END();

--- a/unittest/test_sourcescanner.cpp
+++ b/unittest/test_sourcescanner.cpp
@@ -1,0 +1,180 @@
+// Copyright (C) 2025 Joel Rosdahl and other contributors
+//
+// See doc/authors.adoc for a complete list of contributors.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc., 51
+// Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <ccache/sourcescanner.hpp>
+
+#include <doctest/doctest.h>
+
+#include <string>
+
+using sourcescanner::EmbedDirective;
+using sourcescanner::scan_for_embed_directives;
+
+TEST_SUITE_BEGIN("sourcescanner");
+
+TEST_CASE("scan_for_embed_directives: empty source")
+{
+  auto result = scan_for_embed_directives("");
+  CHECK(result.empty());
+}
+
+TEST_CASE("scan_for_embed_directives: no embed directives")
+{
+  auto result = scan_for_embed_directives(R"(
+#include <stdio.h>
+#include "header.h"
+int main() { return 0; }
+)");
+  CHECK(result.empty());
+}
+
+TEST_CASE("scan_for_embed_directives: simple quoted embed")
+{
+  auto result = scan_for_embed_directives(R"(
+#embed "data.bin"
+)");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "data.bin");
+  CHECK(result[0].is_system == false);
+}
+
+TEST_CASE("scan_for_embed_directives: simple system embed")
+{
+  auto result = scan_for_embed_directives(R"(
+#embed <system_data.bin>
+)");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "system_data.bin");
+  CHECK(result[0].is_system == true);
+}
+
+TEST_CASE("scan_for_embed_directives: embed with path")
+{
+  auto result = scan_for_embed_directives(R"(
+#embed "assets/textures/icon.png"
+)");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "assets/textures/icon.png");
+  CHECK(result[0].is_system == false);
+}
+
+TEST_CASE("scan_for_embed_directives: embed with parameters")
+{
+  auto result = scan_for_embed_directives(R"(
+#embed "data.bin" limit(100)
+)");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "data.bin");
+  CHECK(result[0].is_system == false);
+}
+
+TEST_CASE("scan_for_embed_directives: embed with multiple parameters")
+{
+  auto result = scan_for_embed_directives(R"(
+#embed "data.bin" prefix(0x00,) suffix(,0x00) if_empty(0) limit(256)
+)");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "data.bin");
+  CHECK(result[0].is_system == false);
+}
+
+TEST_CASE("scan_for_embed_directives: multiple embeds")
+{
+  auto result = scan_for_embed_directives(R"(
+#include <stdio.h>
+#embed "file1.bin"
+int main() {
+#embed "file2.bin"
+#embed <system.bin>
+  return 0;
+}
+)");
+  REQUIRE(result.size() == 3);
+  CHECK(result[0].path == "file1.bin");
+  CHECK(result[0].is_system == false);
+  CHECK(result[1].path == "file2.bin");
+  CHECK(result[1].is_system == false);
+  CHECK(result[2].path == "system.bin");
+  CHECK(result[2].is_system == true);
+}
+
+TEST_CASE("scan_for_embed_directives: embed with whitespace")
+{
+  auto result = scan_for_embed_directives(R"(
+#  embed   "data.bin"
+)");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "data.bin");
+}
+
+TEST_CASE("scan_for_embed_directives: embed with line continuation")
+{
+  auto result = scan_for_embed_directives("#embed \\\n\"data.bin\"\n");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "data.bin");
+}
+
+TEST_CASE("scan_for_embed_directives: embed at start of file")
+{
+  auto result = scan_for_embed_directives("#embed \"first.bin\"\n");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "first.bin");
+}
+
+TEST_CASE("scan_for_embed_directives: embed at end of file without newline")
+{
+  auto result = scan_for_embed_directives("#embed \"last.bin\"");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "last.bin");
+}
+
+TEST_CASE("scan_for_embed_directives: ignores embedded in identifier")
+{
+  auto result = scan_for_embed_directives(R"(
+#embedded "not_this.bin"
+#embedx "not_this_either.bin"
+)");
+  CHECK(result.empty());
+}
+
+TEST_CASE("scan_for_embed_directives: handles tabs")
+{
+  auto result = scan_for_embed_directives("#\tembed\t\"data.bin\"\n");
+  REQUIRE(result.size() == 1);
+  CHECK(result[0].path == "data.bin");
+}
+
+TEST_CASE("scan_for_embed_directives: mixed includes and embeds")
+{
+  auto result = scan_for_embed_directives(R"(
+#include <stdio.h>
+#include "local.h"
+#embed "binary.dat"
+#define FOO 1
+#embed <sys/resource.bin>
+#ifdef BAR
+#embed "conditional.bin"
+#endif
+)");
+  REQUIRE(result.size() == 3);
+  CHECK(result[0].path == "binary.dat");
+  CHECK(result[1].path == "sys/resource.bin");
+  CHECK(result[2].path == "conditional.bin");
+}
+
+TEST_SUITE_END();

--- a/unittest/test_sourcescanner.cpp
+++ b/unittest/test_sourcescanner.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 
+using sourcescanner::contains_incbin_directive;
 using sourcescanner::EmbedDirective;
 using sourcescanner::scan_for_embed_directives;
 
@@ -175,6 +176,34 @@ TEST_CASE("scan_for_embed_directives: mixed includes and embeds")
   CHECK(result[0].path == "binary.dat");
   CHECK(result[1].path == "sys/resource.bin");
   CHECK(result[2].path == "conditional.bin");
+}
+
+TEST_CASE("contains_incbin_directive: empty source")
+{
+  CHECK(contains_incbin_directive("") == false);
+}
+
+TEST_CASE("contains_incbin_directive: no incbin directive")
+{
+  CHECK(contains_incbin_directive(R"(
+    #include <stdio.h>
+    .incbin data.bin
+  )") == false);
+}
+
+TEST_CASE("contains_incbin_directive: simple incbin")
+{
+  CHECK(contains_incbin_directive(".incbin \"data.bin\"\n") == true);
+}
+
+TEST_CASE("contains_incbin_directive: incbin without space")
+{
+  CHECK(contains_incbin_directive(".incbin\"data.bin\"\n") == true);
+}
+
+TEST_CASE("contains_incbin_directive: escaped quote")
+{
+  CHECK(contains_incbin_directive(".incbin \\\"data.bin\\\"\n") == true);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Hi, this PR is totally AI generated but I did go through, review and test it, even with my codebase that needed some of this to work. Not sure of your AI use policy, so let me know if you accept this.

Add support for tracking files referenced by C23's #embed directive in direct mode. This ensures that when an embedded file changes, the cache is properly invalidated.

Changes:
- Add sourcescanner module to scan source files for #embed directives
- Integrate scanning into get_manifest_key() to remember embedded files
- Add unit tests for the source scanner

Fixes #1540



<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
