### PR TITLE
fix: Rewrite 'inlined from' messages in absolute_paths_in_stderr

### DIFF
--- a/unittest/test_core_common.cpp
+++ b/unittest/test_core_common.cpp
@@ -80,7 +80,9 @@ TEST_CASE("core::rewrite_stderr_to_absolute_paths")
     "In module imported at \x1b[01m\x1b[Kexisting:\x1b[m\x1b[K: foo\n"
     "In module imported at \x1b[01m\x1b[Kexisting:47:11:\x1b[m\x1b[K: foo\n"
     "imported at \x1b[01m\x1b[Kexisting:\x1b[m\x1b[K: foo\n"
-    "imported at \x1b[01m\x1b[Kexisting:47:11:\x1b[m\x1b[K: foo\n";
+    "imported at \x1b[01m\x1b[Kexisting:47:11:\x1b[m\x1b[K: foo\n"
+    "    inlined from foo at \x1b[01m\x1b[Kexisting:\x1b[m\x1b[K\n"
+    "    inlined from foo at \x1b[01m\x1b[Kexisting:47:11,\x1b[m\x1b[K\n";
   std::string expected = FMT(
     "a:1:2\n"
     "a(3):\n"
@@ -109,7 +111,9 @@ TEST_CASE("core::rewrite_stderr_to_absolute_paths")
     "In module imported at \x1b[01m\x1b[K{0}:\x1b[m\x1b[K: foo\n"
     "In module imported at \x1b[01m\x1b[K{0}:47:11:\x1b[m\x1b[K: foo\n"
     "imported at \x1b[01m\x1b[K{0}:\x1b[m\x1b[K: foo\n"
-    "imported at \x1b[01m\x1b[K{0}:47:11:\x1b[m\x1b[K: foo\n",
+    "imported at \x1b[01m\x1b[K{0}:47:11:\x1b[m\x1b[K: foo\n"
+    "    inlined from foo at \x1b[01m\x1b[K{0}:\x1b[m\x1b[K\n"
+    "    inlined from foo at \x1b[01m\x1b[K{0}:47:11,\x1b[m\x1b[K\n",
     *fs::canonical("existing"));
   CHECK(core::rewrite_stderr_to_absolute_paths(input) == expected);
 }


### PR DESCRIPTION
Resolves #1673 

Here are some changes that should resolve `inlined from ... at` messages not being rewritten to absolute paths when `absolute_paths_in_stderr` is `true`.

I split the message parsing into two functions:
* `parse_inlined_from_msg`
* `parse_in_file_included_from_msg`

While not technically necessary, I found it easier to understand the code with two separate inline functions instead of one rather big if-block in `rewrite_stderr_to_absolute_paths`.

Please let me know if you'd prefer a different version!