### PR TITLE
fix(cmake): Enable assembler compiler conditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(ccache LANGUAGES C CXX ASM ASM_MASM)
+project(ccache LANGUAGES C CXX)
 if(MSVC)
   enable_language(ASM_MASM)
 else()


### PR DESCRIPTION
CMake will call `enable_language` for all languages passed to `project`. This deduplicates the work and only enables one assembler depending on the platform.

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
