### PR TITLE
enhance: Use copy_file_range to copy files if available

### DIFF
--- a/cmake/GenerateConfigurationFile.cmake
+++ b/cmake/GenerateConfigurationFile.cmake
@@ -25,6 +25,7 @@ endforeach()
 
 include(CheckFunctionExists)
 set(functions
+    copy_file_range
     getopt_long
     getpwuid
     localtime_r

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -113,6 +113,9 @@
 
 // === Functions ===
 
+// Define if you have the "copy_file_range" function.
+#cmakedefine HAVE_COPY_FILE_RANGE
+
 // Define if you have the "getopt_long" function.
 #cmakedefine HAVE_GETOPT_LONG
 


### PR DESCRIPTION
Check if copy_file_range function is present and use it.

`sys/sendfile.h` header is linux-specific and calling it with file descriptor destination is linux-specific too.
copy_file_range is adopted a little bit wider, however requires newer kernels (5.3+) .

I placed it before sendfile block for tests to pick it before sendfile, but IMO finally it should be committed after sendfile block not to cause degradation on linux with older kernels.