### PR TITLE
fix(cmake): atomic library build error fixed for Apple Silicon macOS

### DIFF
--- a/cmake/StdAtomic.cmake
+++ b/cmake/StdAtomic.cmake
@@ -4,20 +4,26 @@ set(LIBATOMIC_STATIC_PATH "" CACHE PATH "Directory containing static libatomic.a
 
 include(CheckCXXSourceCompiles)
 
-set(
-  check_std_atomic_source_code
-  [=[
-    #include <atomic>
-    int main()
-    {
-      std::atomic<long long> x;
-      ++x;
-      (void)x.load();
-      return 0;
-    }
-  ]=])
+# On macOS, std::atomic is built-in and doesn't require -latomic
+if(APPLE)
+  set(std_atomic_without_libatomic TRUE)
+  message(STATUS "macOS detected: std::atomic is built-in")
+else()
+  set(
+    check_std_atomic_source_code
+    [=[
+      #include <atomic>
+      int main()
+      {
+        std::atomic<long long> x;
+        ++x;
+        (void)x.load();
+        return 0;
+      }
+    ]=])
 
-check_cxx_source_compiles("${check_std_atomic_source_code}" std_atomic_without_libatomic)
+  check_cxx_source_compiles("${check_std_atomic_source_code}" std_atomic_without_libatomic)
+endif()
 
 if(NOT std_atomic_without_libatomic)
   set(CMAKE_REQUIRED_LIBRARIES atomic)


### PR DESCRIPTION
A fix has been added for the following build error on Apple Silicon macOS:  
`CMake Error at cmake/StdAtomic.cmake:27 (message): Toolchain doesn't support std::atomic with or without -latomic`

Description:
On macOS, std::atomic is part of the standard library and doesn't require linking against -latomic like on Linux systems. 
To handle this, a check using a CMake flag for Apple devices has been added in the **StdAtomic.cmake** file, setting the `std_atomic_without_libatomic` flag to **_TRUE_** for macOS to avoid linking with -latomic.