### PR TITLE
refactor: Generalize "already preprocessed" compiler language slightly

### DIFF
--- a/src/ccache/argsinfo.hpp
+++ b/src/ccache/argsinfo.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 Joel Rosdahl and other contributors
+// Copyright (C) 2020-2026 Joel Rosdahl and other contributors
 //
 // See doc/authors.adoc for a complete list of contributors.
 //
@@ -121,8 +121,9 @@ struct ArgsInfo
   // Have we seen -gsplit-dwarf?
   bool seen_split_dwarf = false;
 
-  // Are we compiling a .i or .ii file directly?
-  bool direct_i_file = false;
+  // Should we run the preprocessor on the input file? False for .i/.ii files,
+  // assembler or ThinLTO backend phase.
+  bool preprocess_input_file = true;
 
   // Whether the output is a precompiled header.
   bool output_is_precompiled_header = false;

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -1394,9 +1394,8 @@ get_result_key_from_cpp(Context& ctx, util::Args& args, Hash& hash)
 
   const bool capture_stdout = is_clang_cu;
 
-  if (ctx.args_info.direct_i_file) {
-    // We are compiling a .i or .ii file - that means we can skip the cpp stage
-    // and directly form the correct i_tmpfile.
+  if (!ctx.args_info.preprocess_input_file) {
+    // We are compiling a file that should be used as is (not be preprocessed).
     preprocessed_path = ctx.args_info.input_file;
   } else {
     // Run cpp on the input file to obtain the .i.

--- a/src/ccache/language.cpp
+++ b/src/ccache/language.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2024 Joel Rosdahl and other contributors
+// Copyright (C) 2010-2026 Joel Rosdahl and other contributors
 //
 // See doc/authors.adoc for a complete list of contributors.
 //
@@ -99,6 +99,7 @@ const struct
   {"objective-c++-cpp-output", "objective-c++-cpp-output"},
   {"assembler-with-cpp",       "assembler"               },
   {"assembler",                "assembler"               },
+  {"ir",                       "ir"                      }, // Clang ThinLTO
   {nullptr,                    nullptr                   },
 };
 


### PR DESCRIPTION
- Rename `ArgsInfo::direct_i_file` to `preprocess_input_file` (inverting the logic), since that's what it now means.
- Add "ir" as a language and let `-fthinlto-index=` use that language implicitly instead of piggybacking on "assembler".

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
