### PR TITLE
chore: use CMake knowledge about helper locations

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ function(addtest name)
   set_tests_properties(
     "test.${name}"
     PROPERTIES
-    ENVIRONMENT "CCACHE=$<TARGET_FILE:ccache>;EXIT_IF_SKIPPED=true"
+    ENVIRONMENT "CCACHE=$<TARGET_FILE:ccache>;STORAGE_TEST_HELPER=$<TARGET_FILE:ccache-storage-test>;STORAGE_TEST_CLIENT=$<TARGET_FILE:storage-test-client>;EXIT_IF_SKIPPED=true"
     SKIP_RETURN_CODE 125)
 endfunction()
 

--- a/test/run
+++ b/test/run
@@ -555,6 +555,16 @@ if [ -z "$CCACHE" ]; then
     CCACHE=`pwd`/ccache
 fi
 
+if [ -z "$STORAGE_TEST_HELPER" ]; then
+    STORAGE_TEST_HELPER=$(pwd)/test/storage/helper/ccache-storage-test
+fi
+
+if [ -z "$STORAGE_TEST_CLIENT" ]; then
+    STORAGE_TEST_CLIENT=$(pwd)/test/storage/client/storage-test-client
+fi
+
+readonly CCACHE STORAGE_TEST_HELPER STORAGE_TEST_CLIENT
+
 COMPILER_TYPE_CLANG=false
 COMPILER_TYPE_GCC=false
 
@@ -565,8 +575,6 @@ COMPILER_USES_MSVC=false
 ABS_ROOT_DIR="$(cd $(dirname "$0"); pwd)"
 readonly HTTP_CLIENT="${ABS_ROOT_DIR}/http-client"
 readonly HTTP_SERVER="${ABS_ROOT_DIR}/http-server"
-readonly STORAGE_TEST_HELPER="$(pwd)/test/storage/helper/ccache-storage-test"
-readonly STORAGE_TEST_CLIENT="$(pwd)/test/storage/client/storage-test-client"
 
 HOST_OS_APPLE=false
 HOST_OS_LINUX=false


### PR DESCRIPTION
In our build system we set [EXECUTABLE_OUTPUT_PATH](https://cmake.org/cmake/help/latest/variable/EXECUTABLE_OUTPUT_PATH.html) which breaks the `remote_helper` test. Pass the binary location from CMake to the test runner.