### PR TITLE
chore: remove obsolete condition

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,14 +12,9 @@ function(addtest name)
     SKIP_RETURN_CODE 125)
 endfunction()
 
-if(${CMAKE_VERSION} VERSION_LESS "3.15")
-  set(clean_files_prop_name ADDITIONAL_MAKE_CLEAN_FILES)
-else()
-  set(clean_files_prop_name ADDITIONAL_CLEAN_FILES)
-endif()
 set_property(
   DIRECTORY PROPERTY
-  ${clean_files_prop_name} "${CMAKE_BINARY_DIR}/testdir")
+  ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/testdir")
 
 addtest(base)
 addtest(basedir)


### PR DESCRIPTION
The minimum CMake version is now 3.18. The condition could be removed.