### PR TITLE
fix: LTO is disabled if `-fno-lto` is used

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -951,8 +951,16 @@ process_option_arg(const Context& ctx,
     return Statistic::none;
   }
 
+  // LTO can be enabled with -flto[=n]
   if (arg == "-flto" || arg.starts_with("-flto=")) {
     args_info.using_lto = true;
+    state.add_common_arg(args[i]);
+    return Statistic::none;
+  }
+
+  // LTO can be disabled with -fno-lto
+  if (arg == "-fno-lto") {
+    args_info.using_lto = false;
     state.add_common_arg(args[i]);
     return Statistic::none;
   }

--- a/test/suites/direct.bash
+++ b/test/suites/direct.bash
@@ -715,6 +715,94 @@ EOF
     fi
 
     # -------------------------------------------------------------------------
+    TEST "-fstack-usage with -flto -fno-lto"
+
+    cat <<EOF >main.c
+extern int test();
+int main() { return test(); }
+EOF
+
+    cat <<EOF >code.c
+int test() { return 0; }
+EOF
+
+    if $COMPILER -c -fstack-usage -flto -fno-lto main.c >/dev/null 2>&1; then
+        $CCACHE_COMPILE -c -fstack-usage -flto -fno-lto main.c
+        $CCACHE_COMPILE -c -fstack-usage -flto -fno-lto code.c
+        $CCACHE_COMPILE -o output -fstack-usage -flto -fno-lto main.o code.o
+        expect_stat called_for_link 1
+        expect_stat direct_cache_hit 0
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 2
+        expect_exists main.su
+        expect_exists code.su
+        expect_missing output.ltrans0.ltrans.su
+
+        rm main.su
+        rm code.su
+
+        $CCACHE_COMPILE -c -fstack-usage -flto -fno-lto main.c
+        $CCACHE_COMPILE -c -fstack-usage -flto -fno-lto code.c
+        $CCACHE_COMPILE -o output -fstack-usage -flto -fno-lto main.o code.o
+        expect_stat called_for_link 2
+        expect_stat direct_cache_hit 2
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 2
+        expect_exists main.su
+        expect_exists code.su
+        expect_missing output.ltrans0.ltrans.su
+    fi
+
+    # -------------------------------------------------------------------------
+    TEST "-fstack-usage with -fno-lto -flto"
+
+    cat <<EOF >main.c
+extern int test();
+int main() { return test(); }
+EOF
+
+    cat <<EOF >code.c
+int test() { return 0; }
+EOF
+
+    if $COMPILER -c -fstack-usage -fno-lto -flto main.c >/dev/null 2>&1; then
+        $CCACHE_COMPILE -c -fstack-usage -fno-lto -flto main.c
+        $CCACHE_COMPILE -c -fstack-usage -fno-lto -flto code.c
+        $CCACHE_COMPILE -o output -fstack-usage -fno-lto -flto main.o code.o
+        expect_stat called_for_link 1
+        expect_stat direct_cache_hit 0
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 2
+        expect_missing main.su
+        expect_missing code.su
+
+        # clang does not produce .su files
+        if [[ "$(basename "$COMPILER")" != clang* ]]; then
+            expect_exists output.ltrans0.ltrans.su
+            expect_contains output.ltrans0.ltrans.su main.c
+            expect_contains output.ltrans0.ltrans.su code.c
+            rm output.ltrans0.ltrans.su
+        fi
+
+        $CCACHE_COMPILE -c -fstack-usage -fno-lto -flto main.c
+        $CCACHE_COMPILE -c -fstack-usage -fno-lto -flto code.c
+        $CCACHE_COMPILE -o output -fstack-usage -fno-lto -flto main.o code.o
+        expect_stat called_for_link 2
+        expect_stat direct_cache_hit 2
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 2
+        expect_missing main.su
+        expect_missing code.su
+
+        # clang does not produce .su files
+        if [[ "$(basename "$COMPILER")" != clang* ]]; then
+            expect_exists output.ltrans0.ltrans.su
+            expect_contains output.ltrans0.ltrans.su main.c
+            expect_contains output.ltrans0.ltrans.su code.c
+        fi
+    fi
+
+    # -------------------------------------------------------------------------
     TEST "-fcallgraph-info"
 
     cat <<EOF >code.c
@@ -833,6 +921,87 @@ EOF
         $CCACHE_COMPILE -c -fcallgraph-info -flto=auto main.c
         $CCACHE_COMPILE -c -fcallgraph-info -flto=auto code.c
         $CCACHE_COMPILE -o output -fcallgraph-info -flto=auto main.o code.o
+        expect_stat called_for_link 2
+        expect_stat direct_cache_hit 2
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 2
+        expect_missing main.ci
+        expect_missing code.ci
+        expect_exists output.ltrans0.ltrans.ci
+        expect_contains output.ltrans0.ltrans.ci main.c
+        expect_contains output.ltrans0.ltrans.ci code.c
+    fi
+
+    # -------------------------------------------------------------------------
+    TEST "-fcallgraph-info with -flto -fno-lto"
+
+    cat <<EOF >main.c
+extern int test();
+int main() { return test(); }
+EOF
+
+    cat <<EOF >code.c
+int test() { return 0; }
+EOF
+
+    if $COMPILER -c -fcallgraph-info -flto -fno-lto main.c >/dev/null 2>&1; then
+        $CCACHE_COMPILE -c -fcallgraph-info -flto -fno-lto main.c
+        $CCACHE_COMPILE -c -fcallgraph-info -flto -fno-lto code.c
+        $CCACHE_COMPILE -o output -fcallgraph-info -flto -fno-lto main.o code.o
+        expect_stat called_for_link 1
+        expect_stat direct_cache_hit 0
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 2
+        expect_exists main.ci
+        expect_exists code.ci
+        expect_missing output.ltrans0.ltrans.ci
+
+        rm main.ci
+        rm code.ci
+
+        $CCACHE_COMPILE -c -fcallgraph-info -flto -fno-lto main.c
+        $CCACHE_COMPILE -c -fcallgraph-info -flto -fno-lto code.c
+        $CCACHE_COMPILE -o output -fcallgraph-info -flto -fno-lto main.o code.o
+        expect_stat called_for_link 2
+        expect_stat direct_cache_hit 2
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 2
+        expect_exists main.ci
+        expect_exists code.ci
+        expect_missing output.ltrans0.ltrans.ci
+    fi
+
+    # -------------------------------------------------------------------------
+    TEST "-fcallgraph-info with -fno-lto -flto"
+
+    cat <<EOF >main.c
+extern int test();
+int main() { return test(); }
+EOF
+
+    cat <<EOF >code.c
+int test() { return 0; }
+EOF
+
+    if $COMPILER -c -fcallgraph-info -fno-lto -flto main.c >/dev/null 2>&1; then
+        $CCACHE_COMPILE -c -fcallgraph-info -fno-lto -flto main.c
+        $CCACHE_COMPILE -c -fcallgraph-info -fno-lto -flto code.c
+        $CCACHE_COMPILE -o output -fcallgraph-info -fno-lto -flto main.o code.o
+        expect_stat called_for_link 1
+        expect_stat direct_cache_hit 0
+        expect_stat preprocessed_cache_hit 0
+        expect_stat cache_miss 2
+        expect_missing main.ci
+        expect_missing code.ci
+        expect_exists output.ltrans0.ltrans.ci
+        expect_contains output.ltrans0.ltrans.ci main.c
+        expect_contains output.ltrans0.ltrans.ci code.c
+
+        rm output.ltrans0.ltrans.ci
+
+        $CCACHE_COMPILE -c -fcallgraph-info -fno-lto -flto main.c
+        $CCACHE_COMPILE -c -fcallgraph-info -fno-lto -flto code.c
+        $CCACHE_COMPILE -o output -fcallgraph-info -fno-lto -flto main.o code.o
         expect_stat called_for_link 2
         expect_stat direct_cache_hit 2
         expect_stat preprocessed_cache_hit 0


### PR DESCRIPTION
If `-flto` is followered by `-fno-lto`, then LTO will be disabled

On the other hand if `-fno-lto` is followered by `-flto`, then LTO will be enabled
