### PR TITLE
feat: Add support for QCC (QNX) compiler

### DIFF
--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -683,6 +683,8 @@ _<<Using ccache with other compiler wrappers>>_.
     Microsoft Visual C++ (MSVC).
 *nvcc*::
     NVCC (CUDA) compiler.
+*qcc*::
+    QCC (QNX) compiler.
 *other*::
     Any compiler other than the known types.
 --

--- a/doc/news.adoc
+++ b/doc/news.adoc
@@ -92,6 +92,8 @@ Release date: 2026-03-05
 - Added support for caching distributed ThinLTO for Clang. +
   [small]#_[contributed by GitHub user zcfh]_#
 
+- Added support for QCC (QNX) compiler.
+
 - Added support for caching MSVC `/sourceDependencies` file. +
   [small]#_[contributed by Joel Rosdahl]_#
 

--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -1158,7 +1158,7 @@ process_option_arg(const Context& ctx,
     return Statistic::none;
   }
 
-  if (config.compiler_type() == CompilerType::gcc) {
+  if (config.is_compiler_group_gcc()) {
     if (arg == "-fdiagnostics-color" || arg == "-fdiagnostics-color=always") {
       state.color_diagnostics = ColorDiagnostics::always;
       state.add_compiler_only_arg_no_hash(args[i]);
@@ -1692,7 +1692,7 @@ process_args(Context& ctx)
     if (args_info.actual_language != "assembler") {
       diagnostics_color_arg = "-fcolor-diagnostics";
     }
-  } else if (config.compiler_type() == CompilerType::gcc) {
+  } else if (config.is_compiler_group_gcc()) {
     diagnostics_color_arg = "-fdiagnostics-color";
   } else {
     // Other compilers shouldn't output color, so no need to strip it.
@@ -1716,9 +1716,9 @@ process_args(Context& ctx)
         if (config.compiler_type() == CompilerType::clang) {
           // Clang does the sane thing: the dependency target is the output file
           // so that the dependency file actually makes sense.
-        } else if (config.compiler_type() == CompilerType::gcc) {
-          // GCC strangely uses the base name of the source file but with a .o
-          // extension.
+        } else if (config.is_compiler_group_gcc()) {
+          // GCC (and QCC) strangely uses the base name of the source file but
+          // with a .o extension.
           dep_target =
             util::with_extension(args_info.orig_input_file.filename(),
                                  get_default_object_file_extension(ctx.config));
@@ -1726,7 +1726,7 @@ process_args(Context& ctx)
           // How other compilers behave is currently unknown, so bail out.
           LOG(
             "-Wp,-M[M]D with -o without -MMD, -MQ or -MT is only supported for"
-            " GCC or Clang");
+            " GCC-like or Clang compilers");
           return tl::unexpected(Statistic::unsupported_compiler_option);
         }
       }

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -328,6 +328,8 @@ do_guess_compiler(const fs::path& path)
     return CompilerType::gcc;
   } else if (name.find("nvcc") != std::string_view::npos) {
     return CompilerType::nvcc;
+  } else if (name == "qcc" || name == "q++") {
+    return CompilerType::qcc;
   } else if (name == "icl") {
     return CompilerType::icl;
   } else if (name == "icx") {
@@ -825,7 +827,7 @@ do_execute(Context& ctx, util::Args& args, const bool capture_stdout = true)
   util::UmaskScope umask_scope(ctx.original_umask);
 
   if (ctx.diagnostics_color_failed) {
-    DEBUG_ASSERT(ctx.config.compiler_type() == CompilerType::gcc);
+    DEBUG_ASSERT(ctx.config.is_compiler_group_gcc());
     args.erase_last("-fdiagnostics-color");
   }
 
@@ -837,11 +839,11 @@ do_execute(Context& ctx, util::Args& args, const bool capture_stdout = true)
                        std::move(tmp_stdout.fd),
                        std::move(tmp_stderr.fd));
   if (status != 0 && !ctx.diagnostics_color_failed
-      && ctx.config.compiler_type() == CompilerType::gcc) {
+      && ctx.config.is_compiler_group_gcc()) {
     const auto errors = util::read_file<std::string>(tmp_stderr.path);
     if (errors && errors->find("fdiagnostics-color") != std::string::npos) {
       // GCC versions older than 4.9 don't understand -fdiagnostics-color, and
-      // non-GCC compilers misclassified as CompilerType::gcc might not do it
+      // non-GCC compilers misclassified as GCC-like might not do it
       // either. We assume that if the error message contains
       // "fdiagnostics-color" then the compilation failed due to
       // -fdiagnostics-color being unsupported and we then retry without the
@@ -1870,11 +1872,23 @@ hash_common_info(const Context& ctx, const util::Args& args, Hash& hash)
   }
 
   // Possibly hash GCC_COLORS (for color diagnostics).
-  if (ctx.config.compiler_type() == CompilerType::gcc) {
+  if (ctx.config.is_compiler_group_gcc()) {
     const char* gcc_colors = getenv("GCC_COLORS");
     if (gcc_colors) {
       hash.hash_delimiter("gcccolors");
       hash.hash(gcc_colors);
+    }
+  }
+
+  // Hash QNX-specific environment variables that affect QCC behavior.
+  if (ctx.config.compiler_type() == CompilerType::qcc) {
+    const char* qnx_env_vars[] = {"QNX_HOST", "QNX_TARGET", "QCC_CONF_PATH"};
+    for (const char* name : qnx_env_vars) {
+      const char* value = getenv(name);
+      if (value) {
+        hash.hash_delimiter(name);
+        hash.hash(value);
+      }
     }
   }
 

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -172,6 +172,7 @@ const CompOpt compopts[] = {
   {"-save-temps",             TOO_HARD                                               },
   {"-save-temps=cwd",         TOO_HARD                                               },
   {"-save-temps=obj",         TOO_HARD                                               },
+  {"-set-default",            TOO_HARD                                               }, // qcc
   {"-specs",                  TAKES_ARG                                              },
   {"-stdlib=",                AFFECTS_CPP | TAKES_CONCAT_ARG                         },
   {"-trigraphs",              AFFECTS_CPP                                            },

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -353,6 +353,8 @@ parse_compiler_type(const std::string& value)
     return CompilerType::msvc;
   } else if (value == "nvcc") {
     return CompilerType::nvcc;
+  } else if (value == "qcc") {
+    return CompilerType::qcc;
   } else if (value == "other") {
     return CompilerType::other;
   } else {
@@ -628,6 +630,7 @@ compiler_type_to_string(CompilerType compiler_type)
     CASE(icx);
     CASE(msvc);
     CASE(nvcc);
+    CASE(qcc);
     CASE(other);
   }
 #undef CASE

--- a/src/ccache/config.hpp
+++ b/src/ccache/config.hpp
@@ -45,6 +45,7 @@ enum class CompilerType {
   icx_cl,
   msvc,
   nvcc,
+  qcc,
   other
 };
 
@@ -112,6 +113,9 @@ public:
 
   // Return true for Clang, clang-cl and icx (not on Windows).
   bool is_compiler_group_clang() const;
+
+  // Return true for GCC and QCC (QNX compiler, which is GCC-based).
+  bool is_compiler_group_gcc() const;
 
   // Return true for MSVC (cl.exe), clang-cl, icl, icx-cl, and icx (on Windows).
   bool is_compiler_group_msvc() const;
@@ -316,6 +320,13 @@ Config::is_compiler_group_clang() const
          || m_compiler_type == CompilerType::icx
 #endif
          || m_compiler_type == CompilerType::clang_cl;
+}
+
+inline bool
+Config::is_compiler_group_gcc() const
+{
+  return m_compiler_type == CompilerType::gcc
+         || m_compiler_type == CompilerType::qcc;
 }
 
 inline bool

--- a/unittest/test_ccache.cpp
+++ b/unittest/test_ccache.cpp
@@ -197,6 +197,9 @@ TEST_CASE("guess_compiler")
     CHECK(guess_compiler("/test/prefix/nvcc") == CompilerType::nvcc);
     CHECK(guess_compiler("/test/prefix/nvcc-10.1.243") == CompilerType::nvcc);
 
+    CHECK(guess_compiler("/test/prefix/qcc") == CompilerType::qcc);
+    CHECK(guess_compiler("/test/prefix/q++") == CompilerType::qcc);
+
     CHECK(guess_compiler("/test/prefix/x") == CompilerType::other);
     CHECK(guess_compiler("/test/prefix/cc") == CompilerType::other);
     CHECK(guess_compiler("/test/prefix/c++") == CompilerType::other);


### PR DESCRIPTION
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->

## Add support for QCC (QNX) compiler

This PR adds support for the QCC compiler, which is the QNX Neutrino RTOS compiler toolchain. QCC is a GCC-based compiler driver, so it shares many behaviors with GCC.

### Changes

**Compiler detection:**
- Auto-detect `qcc` and `q++` executables as `CompilerType::qcc`
- Added `compiler_type = qcc` configuration option

**GCC compatibility:**
- Introduced `is_compiler_group_gcc()` to group GCC and QCC together, since QCC follows GCC conventions for:
  - Diagnostics color (`-fdiagnostics-color`)
  - Dependency target handling with `-Wp,-M[M]D`
  - `GCC_COLORS` environment variable

**QNX-specific handling:**
- Hash QNX environment variables (`QNX_HOST`, `QNX_TARGET`, `QCC_CONF_PATH`) that affect compilation output
- Mark `-set-default` option as `TOO_HARD` (QCC-specific option that changes global state)

**Documentation:**
- Updated manual with `qcc` compiler type
- Added news entry

**Tests:**
- Added unit tests for QCC/q++ compiler detection

