### PR TITLE
fix: allow tests to run remote helpers

### DIFF
--- a/test/suites/remote_http.bash
+++ b/test/suites/remote_http.bash
@@ -35,6 +35,8 @@ SUITE_remote_http_PROBE() {
 SUITE_remote_http_SETUP() {
     unset CCACHE_NODIRECT
 
+    export CRSH_LOGFILE="ccache-storage-http.log"
+
     generate_code 1 test.c
 }
 
@@ -43,7 +45,7 @@ SUITE_remote_http() {
     TEST "Subdirs layout"
 
     start_http_server 12780 remote
-    export CCACHE_REMOTE_STORAGE="http://localhost:12780 helper=_builtin_"
+    export CCACHE_REMOTE_STORAGE="http://localhost:12780"
 
     $CCACHE_COMPILE -c test.c
     expect_stat direct_cache_hit 0
@@ -75,7 +77,7 @@ SUITE_remote_http() {
     TEST "Flat layout"
 
     start_http_server 12780 remote
-    export CCACHE_REMOTE_STORAGE="http://localhost:12780 helper=_builtin_ @layout=flat"
+    export CCACHE_REMOTE_STORAGE="http://localhost:12780 @layout=flat"
 
     $CCACHE_COMPILE -c test.c
     expect_stat direct_cache_hit 0
@@ -108,7 +110,7 @@ SUITE_remote_http() {
 
     start_http_server 12780 remote
     mkdir remote/ac
-    export CCACHE_REMOTE_STORAGE="http://localhost:12780 helper=_builtin_ @layout=bazel"
+    export CCACHE_REMOTE_STORAGE="http://localhost:12780 @layout=bazel"
 
     $CCACHE_COMPILE -c test.c
     expect_stat direct_cache_hit 0
@@ -139,7 +141,7 @@ SUITE_remote_http() {
     TEST "Basic auth"
 
     start_http_server 12780 remote "somebody:secret123"
-    export CCACHE_REMOTE_STORAGE="http://somebody:secret123@localhost:12780 helper=_builtin_"
+    export CCACHE_REMOTE_STORAGE="http://somebody:secret123@localhost:12780"
 
     CCACHE_DEBUG=1 $CCACHE_COMPILE -c test.c
     expect_stat direct_cache_hit 0
@@ -158,14 +160,14 @@ if $RUN_WIN_XFAIL; then
 
     start_http_server 12780 remote "somebody:secret123"
     # no authentication configured on client
-    export CCACHE_REMOTE_STORAGE="http://localhost:12780 helper=_builtin_"
+    export CCACHE_REMOTE_STORAGE="http://localhost:12780"
 
     CCACHE_DEBUG=1 $CCACHE_COMPILE -c test.c
     expect_stat direct_cache_hit 0
     expect_stat cache_miss 1
     expect_stat files_in_cache 2
     expect_file_count 0 '*' remote # result + manifest
-    expect_contains test.o.*.ccache-log "status code: 401"
+    expect_contains test.o.*.ccache-log "401"
 fi
 
     # -------------------------------------------------------------------------
@@ -177,7 +179,7 @@ if $RUN_WIN_XFAIL; then
     TEST "Basic auth failed"
 
     start_http_server 12780 remote "somebody:secret123"
-    export CCACHE_REMOTE_STORAGE="http://somebody:wrong@localhost:12780 helper=_builtin_"
+    export CCACHE_REMOTE_STORAGE="http://somebody:wrong@localhost:12780"
 
     CCACHE_DEBUG=1 $CCACHE_COMPILE -c test.c
     expect_stat direct_cache_hit 0
@@ -185,14 +187,14 @@ if $RUN_WIN_XFAIL; then
     expect_stat files_in_cache 2
     expect_file_count 0 '*' remote # result + manifest
     expect_not_contains test.o.*.ccache-log secret123
-    expect_contains test.o.*.ccache-log "status code: 401"
+    expect_contains test.o.*.ccache-log "401"
 fi
 
      # -------------------------------------------------------------------------
     TEST "Port sharding"
 
     start_http_server 12780 remote
-    export CCACHE_REMOTE_STORAGE="http://localhost:*|shards=12780 helper=_builtin_"
+    export CCACHE_REMOTE_STORAGE="http://localhost:*|shards=12780"
 
     $CCACHE_COMPILE -c test.c
     expect_stat direct_cache_hit 0
@@ -214,7 +216,7 @@ fi
     TEST "IPv6 address"
 
     if maybe_start_ipv6_http_server 12780 remote; then
-        export CCACHE_REMOTE_STORAGE="http://[::1]:12780 helper=_builtin_"
+        export CCACHE_REMOTE_STORAGE="http://[::1]:12780"
 
         $CCACHE_COMPILE -c test.c
         expect_stat direct_cache_hit 0
@@ -243,7 +245,7 @@ fi
     TEST "Empty body on HTTP 2xx treated as error"
 
     start_http_server 12780 remote
-    export CCACHE_REMOTE_STORAGE="http://localhost:12780 helper=_builtin_"
+    export CCACHE_REMOTE_STORAGE="http://localhost:12780"
 
     # Populate remote cache.
     $CCACHE_COMPILE -c test.c

--- a/test/suites/remote_redis.bash
+++ b/test/suites/remote_redis.bash
@@ -2,10 +2,6 @@ REDIS_SERVER=$(command -v redis-server || command -v valkey-server)
 REDIS_CLI=$(command -v redis-cli || command -v valkey-cli)
 
 SUITE_remote_redis_PROBE() {
-    if ! $CCACHE --version | grep -Fq -- redis-storage &> /dev/null; then
-        echo "redis-storage not available"
-        return
-    fi
     if [ -z "${REDIS_SERVER}" ]; then
         echo "neither redis-server nor valkey-server found"
         return
@@ -35,6 +31,8 @@ start_redis_server() {
 
 SUITE_remote_redis_SETUP() {
     unset CCACHE_NODIRECT
+
+    export CRSH_LOGFILE="ccache-storage-redis.log"
 
     generate_code 1 test.c
 }

--- a/test/suites/remote_redis_unix.bash
+++ b/test/suites/remote_redis_unix.bash
@@ -1,20 +1,23 @@
+REDIS_SERVER=$(command -v redis-server || command -v valkey-server)
+REDIS_CLI=$(command -v redis-cli || command -v valkey-cli)
+
 SUITE_remote_redis_unix_PROBE() {
-    if ! command -v redis-server &> /dev/null; then
-        echo "redis-server not found"
+    if [ -z "${REDIS_SERVER}" ]; then
+        echo "neither redis-server nor valkey-server found"
         return
     fi
-    if redis-server --unixsocket /foo/redis.sock 2>&1 | grep -q "FATAL CONFIG FILE ERROR"; then
+    if ${REDIS_SERVER} --unixsocket /foo/redis.sock 2>&1 | grep -q "FATAL CONFIG FILE ERROR"; then
         # "Bad directive or wrong number of arguments"
         echo "redis-server without unixsocket"
         return
     fi
-    if ! command -v redis-cli &> /dev/null; then
-        echo "redis-cli not found"
+    if [ -z "${REDIS_CLI}" ]; then
+        echo "neither redis-cli nor valkey-cli found"
         return
     fi
-    if ! redis-cli -s /foo/redis.sock --version &> /dev/null; then
+    if ! ${REDIS_CLI} -s /foo/redis.sock --version &> /dev/null; then
         # "Unrecognized option or bad number of args"
-        echo "redis-cli without socket"
+        echo "${REDIS_CLI} without socket option"
         return
     fi
 }
@@ -23,16 +26,16 @@ start_redis_unix_server() {
     local socket="$1"
     local password="${2:-}"
 
-    redis-server --bind localhost --unixsocket "${socket}" --port 0 >/dev/null &
+    ${REDIS_SERVER} --bind localhost --unixsocket "${socket}" --port 0 >/dev/null &
     # Wait for server start.
     i=0
-    while [ $i -lt 100 ] && ! redis-cli -s "${socket}" ping &>/dev/null; do
+    while [ $i -lt 100 ] && ! ${REDIS_CLI} -s "${socket}" ping &>/dev/null; do
         sleep 0.1
         i=$((i + 1))
     done
 
     if [ -n "${password}" ]; then
-        redis-cli -s "${socket}" config set requirepass "${password}" &>/dev/null
+        ${REDIS_CLI} -s "${socket}" config set requirepass "${password}" &>/dev/null
     fi
 }
 
@@ -49,7 +52,7 @@ expect_number_of_redis_unix_cache_entries() {
     local socket=$2
     local actual
 
-    actual=$(redis-cli -s "$socket" keys "ccache:*" 2>/dev/null | wc -l)
+    actual=$(${REDIS_CLI} -s "$socket" keys "ccache:*" 2>/dev/null | wc -l)
     if [ "$actual" -ne "$expected" ]; then
         test_failed_internal "Found $actual (expected $expected) entries in $socket"
     fi

--- a/test/suites/remote_redis_unix.bash
+++ b/test/suites/remote_redis_unix.bash
@@ -1,8 +1,4 @@
 SUITE_remote_redis_unix_PROBE() {
-    if ! $CCACHE --version | grep -Fq -- redis-storage &> /dev/null; then
-        echo "redis-storage not available"
-        return
-    fi
     if ! command -v redis-server &> /dev/null; then
         echo "redis-server not found"
         return
@@ -42,6 +38,8 @@ start_redis_unix_server() {
 
 SUITE_remote_redis_unix_SETUP() {
     unset CCACHE_NODIRECT
+
+    export CRSH_LOGFILE="ccache-storage-redis_unix.log"
 
     generate_code 1 test.c
 }


### PR DESCRIPTION
Changed the tests, so that I can run without the builtin drivers.

```
HTTP_STORAGE_BACKEND:BOOL=OFF
REDIS_STORAGE_BACKEND:BOOL=OFF
```

This is for testing the external storage helpers, using "CRSH".

* https://github.com/ccache/ccache/issues/1214#issuecomment-3765408794

* #1727