### PR TITLE
ci: Enable linux-riscv musl-static builds using QEMU

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -355,7 +355,7 @@ jobs:
           retention-days: 3
 
   build_linux_musl_static_binary:
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.qemu && 60 || 30 }}
     name: Linux ${{ matrix.arch }} binary (musl static)
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -366,12 +366,42 @@ jobs:
             runner: ubuntu-22.04-arm
           - arch: x86_64
             runner: ubuntu-22.04
+          - arch: riscv64
+            runner: ubuntu-22.04
+            qemu: true
     steps:
       - name: Get source
         uses: actions/checkout@v4
-      - name: Build in Alpine container
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Trigger build
+        id: trigger
         run: |
-          docker run --rm -v "$PWD:/work" -w /work \
+          set -x
+          # If ref_type is a tag, always trigger
+          if ${{ github.ref_type == 'tag' || github.event.inputs.test_tag != '' }}; then
+            echo "trigger-build=true" >> $GITHUB_OUTPUT
+
+          # If ref_type is a branch, maybe trigger
+          elif ${{ github.ref_type == 'branch' }}; then
+            case "${{ github.ref_name }}" in
+              # If default branch, trigger
+              ${{ github.event.repository.default_branch }}) echo "trigger-build=true" >> $GITHUB_OUTPUT ;;
+              # If release branch, trigger
+              *-maint) echo "trigger-build=true" >> $GITHUB_OUTPUT ;;
+              # Unknown branch, no trigger
+              *) echo "trigger-build=false" >> $GITHUB_OUTPUT ;;
+            esac
+
+          # If ref_type is unknown, no trigger
+          else
+            echo "trigger-build=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Build in Alpine container
+        if: ${{ !matrix.qemu || steps.trigger.outputs.trigger-build }}
+        run: |
+          docker run --rm  -v "$PWD:/work" -w /work \
+            ${{ matrix.qemu && format('--platform linux/{0}', matrix.arch) || '' }} \
             -e GITHUB_REF \
             -e GITHUB_REF_NAME \
             -e GITHUB_SHA \

--- a/ci/generate-release-notes
+++ b/ci/generate-release-notes
@@ -41,12 +41,7 @@ for arch in "${linux_archs[@]}"; do
         add "Linux ${arch} binary release glibc ${ext}" "ccache-${version}-linux-${arch}-glibc.${ext}"
     done
     for ext in "${linux_bin_extensions[@]}"; do
-        if [ "${arch}" == "riscv64" ]; then
-            # Not available, lacking native Github-hosted runners
-            true
-        else
-            add "Linux ${arch} binary release musl static ${ext}" "ccache-${version}-linux-${arch}-musl-static.${ext}"
-        fi
+        add "Linux ${arch} binary release musl static ${ext}" "ccache-${version}-linux-${arch}-musl-static.${ext}"
     done
 done
 for arch in "${windows_archs[@]}"; do

--- a/ci/prepare-release
+++ b/ci/prepare-release
@@ -23,9 +23,20 @@ prepare_source_release() {
 }
 
 prepare_posix_binary_release() {
+    local allow_missing=0
+    if [[ "$1" == "--allow-missing" ]]; then
+        allow_missing=1
+        shift
+    fi
+
     local arch=$1
 
     shift
+
+    if [[ ! -f "${arch}-binary/ccache" && "${allow_missing}" -eq "1" ]]; then
+        echo "::warning file=ci/prepare-release::missing file '${arch}-binary/ccache', skipping"
+        exit 0
+    fi
 
     local name="ccache-${VERSION}-${arch}"
     mkdir "${name}"
@@ -77,6 +88,7 @@ prepare_posix_binary_release darwin gz
 prepare_posix_binary_release linux-aarch64-glibc gz xz
 prepare_posix_binary_release linux-aarch64-musl-static gz xz
 prepare_posix_binary_release linux-riscv64-glibc gz xz
+prepare_posix_binary_release --allow-missing linux-riscv64-musl-static gz xz
 prepare_posix_binary_release linux-x86_64-glibc gz xz
 prepare_posix_binary_release linux-x86_64-musl-static gz xz
 


### PR DESCRIPTION
This is a follow-up to https://github.com/ccache/ccache/pull/1718 where the musl-static binaries are built in QEMU on riscv64. cc @jrosdahl 