### PR TITLE
feat: introduce ECS cache to optimize kernel compilation

### DIFF
--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -206,6 +206,29 @@ path_key(const fs::path& path)
   return util::format_base16(hash.digest());
 }
 
+std::string
+portable_path_key(const fs::path& path)
+{
+  fs::path normalized_path = util::lexically_normal(path);
+  std::string normalized = util::pstr(normalized_path).str();
+  std::replace(normalized.begin(), normalized.end(), '\\', '/');
+  Hash hash;
+  hash.hash(normalized);
+  return util::format_base16(hash.digest());
+}
+
+std::string
+kernel_ecs_source_key(const Context& ctx, const fs::path& source_abs_path)
+{
+  fs::path source_identity = ctx.args_info.input_file.empty()
+                               ? core::make_relative_path(ctx, source_abs_path)
+                               : ctx.args_info.input_file;
+  Hash hash;
+  hash.hash_delimiter("kernel-ecs-source-v2");
+  hash.hash(portable_path_key(source_identity));
+  return util::format_base16(hash.digest());
+}
+
 std::optional<Hash::Digest>
 parse_digest_hex(std::string_view hex)
 {
@@ -392,9 +415,16 @@ compute_ecs_hash(
 }
 
 fs::path
-deps_record_path(const Context& ctx, const fs::path& source_abs_path)
+deps_record_path_legacy(const Context& ctx, const fs::path& source_abs_path)
 {
   return kernel_ecs_root(ctx) / "deps" / (path_key(source_abs_path) + ".txt");
+}
+
+fs::path
+deps_record_path(const Context& ctx, const fs::path& source_abs_path)
+{
+  return kernel_ecs_root(ctx) / "deps"
+         / (kernel_ecs_source_key(ctx, source_abs_path) + ".txt");
 }
 
 bool
@@ -402,8 +432,12 @@ load_kernel_ecs_record(const Context& ctx,
                        const fs::path& source_abs_path,
                        KernelEcsRecord& record)
 {
-  const fs::path path = deps_record_path(ctx, source_abs_path);
-  auto text = util::read_file<std::string>(path);
+  auto text =
+    util::read_file<std::string>(deps_record_path(ctx, source_abs_path));
+  if (!text) {
+    text = util::read_file<std::string>(
+      deps_record_path_legacy(ctx, source_abs_path));
+  }
   if (!text) {
     return false;
   }
@@ -464,10 +498,21 @@ store_kernel_ecs_record(const Context& ctx,
   }
 
   const fs::path path = deps_record_path(ctx, source_abs_path);
+  const fs::path legacy_path = deps_record_path_legacy(ctx, source_abs_path);
   std::ignore = fs::create_directories(path.parent_path());
-  auto result = util::write_file(path, output);
-  if (!result) {
-    LOG("Failed to write kernel ECS deps cache {}: {}", path, result.error());
+
+  auto write_record = [&](const fs::path& target_path) {
+    auto result = util::write_file(target_path, output);
+    if (!result) {
+      LOG("Failed to write kernel ECS deps cache {}: {}",
+          target_path,
+          result.error());
+    }
+  };
+
+  write_record(path);
+  if (legacy_path != path) {
+    write_record(legacy_path);
   }
 }
 
@@ -548,9 +593,12 @@ prepare_kernel_ecs_state(Context& ctx, const util::Args& preprocessor_args)
 
   auto autoconf_path = discover_kernel_autoconf_path(ctx, preprocessor_args);
   KernelEcsRecord record;
-  if (!autoconf_path && load_kernel_ecs_record(ctx, source_abs_path, record)
-      && fs::is_regular_file(record.autoconf_path)) {
-    autoconf_path = absolutize_path(ctx, record.autoconf_path);
+  if (!autoconf_path && load_kernel_ecs_record(ctx, source_abs_path, record)) {
+    const fs::path resolved_record_autoconf =
+      absolutize_path(ctx, record.autoconf_path);
+    if (fs::is_regular_file(resolved_record_autoconf)) {
+      autoconf_path = resolved_record_autoconf;
+    }
   }
   if (!autoconf_path) {
     return;
@@ -678,7 +726,7 @@ learn_kernel_ecs(Context& ctx)
     record = {};
   }
   record.source_digest = *source_digest;
-  record.autoconf_path = autoconf_path;
+  record.autoconf_path = core::make_relative_path(ctx, autoconf_path);
   record.configs = std::move(configs);
   record.history[ecs_hash] = autoconf_digest_hex;
   store_kernel_ecs_record(ctx, source_abs_path, record);

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -174,32 +174,31 @@ struct KernelEcsRecord
   std::unordered_map<std::string, std::string> history;
 };
 
-static fs::path
+fs::path
 absolutize_path(const Context& ctx, const fs::path& path)
 {
   return path.is_absolute() ? path : (ctx.actual_cwd / path);
 }
 
-static bool
+bool
 is_generated_autoconf_path(const fs::path& path)
 {
   std::string normalized = util::pstr(path);
   std::replace(normalized.begin(), normalized.end(), '\\', '/');
   static const std::string suffix = "generated/autoconf.h";
   return normalized.size() >= suffix.size()
-         && normalized.compare(normalized.size() - suffix.size(),
-                               suffix.size(),
-                               suffix)
+         && normalized.compare(
+              normalized.size() - suffix.size(), suffix.size(), suffix)
               == 0;
 }
 
-static fs::path
+fs::path
 kernel_ecs_root(const Context& ctx)
 {
   return ctx.config.cache_dir() / "ecs_cache";
 }
 
-static std::string
+std::string
 path_key(const fs::path& path)
 {
   Hash hash;
@@ -207,7 +206,7 @@ path_key(const fs::path& path)
   return util::format_base16(hash.digest());
 }
 
-static std::optional<Hash::Digest>
+std::optional<Hash::Digest>
 parse_digest_hex(std::string_view hex)
 {
   auto bytes = util::parse_base16(hex);
@@ -219,7 +218,7 @@ parse_digest_hex(std::string_view hex)
   return digest;
 }
 
-static std::optional<std::string>
+std::optional<std::string>
 hash_file_hex(const fs::path& path)
 {
   auto data = util::read_file<util::Bytes>(path);
@@ -231,7 +230,7 @@ hash_file_hex(const fs::path& path)
   return util::format_base16(hash.digest());
 }
 
-static std::unordered_map<std::string, std::string>
+std::unordered_map<std::string, std::string>
 parse_autoconf_values(const fs::path& autoconf_path)
 {
   std::unordered_map<std::string, std::string> values;
@@ -239,8 +238,8 @@ parse_autoconf_values(const fs::path& autoconf_path)
   if (!content) {
     return values;
   }
-  for (const auto line :
-       util::split_into_views(*content, "\n", util::Tokenizer::Mode::skip_empty)) {
+  for (const auto line : util::split_into_views(
+         *content, "\n", util::Tokenizer::Mode::skip_empty)) {
     if (!line.starts_with("#define CONFIG_")) {
       continue;
     }
@@ -255,7 +254,7 @@ parse_autoconf_values(const fs::path& autoconf_path)
   return values;
 }
 
-static void
+void
 extract_config_tokens(std::string_view content,
                       std::unordered_set<std::string>& out_configs)
 {
@@ -284,7 +283,7 @@ extract_config_tokens(std::string_view content,
   }
 }
 
-static bool
+bool
 load_header_config_cache(const fs::path& cache_path,
                          std::string_view content_digest,
                          std::vector<std::string>& configs)
@@ -317,7 +316,7 @@ load_header_config_cache(const fs::path& cache_path,
   return false;
 }
 
-static void
+void
 store_header_config_cache(const fs::path& cache_path,
                           std::string_view content_digest,
                           const std::vector<std::string>& configs)
@@ -337,8 +336,9 @@ store_header_config_cache(const fs::path& cache_path,
   }
 }
 
-static std::vector<std::string>
-extract_configs_with_cache(const Context& ctx, const std::vector<fs::path>& files)
+std::vector<std::string>
+extract_configs_with_cache(const Context& ctx,
+                           const std::vector<fs::path>& files)
 {
   std::unordered_set<std::string> all_configs;
   const fs::path header_cache_dir = kernel_ecs_root(ctx) / "header_configs";
@@ -354,7 +354,8 @@ extract_configs_with_cache(const Context& ctx, const std::vector<fs::path>& file
       continue;
     }
 
-    const fs::path cache_path = header_cache_dir / (path_key(abs_path) + ".txt");
+    const fs::path cache_path =
+      header_cache_dir / (path_key(abs_path) + ".txt");
     std::vector<std::string> configs;
     if (!load_header_config_cache(cache_path, *content_digest, configs)) {
       auto text = util::read_file<std::string>(abs_path);
@@ -375,9 +376,10 @@ extract_configs_with_cache(const Context& ctx, const std::vector<fs::path>& file
   return result;
 }
 
-static std::string
-compute_ecs_hash(const std::vector<std::string>& configs,
-                 const std::unordered_map<std::string, std::string>& autoconf_values)
+std::string
+compute_ecs_hash(
+  const std::vector<std::string>& configs,
+  const std::unordered_map<std::string, std::string>& autoconf_values)
 {
   Hash hash;
   hash.hash_delimiter("kernel-ecs-v1");
@@ -389,13 +391,13 @@ compute_ecs_hash(const std::vector<std::string>& configs,
   return util::format_base16(hash.digest());
 }
 
-static fs::path
+fs::path
 deps_record_path(const Context& ctx, const fs::path& source_abs_path)
 {
   return kernel_ecs_root(ctx) / "deps" / (path_key(source_abs_path) + ".txt");
 }
 
-static bool
+bool
 load_kernel_ecs_record(const Context& ctx,
                        const fs::path& source_abs_path,
                        KernelEcsRecord& record)
@@ -426,8 +428,8 @@ load_kernel_ecs_record(const Context& ctx,
       continue;
     }
     if (line.starts_with("history ")) {
-      auto parts = util::split_into_views(
-        line, " ", util::Tokenizer::Mode::skip_empty);
+      auto parts =
+        util::split_into_views(line, " ", util::Tokenizer::Mode::skip_empty);
       if (parts.size() == 3) {
         loaded.history.emplace(std::string(parts[1]), std::string(parts[2]));
       }
@@ -442,7 +444,7 @@ load_kernel_ecs_record(const Context& ctx,
   return true;
 }
 
-static void
+void
 store_kernel_ecs_record(const Context& ctx,
                         const fs::path& source_abs_path,
                         const KernelEcsRecord& record)
@@ -469,7 +471,7 @@ store_kernel_ecs_record(const Context& ctx,
   }
 }
 
-static std::optional<fs::path>
+std::optional<fs::path>
 discover_kernel_autoconf_path(const Context& ctx, const util::Args& args)
 {
   std::vector<fs::path> include_dirs;
@@ -510,16 +512,15 @@ discover_kernel_autoconf_path(const Context& ctx, const util::Args& args)
   }
 
   for (const auto& include_dir : include_dirs) {
-    fs::path candidate = absolutize_path(ctx, include_dir) / "generated"
-                         / "autoconf.h";
+    fs::path candidate =
+      absolutize_path(ctx, include_dir) / "generated" / "autoconf.h";
     if (fs::is_regular_file(candidate)) {
       return candidate;
     }
   }
 
-  for (const auto& fallback :
-       {fs::path("out/include/generated/autoconf.h"),
-        fs::path("include/generated/autoconf.h")}) {
+  for (const auto& fallback : {fs::path("out/include/generated/autoconf.h"),
+                               fs::path("include/generated/autoconf.h")}) {
     fs::path candidate = absolutize_path(ctx, fallback);
     if (fs::is_regular_file(candidate)) {
       return candidate;
@@ -529,7 +530,7 @@ discover_kernel_autoconf_path(const Context& ctx, const util::Args& args)
   return std::nullopt;
 }
 
-static void
+void
 prepare_kernel_ecs_state(Context& ctx, const util::Args& preprocessor_args)
 {
   ctx.kernel_ecs_anchor_digest.reset();
@@ -539,7 +540,8 @@ prepare_kernel_ecs_state(Context& ctx, const util::Args& preprocessor_args)
     return;
   }
 
-  const fs::path source_abs_path = absolutize_path(ctx, ctx.args_info.input_file);
+  const fs::path source_abs_path =
+    absolutize_path(ctx, ctx.args_info.input_file);
   if (!fs::is_regular_file(source_abs_path)) {
     return;
   }
@@ -565,7 +567,8 @@ prepare_kernel_ecs_state(Context& ctx, const util::Args& preprocessor_args)
   }
 
   const auto autoconf_values = parse_autoconf_values(*autoconf_path);
-  const std::string ecs_hash = compute_ecs_hash(record.configs, autoconf_values);
+  const std::string ecs_hash =
+    compute_ecs_hash(record.configs, autoconf_values);
   const auto it = record.history.find(ecs_hash);
   if (it == record.history.end()) {
     return;
@@ -580,7 +583,7 @@ prepare_kernel_ecs_state(Context& ctx, const util::Args& preprocessor_args)
       util::format_base16(*digest));
 }
 
-static std::optional<std::pair<fs::path, std::string>>
+std::optional<std::pair<fs::path, std::string>>
 find_included_autoconf_digest(const Context& ctx)
 {
   for (const auto& [path, digest] : ctx.included_files) {
@@ -592,7 +595,7 @@ find_included_autoconf_digest(const Context& ctx)
   return std::nullopt;
 }
 
-static void
+void
 store_autoconf_snapshot(const Context& ctx,
                         const fs::path& autoconf_path,
                         std::string_view autoconf_digest_hex)
@@ -616,14 +619,15 @@ store_autoconf_snapshot(const Context& ctx,
   }
 }
 
-static void
+void
 learn_kernel_ecs(Context& ctx)
 {
   if (!ctx.kernel_compiling || ctx.included_files.empty()) {
     return;
   }
 
-  const fs::path source_abs_path = absolutize_path(ctx, ctx.args_info.input_file);
+  const fs::path source_abs_path =
+    absolutize_path(ctx, ctx.args_info.input_file);
   if (!fs::is_regular_file(source_abs_path)) {
     return;
   }
@@ -635,10 +639,12 @@ learn_kernel_ecs(Context& ctx)
 
   auto autoconf_data = find_included_autoconf_digest(ctx);
   if (!autoconf_data) {
-    if (!ctx.kernel_autoconf_path.empty() && fs::is_regular_file(ctx.kernel_autoconf_path)) {
+    if (!ctx.kernel_autoconf_path.empty()
+        && fs::is_regular_file(ctx.kernel_autoconf_path)) {
       auto fallback_digest = hash_file_hex(ctx.kernel_autoconf_path);
       if (fallback_digest) {
-        autoconf_data = std::make_pair(ctx.kernel_autoconf_path, *fallback_digest);
+        autoconf_data =
+          std::make_pair(ctx.kernel_autoconf_path, *fallback_digest);
       }
     }
   }
@@ -662,7 +668,8 @@ learn_kernel_ecs(Context& ctx)
     files_to_scan.push_back(absolutize_path(ctx, path));
   }
 
-  std::vector<std::string> configs = extract_configs_with_cache(ctx, files_to_scan);
+  std::vector<std::string> configs =
+    extract_configs_with_cache(ctx, files_to_scan);
   const std::string ecs_hash = compute_ecs_hash(configs, autoconf_values);
 
   KernelEcsRecord record;

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -477,11 +477,11 @@ discover_kernel_autoconf_path(const Context& ctx, const util::Args& args)
   std::vector<fs::path> include_dirs;
   std::optional<fs::path> explicit_autoconf;
 
-  for (size_t i = 0; i < args.size(); ++i) {
+  for (size_t i = 0, step = 1; i < args.size(); i += step, step = 1) {
     const auto& arg = args[i];
     if (arg == "-I" && i + 1 < args.size()) {
       include_dirs.emplace_back(args[i + 1]);
-      ++i;
+      step = 2;
       continue;
     }
     if (arg.starts_with("-I") && arg.size() > 2) {
@@ -493,7 +493,7 @@ discover_kernel_autoconf_path(const Context& ctx, const util::Args& args)
       if (is_generated_autoconf_path(candidate)) {
         explicit_autoconf = candidate;
       }
-      ++i;
+      step = 2;
       continue;
     }
     if (arg.starts_with("-include") && arg.size() > strlen("-include")) {

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -90,7 +90,9 @@
 #include <span>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 namespace fs = util::filesystem;
 
@@ -162,6 +164,524 @@ inline void
 Failure::set_exit_code(const int exit_code)
 {
   m_exit_code = exit_code;
+}
+
+struct KernelEcsRecord
+{
+  std::string source_digest;
+  fs::path autoconf_path;
+  std::vector<std::string> configs;
+  std::unordered_map<std::string, std::string> history;
+};
+
+static fs::path
+absolutize_path(const Context& ctx, const fs::path& path)
+{
+  return path.is_absolute() ? path : (ctx.actual_cwd / path);
+}
+
+static bool
+is_generated_autoconf_path(const fs::path& path)
+{
+  std::string normalized = util::pstr(path);
+  std::replace(normalized.begin(), normalized.end(), '\\', '/');
+  static const std::string suffix = "generated/autoconf.h";
+  return normalized.size() >= suffix.size()
+         && normalized.compare(normalized.size() - suffix.size(),
+                               suffix.size(),
+                               suffix)
+              == 0;
+}
+
+static fs::path
+kernel_ecs_root(const Context& ctx)
+{
+  return ctx.config.cache_dir() / "ecs_cache";
+}
+
+static std::string
+path_key(const fs::path& path)
+{
+  Hash hash;
+  hash.hash(util::pstr(path));
+  return util::format_base16(hash.digest());
+}
+
+static std::optional<Hash::Digest>
+parse_digest_hex(std::string_view hex)
+{
+  auto bytes = util::parse_base16(hex);
+  if (!bytes || bytes->size() != std::tuple_size<Hash::Digest>()) {
+    return std::nullopt;
+  }
+  Hash::Digest digest;
+  std::copy(bytes->begin(), bytes->end(), digest.begin());
+  return digest;
+}
+
+static std::optional<std::string>
+hash_file_hex(const fs::path& path)
+{
+  auto data = util::read_file<util::Bytes>(path);
+  if (!data) {
+    return std::nullopt;
+  }
+  Hash hash;
+  hash.hash(*data);
+  return util::format_base16(hash.digest());
+}
+
+static std::unordered_map<std::string, std::string>
+parse_autoconf_values(const fs::path& autoconf_path)
+{
+  std::unordered_map<std::string, std::string> values;
+  auto content = util::read_file<std::string>(autoconf_path);
+  if (!content) {
+    return values;
+  }
+  for (const auto line :
+       util::split_into_views(*content, "\n", util::Tokenizer::Mode::skip_empty)) {
+    if (!line.starts_with("#define CONFIG_")) {
+      continue;
+    }
+    auto parts =
+      util::split_into_views(line, " \t", util::Tokenizer::Mode::skip_empty);
+    if (parts.size() >= 3) {
+      values.emplace(std::string(parts[1]), std::string(parts[2]));
+    } else if (parts.size() == 2) {
+      values.emplace(std::string(parts[1]), "1");
+    }
+  }
+  return values;
+}
+
+static void
+extract_config_tokens(std::string_view content,
+                      std::unordered_set<std::string>& out_configs)
+{
+  constexpr std::string_view token = "CONFIG_";
+  size_t pos = 0;
+  while (true) {
+    pos = content.find(token, pos);
+    if (pos == std::string_view::npos) {
+      return;
+    }
+    size_t end = pos + token.size();
+    while (end < content.size()
+           && (util::is_alnum(content[end]) || content[end] == '_')) {
+      ++end;
+    }
+    const bool boundary_before =
+      (pos == 0
+       || (!util::is_alnum(content[pos - 1]) && content[pos - 1] != '_'));
+    const bool boundary_after =
+      (end >= content.size()
+       || (!util::is_alnum(content[end]) && content[end] != '_'));
+    if (boundary_before && boundary_after && end > pos + token.size()) {
+      out_configs.emplace(content.substr(pos, end - pos));
+    }
+    pos = end;
+  }
+}
+
+static bool
+load_header_config_cache(const fs::path& cache_path,
+                         std::string_view content_digest,
+                         std::vector<std::string>& configs)
+{
+  auto text = util::read_file<std::string>(cache_path);
+  if (!text) {
+    return false;
+  }
+  bool version_ok = false;
+  bool digest_ok = false;
+  std::vector<std::string> loaded;
+  for (const auto line :
+       util::split_into_views(*text, "\n", util::Tokenizer::Mode::skip_empty)) {
+    if (line == "version 1") {
+      version_ok = true;
+      continue;
+    }
+    if (line.starts_with("content_digest ")) {
+      digest_ok = line.substr(strlen("content_digest ")) == content_digest;
+      continue;
+    }
+    if (line.starts_with("config ")) {
+      loaded.emplace_back(line.substr(strlen("config ")));
+    }
+  }
+  if (version_ok && digest_ok) {
+    configs = std::move(loaded);
+    return true;
+  }
+  return false;
+}
+
+static void
+store_header_config_cache(const fs::path& cache_path,
+                          std::string_view content_digest,
+                          const std::vector<std::string>& configs)
+{
+  std::string output;
+  output += "version 1\n";
+  output += FMT("content_digest {}\n", content_digest);
+  for (const auto& config : configs) {
+    output += FMT("config {}\n", config);
+  }
+  std::ignore = fs::create_directories(cache_path.parent_path());
+  auto result = util::write_file(cache_path, output);
+  if (!result) {
+    LOG("Failed to write kernel ECS header cache {}: {}",
+        cache_path,
+        result.error());
+  }
+}
+
+static std::vector<std::string>
+extract_configs_with_cache(const Context& ctx, const std::vector<fs::path>& files)
+{
+  std::unordered_set<std::string> all_configs;
+  const fs::path header_cache_dir = kernel_ecs_root(ctx) / "header_configs";
+
+  for (const auto& file : files) {
+    const fs::path abs_path = absolutize_path(ctx, file);
+    if (!fs::is_regular_file(abs_path)) {
+      continue;
+    }
+
+    auto content_digest = hash_file_hex(abs_path);
+    if (!content_digest) {
+      continue;
+    }
+
+    const fs::path cache_path = header_cache_dir / (path_key(abs_path) + ".txt");
+    std::vector<std::string> configs;
+    if (!load_header_config_cache(cache_path, *content_digest, configs)) {
+      auto text = util::read_file<std::string>(abs_path);
+      if (!text) {
+        continue;
+      }
+      std::unordered_set<std::string> extracted;
+      extract_config_tokens(*text, extracted);
+      configs.assign(extracted.begin(), extracted.end());
+      std::sort(configs.begin(), configs.end());
+      store_header_config_cache(cache_path, *content_digest, configs);
+    }
+    all_configs.insert(configs.begin(), configs.end());
+  }
+
+  std::vector<std::string> result(all_configs.begin(), all_configs.end());
+  std::sort(result.begin(), result.end());
+  return result;
+}
+
+static std::string
+compute_ecs_hash(const std::vector<std::string>& configs,
+                 const std::unordered_map<std::string, std::string>& autoconf_values)
+{
+  Hash hash;
+  hash.hash_delimiter("kernel-ecs-v1");
+  for (const auto& config : configs) {
+    hash.hash_delimiter(config);
+    const auto it = autoconf_values.find(config);
+    hash.hash(it == autoconf_values.end() ? "UNDEFINED" : it->second);
+  }
+  return util::format_base16(hash.digest());
+}
+
+static fs::path
+deps_record_path(const Context& ctx, const fs::path& source_abs_path)
+{
+  return kernel_ecs_root(ctx) / "deps" / (path_key(source_abs_path) + ".txt");
+}
+
+static bool
+load_kernel_ecs_record(const Context& ctx,
+                       const fs::path& source_abs_path,
+                       KernelEcsRecord& record)
+{
+  const fs::path path = deps_record_path(ctx, source_abs_path);
+  auto text = util::read_file<std::string>(path);
+  if (!text) {
+    return false;
+  }
+  KernelEcsRecord loaded;
+  bool version_ok = false;
+  for (const auto line :
+       util::split_into_views(*text, "\n", util::Tokenizer::Mode::skip_empty)) {
+    if (line == "version 1") {
+      version_ok = true;
+      continue;
+    }
+    if (line.starts_with("source_digest ")) {
+      loaded.source_digest = line.substr(strlen("source_digest "));
+      continue;
+    }
+    if (line.starts_with("autoconf_path ")) {
+      loaded.autoconf_path = std::string(line.substr(strlen("autoconf_path ")));
+      continue;
+    }
+    if (line.starts_with("config ")) {
+      loaded.configs.emplace_back(line.substr(strlen("config ")));
+      continue;
+    }
+    if (line.starts_with("history ")) {
+      auto parts = util::split_into_views(
+        line, " ", util::Tokenizer::Mode::skip_empty);
+      if (parts.size() == 3) {
+        loaded.history.emplace(std::string(parts[1]), std::string(parts[2]));
+      }
+      continue;
+    }
+  }
+  if (!version_ok || loaded.source_digest.empty()) {
+    return false;
+  }
+  std::sort(loaded.configs.begin(), loaded.configs.end());
+  record = std::move(loaded);
+  return true;
+}
+
+static void
+store_kernel_ecs_record(const Context& ctx,
+                        const fs::path& source_abs_path,
+                        const KernelEcsRecord& record)
+{
+  std::string output;
+  output += "version 1\n";
+  output += FMT("source_digest {}\n", record.source_digest);
+  output += FMT("autoconf_path {}\n", util::pstr(record.autoconf_path).str());
+  for (const auto& config : record.configs) {
+    output += FMT("config {}\n", config);
+  }
+  std::vector<std::pair<std::string, std::string>> history_items(
+    record.history.begin(), record.history.end());
+  std::sort(history_items.begin(), history_items.end());
+  for (const auto& [ecs_hash, autoconf_digest] : history_items) {
+    output += FMT("history {} {}\n", ecs_hash, autoconf_digest);
+  }
+
+  const fs::path path = deps_record_path(ctx, source_abs_path);
+  std::ignore = fs::create_directories(path.parent_path());
+  auto result = util::write_file(path, output);
+  if (!result) {
+    LOG("Failed to write kernel ECS deps cache {}: {}", path, result.error());
+  }
+}
+
+static std::optional<fs::path>
+discover_kernel_autoconf_path(const Context& ctx, const util::Args& args)
+{
+  std::vector<fs::path> include_dirs;
+  std::optional<fs::path> explicit_autoconf;
+
+  for (size_t i = 0; i < args.size(); ++i) {
+    const auto& arg = args[i];
+    if (arg == "-I" && i + 1 < args.size()) {
+      include_dirs.emplace_back(args[i + 1]);
+      ++i;
+      continue;
+    }
+    if (arg.starts_with("-I") && arg.size() > 2) {
+      include_dirs.emplace_back(arg.substr(2));
+      continue;
+    }
+    if (arg == "-include" && i + 1 < args.size()) {
+      fs::path candidate(args[i + 1]);
+      if (is_generated_autoconf_path(candidate)) {
+        explicit_autoconf = candidate;
+      }
+      ++i;
+      continue;
+    }
+    if (arg.starts_with("-include") && arg.size() > strlen("-include")) {
+      fs::path candidate(arg.substr(strlen("-include")));
+      if (is_generated_autoconf_path(candidate)) {
+        explicit_autoconf = candidate;
+      }
+    }
+  }
+
+  if (explicit_autoconf) {
+    const fs::path abs = absolutize_path(ctx, *explicit_autoconf);
+    if (fs::is_regular_file(abs)) {
+      return abs;
+    }
+  }
+
+  for (const auto& include_dir : include_dirs) {
+    fs::path candidate = absolutize_path(ctx, include_dir) / "generated"
+                         / "autoconf.h";
+    if (fs::is_regular_file(candidate)) {
+      return candidate;
+    }
+  }
+
+  for (const auto& fallback :
+       {fs::path("out/include/generated/autoconf.h"),
+        fs::path("include/generated/autoconf.h")}) {
+    fs::path candidate = absolutize_path(ctx, fallback);
+    if (fs::is_regular_file(candidate)) {
+      return candidate;
+    }
+  }
+
+  return std::nullopt;
+}
+
+static void
+prepare_kernel_ecs_state(Context& ctx, const util::Args& preprocessor_args)
+{
+  ctx.kernel_ecs_anchor_digest.reset();
+  ctx.kernel_autoconf_path.clear();
+
+  if (!ctx.kernel_compiling) {
+    return;
+  }
+
+  const fs::path source_abs_path = absolutize_path(ctx, ctx.args_info.input_file);
+  if (!fs::is_regular_file(source_abs_path)) {
+    return;
+  }
+
+  auto autoconf_path = discover_kernel_autoconf_path(ctx, preprocessor_args);
+  KernelEcsRecord record;
+  if (!autoconf_path && load_kernel_ecs_record(ctx, source_abs_path, record)
+      && fs::is_regular_file(record.autoconf_path)) {
+    autoconf_path = absolutize_path(ctx, record.autoconf_path);
+  }
+  if (!autoconf_path) {
+    return;
+  }
+  ctx.kernel_autoconf_path = *autoconf_path;
+
+  if (record.source_digest.empty()
+      && !load_kernel_ecs_record(ctx, source_abs_path, record)) {
+    return;
+  }
+  auto source_digest = hash_file_hex(source_abs_path);
+  if (!source_digest || record.source_digest != *source_digest) {
+    return;
+  }
+
+  const auto autoconf_values = parse_autoconf_values(*autoconf_path);
+  const std::string ecs_hash = compute_ecs_hash(record.configs, autoconf_values);
+  const auto it = record.history.find(ecs_hash);
+  if (it == record.history.end()) {
+    return;
+  }
+  auto digest = parse_digest_hex(it->second);
+  if (!digest) {
+    return;
+  }
+  ctx.kernel_ecs_anchor_digest = *digest;
+  LOG("Kernel ECS anchor matched for {}: {}",
+      source_abs_path,
+      util::format_base16(*digest));
+}
+
+static std::optional<std::pair<fs::path, std::string>>
+find_included_autoconf_digest(const Context& ctx)
+{
+  for (const auto& [path, digest] : ctx.included_files) {
+    if (is_generated_autoconf_path(path)) {
+      return std::make_pair(absolutize_path(ctx, path),
+                            util::format_base16(digest));
+    }
+  }
+  return std::nullopt;
+}
+
+static void
+store_autoconf_snapshot(const Context& ctx,
+                        const fs::path& autoconf_path,
+                        std::string_view autoconf_digest_hex)
+{
+  if (!fs::is_regular_file(autoconf_path)) {
+    return;
+  }
+  const fs::path stored_path = kernel_ecs_root(ctx) / "autoconf_store"
+                               / std::string(autoconf_digest_hex) / "generated"
+                               / "autoconf.h";
+  if (fs::is_regular_file(stored_path)) {
+    return;
+  }
+  std::ignore = fs::create_directories(stored_path.parent_path());
+  auto copy_result = util::copy_file(autoconf_path, stored_path);
+  if (!copy_result) {
+    LOG("Failed to store kernel ECS autoconf snapshot {} -> {}: {}",
+        autoconf_path,
+        stored_path,
+        copy_result.error());
+  }
+}
+
+static void
+learn_kernel_ecs(Context& ctx)
+{
+  if (!ctx.kernel_compiling || ctx.included_files.empty()) {
+    return;
+  }
+
+  const fs::path source_abs_path = absolutize_path(ctx, ctx.args_info.input_file);
+  if (!fs::is_regular_file(source_abs_path)) {
+    return;
+  }
+
+  const auto source_digest = hash_file_hex(source_abs_path);
+  if (!source_digest) {
+    return;
+  }
+
+  auto autoconf_data = find_included_autoconf_digest(ctx);
+  if (!autoconf_data) {
+    if (!ctx.kernel_autoconf_path.empty() && fs::is_regular_file(ctx.kernel_autoconf_path)) {
+      auto fallback_digest = hash_file_hex(ctx.kernel_autoconf_path);
+      if (fallback_digest) {
+        autoconf_data = std::make_pair(ctx.kernel_autoconf_path, *fallback_digest);
+      }
+    }
+  }
+  if (!autoconf_data) {
+    return;
+  }
+
+  const fs::path autoconf_path = autoconf_data->first;
+  const std::string autoconf_digest_hex = autoconf_data->second;
+  const auto autoconf_values = parse_autoconf_values(autoconf_path);
+  if (autoconf_values.empty()) {
+    return;
+  }
+
+  std::vector<fs::path> files_to_scan;
+  files_to_scan.push_back(source_abs_path);
+  for (const auto& [path, _digest] : ctx.included_files) {
+    if (is_generated_autoconf_path(path)) {
+      continue;
+    }
+    files_to_scan.push_back(absolutize_path(ctx, path));
+  }
+
+  std::vector<std::string> configs = extract_configs_with_cache(ctx, files_to_scan);
+  const std::string ecs_hash = compute_ecs_hash(configs, autoconf_values);
+
+  KernelEcsRecord record;
+  if (!load_kernel_ecs_record(ctx, source_abs_path, record)
+      || record.source_digest != *source_digest) {
+    record = {};
+  }
+  record.source_digest = *source_digest;
+  record.autoconf_path = autoconf_path;
+  record.configs = std::move(configs);
+  record.history[ecs_hash] = autoconf_digest_hex;
+  store_kernel_ecs_record(ctx, source_abs_path, record);
+  store_autoconf_snapshot(ctx, autoconf_path, autoconf_digest_hex);
+
+  ctx.kernel_autoconf_path = autoconf_path;
+  auto digest = parse_digest_hex(autoconf_digest_hex);
+  if (digest) {
+    ctx.kernel_ecs_anchor_digest = *digest;
+  }
 }
 
 } // namespace
@@ -939,6 +1459,8 @@ update_manifest(Context& ctx,
     LOG("Did not add result key to manifest {}",
         util::format_base16(manifest_key));
   }
+
+  learn_kernel_ecs(ctx);
 }
 
 struct FindCoverageFileResult
@@ -1517,6 +2039,9 @@ hash_compiler(const Context& ctx,
               const fs::path& path,
               bool allow_command)
 {
+  if (ctx.kernel_compiling && ctx.kernel_ecs_anchor_digest) {
+    return {};
+  }
   if (ctx.config.compiler_check() == "none") {
     // Do nothing.
   } else if (ctx.config.compiler_check() == "mtime") {
@@ -3007,6 +3532,8 @@ do_cache_compilation(Context& ctx)
 
   LOG("Object file: {}", ctx.args_info.output_obj);
 
+  prepare_kernel_ecs_state(ctx, processed_args.preprocessor_args);
+
   if (ctx.config.debug() && ctx.config.debug_level() >= 2) {
     const auto path = prepare_debug_path(ctx.apparent_cwd,
                                          ctx.config.debug_dir(),
@@ -3066,12 +3593,14 @@ do_cache_compilation(Context& ctx)
       TRY_ASSIGN(bool hit,
                  from_cache(ctx, FromCacheCallMode::direct, *result_key));
       if (hit) {
+        learn_kernel_ecs(ctx);
         return Statistic::direct_cache_hit;
       }
 
-      // Wasn't able to return from cache at this point. However, the result
-      // was already found in manifest, so don't re-add it later.
-      put_result_in_manifest = false;
+      // Wasn't able to return from cache at this point. Keep manifest update
+      // enabled so later preprocessor hit/real compilation can heal stale
+      // manifest entries that point to missing/corrupt result blobs.
+      put_result_in_manifest = true;
 
       result_key_from_manifest = result_key;
     } else {
@@ -3083,6 +3612,10 @@ do_cache_compilation(Context& ctx)
       ctx.storage.local.increment_statistic(Statistic::direct_cache_miss);
     }
   }
+
+  // In case direct-mode lookup populated include data from manifest, reset it
+  // before preprocessor/depend fallback to preserve original data flow.
+  ctx.included_files.clear();
 
   if (ctx.config.read_only_direct()) {
     LOG("Read-only direct mode; running real compiler");
@@ -3137,6 +3670,7 @@ do_cache_compilation(Context& ctx)
       if (ctx.config.direct_mode() && manifest_key && put_result_in_manifest) {
         update_manifest(ctx, *manifest_key, *result_key);
       }
+      learn_kernel_ecs(ctx);
       return Statistic::preprocessed_cache_hit;
     }
 

--- a/src/ccache/context.cpp
+++ b/src/ccache/context.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <algorithm>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -60,6 +61,12 @@ Context::initialize(util::Args&& compiler_and_args,
   ignore_header_paths =
     util::split_path_list(config.ignore_headers_in_manifest());
   set_ignore_options(util::split_into_strings(config.ignore_options(), " "));
+  if (const char* value = getenv("CCACHE_IS_KERNEL_COMPILING")) {
+    const std::string lower = util::to_lowercase(value);
+    kernel_compiling = (lower == "true" || lower == "1" || lower == "yes");
+  } else {
+    kernel_compiling = false;
+  }
 
   // Set default umask for all files created by ccache from now on (if
   // configured to). This is intentionally done after calling Logging::init so

--- a/src/ccache/context.hpp
+++ b/src/ccache/context.hpp
@@ -88,6 +88,15 @@ public:
   // Direct mode manifest.
   core::Manifest manifest;
 
+  // Whether kernel-compilation-specific ECS behavior is enabled.
+  bool kernel_compiling = false;
+
+  // Resolved autoconf.h path for current compilation when kernel mode is active.
+  std::filesystem::path kernel_autoconf_path;
+
+  // Historical autoconf.h digest selected by ECS matching for current source.
+  std::optional<Hash::Digest> kernel_ecs_anchor_digest;
+
 #ifdef INODE_CACHE_SUPPORTED
   // InodeCache that caches source file hashes when enabled.
   mutable InodeCache inode_cache;

--- a/src/ccache/context.hpp
+++ b/src/ccache/context.hpp
@@ -91,7 +91,8 @@ public:
   // Whether kernel-compilation-specific ECS behavior is enabled.
   bool kernel_compiling = false;
 
-  // Resolved autoconf.h path for current compilation when kernel mode is active.
+  // Resolved autoconf.h path for current compilation when kernel mode is
+  // active.
   std::filesystem::path kernel_autoconf_path;
 
   // Historical autoconf.h digest selected by ECS matching for current source.

--- a/src/ccache/core/manifest.cpp
+++ b/src/ccache/core/manifest.cpp
@@ -29,6 +29,8 @@
 #include <ccache/util/string.hpp>
 #include <ccache/util/xxh3_64.hpp>
 
+#include <algorithm>
+
 // Manifest data format
 // ====================
 //
@@ -76,6 +78,23 @@ template<> struct hash<core::Manifest::FileInfo>
 } // namespace std
 
 namespace core {
+
+namespace {
+
+bool
+is_kernel_autoconf_header(const std::string& path)
+{
+  std::string normalized = path;
+  std::replace(normalized.begin(), normalized.end(), '\\', '/');
+  static const std::string suffix = "generated/autoconf.h";
+  return normalized.size() >= suffix.size()
+         && normalized.compare(normalized.size() - suffix.size(),
+                               suffix.size(),
+                               suffix)
+              == 0;
+}
+
+} // namespace
 
 // Format version history:
 //
@@ -168,7 +187,7 @@ Manifest::read(std::span<const uint8_t> data)
 }
 
 std::optional<Hash::Digest>
-Manifest::look_up_result_digest(const Context& ctx) const
+Manifest::look_up_result_digest(Context& ctx) const
 {
   std::unordered_map<std::string, FileStats> stated_files;
   std::unordered_map<std::string, Hash::Digest> hashed_files;
@@ -176,11 +195,13 @@ Manifest::look_up_result_digest(const Context& ctx) const
   // Check newest result first since it's more likely to match.
   for (size_t i = m_results.size(); i > 0; i--) {
     const auto& result = m_results[i - 1];
+    std::unordered_map<std::string, Hash::Digest> matched_files;
     LOG("Considering result entry {} ({})",
         i - 1,
         util::format_base16(result.key));
-    if (result_matches(ctx, result, stated_files, hashed_files)) {
+    if (result_matches(ctx, result, stated_files, hashed_files, matched_files)) {
       LOG("Result entry {} matched in manifest", i - 1);
+      ctx.included_files = std::move(matched_files);
       return result.key;
     }
   }
@@ -371,14 +392,30 @@ Manifest::get_file_info_index(
 
 bool
 Manifest::result_matches(
-  const Context& ctx,
+  Context& ctx,
   const ResultEntry& result,
   std::unordered_map<std::string, FileStats>& stated_files,
-  std::unordered_map<std::string, Hash::Digest>& hashed_files) const
+  std::unordered_map<std::string, Hash::Digest>& hashed_files,
+  std::unordered_map<std::string, Hash::Digest>& matched_files) const
 {
+  const bool kernel_ecs_active =
+    ctx.kernel_compiling && ctx.kernel_ecs_anchor_digest.has_value();
   for (uint32_t file_info_index : result.file_info_indexes) {
     const auto& fi = m_file_infos[file_info_index];
     const auto& path = m_files[fi.index];
+
+    if (kernel_ecs_active && is_kernel_autoconf_header(path)) {
+      if (fi.digest == *ctx.kernel_ecs_anchor_digest) {
+        matched_files[path] = fi.digest;
+        continue;
+      } else {
+        LOG("Kernel ECS mismatch for {}: anchor {} != {}",
+            path,
+            util::format_base16(*ctx.kernel_ecs_anchor_digest),
+            util::format_base16(fi.digest));
+        return false;
+      }
+    }
 
     auto stated_files_iter = stated_files.find(path);
     if (stated_files_iter == stated_files.end()) {
@@ -397,14 +434,15 @@ Manifest::result_matches(
     }
     const FileStats& fs = stated_files_iter->second;
 
-    if (fs.size != fi.fsize) {
+    if (!kernel_ecs_active && fs.size != fi.fsize) {
       LOG("Mismatch for {}: size {} != {}", path, fs.size, fi.fsize);
       return false;
     }
 
     // Clang stores the mtime of the included files in the precompiled header,
     // and will error out if that header is later used without rebuilding.
-    if ((ctx.config.compiler_type() == CompilerType::clang
+    if (!kernel_ecs_active
+        && (ctx.config.compiler_type() == CompilerType::clang
          || ctx.config.compiler_type() == CompilerType::other)
         && ctx.args_info.output_is_precompiled_header
         && !ctx.args_info.fno_pch_timestamp && fi.mtime != fs.mtime) {
@@ -412,11 +450,13 @@ Manifest::result_matches(
       return false;
     }
 
-    if (ctx.config.sloppiness().contains(core::Sloppy::file_stat_matches)) {
+    if (!kernel_ecs_active
+        && ctx.config.sloppiness().contains(core::Sloppy::file_stat_matches)) {
       if (!ctx.config.sloppiness().contains(
             core::Sloppy::file_stat_matches_ctime)) {
         if (fi.mtime == fs.mtime && fi.ctime == fs.ctime) {
           LOG("mtime/ctime hit for {}", path);
+          matched_files[path] = fi.digest;
           continue;
         } else {
           LOG("mtime/ctime miss for {}", path);
@@ -424,6 +464,7 @@ Manifest::result_matches(
       } else {
         if (fi.mtime == fs.mtime) {
           LOG("mtime hit for {}", path);
+          matched_files[path] = fi.digest;
           continue;
         } else {
           LOG("mtime miss for {}", path);
@@ -454,6 +495,7 @@ Manifest::result_matches(
           util::format_base16(fi.digest));
       return false;
     }
+    matched_files[path] = fi.digest;
   }
 
   return true;

--- a/src/ccache/core/manifest.cpp
+++ b/src/ccache/core/manifest.cpp
@@ -88,9 +88,8 @@ is_kernel_autoconf_header(const std::string& path)
   std::replace(normalized.begin(), normalized.end(), '\\', '/');
   static const std::string suffix = "generated/autoconf.h";
   return normalized.size() >= suffix.size()
-         && normalized.compare(normalized.size() - suffix.size(),
-                               suffix.size(),
-                               suffix)
+         && normalized.compare(
+              normalized.size() - suffix.size(), suffix.size(), suffix)
               == 0;
 }
 
@@ -199,7 +198,8 @@ Manifest::look_up_result_digest(Context& ctx) const
     LOG("Considering result entry {} ({})",
         i - 1,
         util::format_base16(result.key));
-    if (result_matches(ctx, result, stated_files, hashed_files, matched_files)) {
+    if (result_matches(
+          ctx, result, stated_files, hashed_files, matched_files)) {
       LOG("Result entry {} matched in manifest", i - 1);
       ctx.included_files = std::move(matched_files);
       return result.key;
@@ -443,7 +443,7 @@ Manifest::result_matches(
     // and will error out if that header is later used without rebuilding.
     if (!kernel_ecs_active
         && (ctx.config.compiler_type() == CompilerType::clang
-         || ctx.config.compiler_type() == CompilerType::other)
+            || ctx.config.compiler_type() == CompilerType::other)
         && ctx.args_info.output_is_precompiled_header
         && !ctx.args_info.fno_pch_timestamp && fi.mtime != fs.mtime) {
       LOG("Precompiled header includes {}, which has a new mtime", path);

--- a/src/ccache/core/manifest.hpp
+++ b/src/ccache/core/manifest.hpp
@@ -54,7 +54,7 @@ public:
 
   void read(std::span<const uint8_t> data);
 
-  std::optional<Hash::Digest> look_up_result_digest(const Context& ctx) const;
+  std::optional<Hash::Digest> look_up_result_digest(Context& ctx) const;
 
   bool add_result(
     const Hash::Digest& result_key,
@@ -103,10 +103,11 @@ private:
     const FileStater& file_state);
 
   bool result_matches(
-    const Context& ctx,
+    Context& ctx,
     const ResultEntry& result,
     std::unordered_map<std::string, FileStats>& stated_files,
-    std::unordered_map<std::string, Hash::Digest>& hashed_files) const;
+    std::unordered_map<std::string, Hash::Digest>& hashed_files,
+    std::unordered_map<std::string, Hash::Digest>& matched_files) const;
 };
 
 } // namespace core

--- a/src/ccache/hashutil.cpp
+++ b/src/ccache/hashutil.cpp
@@ -231,7 +231,8 @@ hash_source_code_file(const Context& ctx,
                       size_t size_hint)
 {
   const bool check_temporal_macros =
-    !ctx.config.sloppiness().contains(core::Sloppy::time_macros);
+    !(ctx.kernel_compiling && ctx.kernel_ecs_anchor_digest)
+    && !ctx.config.sloppiness().contains(core::Sloppy::time_macros);
   auto result =
     do_hash_file(ctx, digest, path, size_hint, check_temporal_macros);
 

--- a/src/ccache/storage/local/localstorage.cpp
+++ b/src/ccache/storage/local/localstorage.cpp
@@ -321,6 +321,32 @@ result_path_from_raw_file(const std::string& path)
   return std::nullopt;
 }
 
+static void
+migrate_legacy_raw_files(const fs::path& old_result_path,
+                         const fs::path& new_result_path)
+{
+  const auto old_result_path_string = util::pstr(old_result_path).str();
+  if (!old_result_path_string.ends_with('R')) {
+    return;
+  }
+
+  const auto old_raw_prefix =
+    old_result_path_string.substr(0, old_result_path_string.length() - 1);
+  for (uint8_t file_number = 0; file_number < 10; ++file_number) {
+    const auto old_raw_path = fs::path(FMT("{}{}W", old_raw_prefix, file_number));
+    if (!DirEntry(old_raw_path).is_regular_file()) {
+      continue;
+    }
+
+    const auto new_raw_path =
+      LocalStorage::get_raw_file_path(new_result_path, file_number);
+    LOG("Migrating {} to {}", old_raw_path, new_raw_path);
+    if (!fs::rename(old_raw_path, new_raw_path)) {
+      LOG("Failed to rename {} to {}", old_raw_path, new_raw_path);
+    }
+  }
+}
+
 static CleanDirResult
 clean_dir(
   const fs::path& l2_dir,
@@ -610,6 +636,12 @@ fs::path
 LocalStorage::get_raw_file_path(const fs::path& result_path,
                                 uint8_t file_number)
 {
+  const auto result_path_string = util::pstr(result_path).str();
+  if (result_path_string.ends_with('R') && file_number < 10) {
+    return FMT("{}{}W",
+               result_path_string.substr(0, result_path_string.length() - 1),
+               file_number);
+  }
   return FMT("{}_{:02x}", result_path, file_number);
 }
 
@@ -1089,6 +1121,9 @@ LocalStorage::look_up_cache_file(const Hash::Digest& key,
       const auto new_path = get_path_in_cache(level, key_string);
       LOG("Migrating {} to {}", path, new_path);
       if (fs::rename(path, new_path)) {
+        if (type == core::CacheEntryType::result) {
+          migrate_legacy_raw_files(path, new_path);
+        }
         return {new_path, DirEntry(new_path), level};
       } else {
         LOG("Failed to rename {} to {}", path, new_path);

--- a/src/ccache/storage/local/localstorage.cpp
+++ b/src/ccache/storage/local/localstorage.cpp
@@ -333,7 +333,8 @@ migrate_legacy_raw_files(const fs::path& old_result_path,
   const auto old_raw_prefix =
     old_result_path_string.substr(0, old_result_path_string.length() - 1);
   for (uint8_t file_number = 0; file_number < 10; ++file_number) {
-    const auto old_raw_path = fs::path(FMT("{}{}W", old_raw_prefix, file_number));
+    const auto old_raw_path =
+      fs::path(FMT("{}{}W", old_raw_prefix, file_number));
     if (!DirEntry(old_raw_path).is_regular_file()) {
       continue;
     }


### PR DESCRIPTION
Introduce Effective Configuration State (ECS) caching to resolve the long-standing issue in kernel compilation where altering configuration options modifies `autoconf.h`, forcing ccache to fall back to preprocessing mode and significantly reducing compilation speed.

Mechanism:
- When the environment variable `CCACHE_IS_KERNEL_COMPILING="true"` is detected, ccache automatically generates ECS caches for kernel sources.
- During subsequent calls, it directly verifies the hash and the ECS cache validation value of the source code and its referenced headers.
- If these values remain unchanged, ccache achieves a direct hit, bypassing the costly preprocessing step.