### PR TITLE
Expose base16 source digest in debug input text

### DIFF
--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -2366,6 +2366,14 @@ get_manifest_key(Context& ctx, Hash& hash)
     return {};
   }
   hash.hash(util::format_legacy_digest(input_file_digest));
+  if (ctx.config.debug() && ctx.config.debug_level() >= 2
+      && !ctx.hash_debug_files.empty()) {
+    // Keep the hashed direct-mode input unchanged, but expose the raw digest
+    // in debug output so it can be compared with `ccache --hash-file`.
+    PRINT(ctx.hash_debug_files.front().get(),
+          "### sourcecode hash (base16)\n{}\n",
+          util::format_base16(input_file_digest));
+  }
   return hash.digest();
 }
 

--- a/test/suites/base.bash
+++ b/test/suites/base.bash
@@ -412,6 +412,10 @@ EOF
     if ! grep -q "PREPROCESSOR MODE" test1.o.*.ccache-input-text; then
         test_failed "Unexpected data in <obj>.<timestamp>.ccache-input-text"
     fi
+    local source_digest
+    source_digest=$($CCACHE --hash-file test1.c)
+    expect_contains test1.o.*.ccache-input-text "### sourcecode hash (base16)"
+    expect_contains test1.o.*.ccache-input-text "$source_digest"
     for ext in c p d; do
         if ! [ -f test1.o.*.ccache-input-$ext ]; then
             test_failed "<obj>.ccache-input-$ext missing"


### PR DESCRIPTION
This adds the raw base16 source digest to `ccache-input-text` without changing the legacy digest bytes used for the direct-mode hash.

That makes the debug artifact directly comparable with `ccache --hash-file`.

- https://github.com/Homebrew/homebrew-core/pull/278330
- https://github.com/Homebrew/homebrew-core/pull/271486