### PR TITLE
feat: Enable reflinking .dwo files

### DIFF
--- a/src/ccache/core/result.cpp
+++ b/src/ccache/core/result.cpp
@@ -87,8 +87,8 @@ should_store_raw_file(const Config& config, core::result::FileType type)
     return false;
   }
 
-  // Only store object files as raw files since there are several problems with
-  // storing other file types:
+  // Only store object and .dwo files as raw files since there are several
+  // problems with storing other file types:
   //
   // 1. The compiler unlinks object files before writing to them but it doesn't
   //    unlink .d files, so it's possible to corrupt .d files just by running
@@ -103,7 +103,9 @@ should_store_raw_file(const Config& config, core::result::FileType type)
   // files that become large enough that it's of interest to clone or hard link
   // them, so we keep things simple for now. This will also save i-nodes in the
   // cache.
-  return type == core::result::FileType::object;
+  return type == core::result::FileType::object
+
+         || type == core::result::FileType::dwarf_object;
 }
 
 } // namespace

--- a/test/suites/fileclone.bash
+++ b/test/suites/fileclone.bash
@@ -54,4 +54,42 @@ SUITE_fileclone() {
     if grep -q 'Cloning' test.o.*.ccache-log; then
         test_failed "Tried to clone"
     fi
+
+    # -------------------------------------------------------------------------
+    TEST "Split DWARF .dwo file is cloned"
+
+    # Skip if -gsplit-dwarf not supported.
+    touch test.c
+    if ! $COMPILER -c -gsplit-dwarf test.c 2>/dev/null || [ ! -e test.dwo ]; then
+        return
+    fi
+
+    generate_code 1 test.c
+
+    $COMPILER -c -gsplit-dwarf -o reference_test.o test.c
+
+    CCACHE_FILECLONE=1 $CCACHE_COMPILE -c -gsplit-dwarf test.c
+    expect_stat preprocessed_cache_hit 0
+    expect_stat cache_miss 1
+    expect_stat files_in_cache 3
+    expect_equal_object_files reference_test.o test.o
+
+    # Note: CCACHE_DEBUG=1 below is needed for the test case.
+    CCACHE_FILECLONE=1 CCACHE_DEBUG=1 $CCACHE_COMPILE -c -gsplit-dwarf test.c
+    expect_stat preprocessed_cache_hit 1
+    expect_stat cache_miss 1
+    expect_stat files_in_cache 3
+    expect_equal_object_files reference_test.o test.o
+    if ! grep -q 'Cloning.*to test.o' test.o.*.ccache-log; then
+        test_failed "Did not try to clone .o file"
+    fi
+    if ! grep -q 'Cloning.*to test.dwo' test.o.*.ccache-log; then
+        test_failed "Did not try to clone .dwo file"
+    fi
+    if grep -q 'Failed to clone' test.o.*.ccache-log; then
+        test_failed "Failed to clone"
+    fi
+    if grep -q 'Failed to clone' test.dwo.*.ccache-log; then
+        test_failed "Failed to clone"
+    fi
 }


### PR DESCRIPTION
.dwo files should be reflinked like regular .o files. E.g. on my RelWithDebInfo LLVM build with split dwarf, object files take 2.2GB, whereas .dwo files take up 2.6GB. These files should be trivially shareable across build directories.