### PR TITLE
Support Ascend C language

### DIFF
--- a/src/ccache/language.cpp
+++ b/src/ccache/language.cpp
@@ -71,6 +71,7 @@ const struct
   {".TCC",  "c++-header"              },
   {".cu",   "cu"                      }, // Special case in language_for_file: "cuda" for Clang
   {".hip",  "hip"                     },
+  {".asc",  "asc"                     },
   {nullptr, nullptr                   },
 };
 
@@ -89,6 +90,7 @@ const struct
   {"cu",                       "cpp-output"              }, // NVCC
   {"cuda",                     "cpp-output"              }, // Clang
   {"hip",                      "cpp-output"              },
+  {"asc",                      "cpp-output"              },
   {"objective-c",              "objective-c-cpp-output"  },
   {"objective-c-header",       "objective-c-cpp-output"  },
   {"objc-cpp-output",          "objective-c-cpp-output"  },


### PR DESCRIPTION
This PR adds support for compilation caching of Ascend C. Ascend C is a dedicated programming language tailor-made by Huawei for the Ascend computing platform.
<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
