### PR TITLE
feat: Rewrite -fprofile-use= path family relative to base_dir

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -1010,7 +1010,17 @@ process_option_arg(const Context& ctx,
       // The failure is logged by process_profiling_option.
       return Statistic::unsupported_compiler_option;
     }
-    state.add_common_arg(args[i]);
+    if (arg.starts_with("-fprofile-use=")
+        || arg.starts_with("-fprofile-instr-use=")
+        || arg.starts_with("-fprofile-sample-use=")
+        || arg.starts_with("-fauto-profile=")) {
+      const auto [option, path] = util::split_once(args[i], '=');
+      DEBUG_ASSERT(path);
+      const auto relpath = core::make_relative_path(ctx, *path);
+      state.add_common_arg(FMT("{}={}", option, relpath));
+    } else {
+      state.add_common_arg(args[i]);
+    }
     return Statistic::none;
   }
 

--- a/test/suites/profiling_clang.bash
+++ b/test/suites/profiling_clang.bash
@@ -101,6 +101,68 @@ SUITE_profiling_clang() {
     expect_stat cache_miss 3
 
     # -------------------------------------------------------------------------
+    TEST "-fprofile-instr-use=file with absolute path and base_dir"
+
+    $CCACHE_COMPILE -fprofile-instr-generate=foo.profraw -c test.c
+    $COMPILER -fprofile-instr-generate=foo.profraw test.o -o test
+    ./test
+    llvm-profdata$CLANG_VERSION_SUFFIX merge -output foo.profdata foo.profraw
+
+    mkdir -p ws1/build ws2/build
+    echo 'int main(void) { return 0; }' >ws1/test.c
+    echo 'int main(void) { return 0; }' >ws2/test.c
+    cp foo.profdata ws1/foo.profdata
+    cp foo.profdata ws2/foo.profdata
+
+    ws1_abs="$(cd ws1 && pwd)"
+    ws2_abs="$(cd ws2 && pwd)"
+
+    cd ws1/build
+    CCACHE_BASEDIR="$ws1_abs" $CCACHE_COMPILE \
+        -fprofile-instr-use="$ws1_abs/foo.profdata" -c ../test.c
+    expect_stat direct_cache_hit 0
+    expect_stat cache_miss 2
+
+    cd ../../ws2/build
+    CCACHE_BASEDIR="$ws2_abs" $CCACHE_COMPILE \
+        -fprofile-instr-use="$ws2_abs/foo.profdata" -c ../test.c
+    expect_stat direct_cache_hit 1
+    expect_stat cache_miss 2
+
+    cd ../../ws1/build
+    CCACHE_BASEDIR="$ws1_abs" $CCACHE_COMPILE \
+        -fprofile-use="$ws1_abs/foo.profdata" -c ../test.c
+    expect_stat direct_cache_hit 1
+    expect_stat cache_miss 3
+
+    cd ../../ws2/build
+    CCACHE_BASEDIR="$ws2_abs" $CCACHE_COMPILE \
+        -fprofile-use="$ws2_abs/foo.profdata" -c ../test.c
+    expect_stat direct_cache_hit 2
+    expect_stat cache_miss 3
+
+    cd ../../ws1/build
+    CCACHE_BASEDIR="$ws1_abs" $CCACHE_COMPILE \
+        -fprofile-sample-use="$ws1_abs/foo.profdata" -c ../test.c
+    expect_stat direct_cache_hit 2
+    expect_stat cache_miss 4
+
+    cd ../../ws2/build
+    CCACHE_BASEDIR="$ws2_abs" $CCACHE_COMPILE \
+        -fprofile-sample-use="$ws2_abs/foo.profdata" -c ../test.c
+    expect_stat direct_cache_hit 3
+    expect_stat cache_miss 4
+
+    echo >>"$ws2_abs/foo.profdata"
+
+    CCACHE_BASEDIR="$ws2_abs" $CCACHE_COMPILE \
+        -fprofile-instr-use="$ws2_abs/foo.profdata" -c ../test.c
+    expect_stat direct_cache_hit 3
+    expect_stat cache_miss 5
+
+    cd ../..
+
+    # -------------------------------------------------------------------------
     TEST "-fprofile-sample-use"
 
     echo 'main:1:1' > sample.prof


### PR DESCRIPTION
Without this, the absolute path of the profile data file leaks into the
hash, so two workspaces sharing a cache (CI, parallel checkouts) miss
each other on otherwise identical compilations. Content changes still
produce a miss because hash_profile_data_file() hashes the file content.

this change rewrites only the args path while the per-file content hash 
continues to disambiguate, so workspaces with different profile content 
remain distinct.

Tested in profiling_clang.bash: a base_dir cross-workspace case
exercising -fprofile-instr-use=, -fprofile-use=, -fprofile-sample-use=
in both directions (path-only difference hits, content difference misses).

