### PR TITLE
ci: update "uses:" to latest versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -144,7 +144,7 @@ jobs:
           fi
 
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build and test
         run: ci/build
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload testdir from failed tests
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.version }}-testdir.tar.xz
           path: testdir.tar.xz
@@ -217,7 +217,7 @@ jobs:
           echo "CMAKE_PARAMS=${cmake_params[*]}" >> $GITHUB_ENV
 
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build and test
         run: ci/build
@@ -233,7 +233,7 @@ jobs:
 
       - name: Upload testdir from failed tests
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.sys }}-${{ matrix.compiler }}-testdir.tar.xz
           path: testdir.tar.xz
@@ -246,14 +246,14 @@ jobs:
       CMAKE_GENERATOR: Ninja
     steps:
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Prepare environment
         run: |
           sudo apt-get install -y asciidoctor pandoc
       - name: Build documentation
         run: ci/build-docs
       - name: Upload documentation
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs
           path: |
@@ -274,7 +274,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y g++-aarch64-linux-gnu libc6-dev-arm64-cross
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build binary
         env:
           CMAKE_GENERATOR: Ninja
@@ -283,7 +283,7 @@ jobs:
             -D CMAKE_EXE_LINKER_FLAGS_INIT=-static-libstdc++
         run: ci/build-binary
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-aarch64-glibc-binary
           path: install/ccache
@@ -301,7 +301,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y g++-riscv64-linux-gnu libc6-dev-arm64-cross
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build binary
         env:
           CMAKE_GENERATOR: Ninja
@@ -310,7 +310,7 @@ jobs:
             -D CMAKE_EXE_LINKER_FLAGS_INIT=-static-libstdc++
         run: ci/build-binary
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-riscv64-glibc-binary
           path: install/ccache
@@ -340,7 +340,7 @@ jobs:
             git \
             ninja-build
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build binary
         env:
           CMAKE_GENERATOR: Ninja
@@ -348,7 +348,7 @@ jobs:
         run: |
           scl enable gcc-toolset-11 ci/build-binary
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-x86_64-glibc-binary
           path: install/ccache
@@ -371,7 +371,7 @@ jobs:
             runner: ubuntu-22.04
     steps:
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Trigger build
@@ -410,7 +410,7 @@ jobs:
               CMAKE_GENERATOR=Ninja CMAKE_PARAMS="-D CMAKE_EXE_LINKER_FLAGS_INIT=-static" ci/build-binary
           '
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-${{ matrix.arch }}-musl-static-binary
           path: install/ccache
@@ -424,11 +424,11 @@ jobs:
       CMAKE_GENERATOR: Ninja
     steps:
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build Darwin binary
         run: ci/build-darwin-binary
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: darwin-binary
           path: install/ccache
@@ -473,13 +473,13 @@ jobs:
           sudo mv $(basename ${TOOLCHAIN_FILENAME} .tar.xz) /opt/llvm-mingw
           echo /opt/llvm-mingw/bin >>${GITHUB_PATH}
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build binary
         env:
           CMAKE_PARAMS: -D CMAKE_TOOLCHAIN_FILE=../toolchains/${{ matrix.toolchain }}.cmake
         run: ci/build-binary
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.arch }}-binary
           path: install/ccache.exe
@@ -491,10 +491,10 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -629,7 +629,7 @@ jobs:
 
     steps:
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install CUDA
         if: matrix.CUDA != ''
@@ -643,7 +643,7 @@ jobs:
 
       - name: Prepare Windows environment (Visual Studio)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1.12.0
+        uses: ilammy/msvc-dev-cmd@v1.13.0
         with:
           arch: ${{ matrix.msvc_arch }}
 
@@ -697,7 +697,7 @@ jobs:
 
       - name: Upload testdir from failed tests
         if: failure() || steps.build-and-test.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }} - testdir.tar.xz
           path: testdir.tar.xz
@@ -720,15 +720,15 @@ jobs:
           sudo apt-get install -y minisign
 
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download binaries
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: "*-binary"
 
       - name: Download docs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: docs
           path: docs
@@ -746,7 +746,7 @@ jobs:
           minisign -Sm release/*
 
       - name: Upload release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ github.ref_type == 'tag' || github.event.inputs.test_tag != '' }}
         with:
           name: release
@@ -763,9 +763,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download release
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: release
           path: release
@@ -792,7 +792,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Clang-Format in check mode
         run: misc/format-files --all --check
@@ -805,7 +805,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Get source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install spell checkers
         run: |


### PR DESCRIPTION
This change updated all `uses:` entries in the GH pipeline to the latest versions. This is to avoid warnings about node 20.x deprecated by the gha.