### PR TITLE
fix: Logic error with read_only storage gating

### DIFF
--- a/src/ccache/storage/storage.cpp
+++ b/src/ccache/storage/storage.cpp
@@ -582,7 +582,7 @@ Storage::get_backend(RemoteStorageEntry& entry,
                      const std::string_view operation_description,
                      const bool for_writing)
 {
-  if (for_writing && entry.config.read_only) {
+  if (for_writing && entry.config.read_only.value_or(false)) {
     LOG("Not {} {} storage since it is read-only",
         operation_description,
         entry.config.shards.front().url.scheme());


### PR DESCRIPTION
RemoteStorageEntry::read_only is an std::optional<bool>. Storage::get_backend was treating read_only as a regular bool (likely a residue left over from a refactor?). Operator bool on std::optional is just a has_value check, so the backend storage gating was behaving as read_only even if read_only was set to false.

Closes #1746

<!--
  Thanks for contributing to ccache! Please read
  https://github.com/ccache/ccache/blob/master/CONTRIBUTING.md#contributing-code
  before submitting the pull request.

  Please describe what the pull request is about. If it fixes a bug or
  implements a feature that exists as a ccache issue, state which one. If it
  implements a feature, please describe what it does and motivate why you think
  that it would be a good idea for ccache.
-->
