### PR TITLE
feat: Add auto depend mode for NVCC on Windows

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -376,6 +376,15 @@ is_msvc_z_debug_option(std::string_view arg)
          != std::end(debug_options);
 }
 
+bool
+is_msvc_show_includes_option(std::string_view arg)
+{
+  return arg == "-showIncludes"
+         || arg == "/showIncludes"
+         // clang-cl:
+         || arg == "-showIncludes:user" || arg == "/showIncludes:user";
+}
+
 // Returns std::nullopt if the option wasn't recognized, otherwise the error
 // code (with Statistic::none for "no error").
 std::optional<Statistic>
@@ -931,11 +940,19 @@ process_option_arg(const Context& ctx,
     return Statistic::none;
   }
 
-  if (arg == "-showIncludes"
-      // clang-cl:
-      || arg == "-showIncludes:user") {
+  if (is_msvc_show_includes_option(arg)) {
     args_info.generating_includes = true;
     state.add_compiler_only_arg(args[i]);
+    return Statistic::none;
+  }
+
+  if (ctx.config.compiler_type() == CompilerType::nvcc
+      && (arg == "-Xcompiler" || arg == "--compiler-options")
+      && i < args.size() - 1 && is_msvc_show_includes_option(args[i + 1])) {
+    args_info.generating_includes = true;
+    state.add_compiler_only_arg(args[i]);
+    state.add_compiler_only_arg(args[i + 1]);
+    ++i;
     return Statistic::none;
   }
 
@@ -1912,11 +1929,20 @@ process_args(Context& ctx)
     state.add_compiler_only_arg_no_hash(*diagnostics_color_arg);
   }
 
-  if (ctx.config.depend_mode() && !args_info.generating_includes
-      && ctx.config.compiler_type() == CompilerType::msvc) {
-    ctx.auto_depend_mode = true;
-    args_info.generating_includes = true;
-    state.add_compiler_only_arg_no_hash("/showIncludes");
+  if (ctx.config.depend_mode() && !args_info.generating_includes) {
+    if (ctx.config.compiler_type() == CompilerType::msvc) {
+      ctx.auto_depend_mode = true;
+      args_info.generating_includes = true;
+      state.add_compiler_only_arg_no_hash("/showIncludes");
+    }
+#ifdef _WIN32
+    else if (ctx.config.compiler_type() == CompilerType::nvcc) {
+      ctx.auto_depend_mode = true;
+      args_info.generating_includes = true;
+      state.add_compiler_only_arg_no_hash("-Xcompiler");
+      state.add_compiler_only_arg_no_hash("/showIncludes");
+    }
+#endif
   }
 
   if (state.found_c_opt) {

--- a/src/ccache/compiler/msvc.cpp
+++ b/src/ccache/compiler/msvc.cpp
@@ -57,8 +57,12 @@ strip_includes_from_msvc_show_includes(const Context& ctx,
   using Mode = Tokenizer::Mode;
   using IncludeDelimiter = Tokenizer::IncludeDelimiter;
 
-  if (stdout_data.empty() || !ctx.auto_depend_mode
-      || ctx.config.compiler_type() != CompilerType::msvc) {
+  const bool strip_auto_includes =
+    ctx.auto_depend_mode
+    && (ctx.config.compiler_type() == CompilerType::msvc
+        || ctx.config.compiler_type() == CompilerType::nvcc);
+
+  if (stdout_data.empty() || !strip_auto_includes) {
     return std::move(stdout_data);
   }
 

--- a/unittest/test_argprocessing.cpp
+++ b/unittest/test_argprocessing.cpp
@@ -590,6 +590,51 @@ TEST_CASE("nvcc_warning_flags_long")
         == "nvcc --Werror all-warnings -Xcompiler -Werror -c");
 }
 
+TEST_CASE("nvcc_show_includes_via_host_compiler_option")
+{
+  TestContext test_context;
+  Context ctx;
+  ctx.config.set_compiler_type(CompilerType::nvcc);
+  ctx.config.set_depend_mode(true);
+  ctx.orig_args = Args::from_string("nvcc -c foo.cu -Xcompiler /showIncludes");
+  REQUIRE(util::write_file("foo.cu", ""));
+  const auto result = process_args(ctx);
+
+  CHECK(result);
+  CHECK(ctx.args_info.generating_includes);
+  CHECK(result->preprocessor_args.to_string() == "nvcc");
+  CHECK(result->extra_args_to_hash.to_string() == "-Xcompiler /showIncludes");
+  CHECK(result->compiler_args.to_string()
+        == "nvcc -Xcompiler /showIncludes -c");
+}
+
+TEST_CASE("nvcc_auto_depend_mode")
+{
+  TestContext test_context;
+  Context ctx;
+  ctx.config.set_compiler_type(CompilerType::nvcc);
+  ctx.config.set_depend_mode(true);
+  ctx.orig_args = Args::from_string("nvcc -c foo.cu");
+  REQUIRE(util::write_file("foo.cu", ""));
+  const auto result = process_args(ctx);
+
+  CHECK(result);
+#ifdef _WIN32
+  CHECK(ctx.auto_depend_mode);
+  CHECK(ctx.args_info.generating_includes);
+  CHECK(result->preprocessor_args.to_string() == "nvcc");
+  CHECK(result->extra_args_to_hash.to_string() == "");
+  CHECK(result->compiler_args.to_string()
+        == "nvcc -Xcompiler /showIncludes -c");
+#else
+  CHECK(!ctx.auto_depend_mode);
+  CHECK(!ctx.args_info.generating_includes);
+  CHECK(result->preprocessor_args.to_string() == "nvcc");
+  CHECK(result->extra_args_to_hash.to_string() == "");
+  CHECK(result->compiler_args.to_string() == "nvcc -c");
+#endif
+}
+
 TEST_CASE("-Xclang")
 {
   TestContext test_context;

--- a/unittest/test_compiler_msvc.cpp
+++ b/unittest/test_compiler_msvc.cpp
@@ -171,6 +171,25 @@ TEST_CASE("strip_includes_from_msvc_show_includes")
                     "Third custom line\n"));
     CHECK(result == util::to_span("First\nSecond\nThird custom line\n"));
   }
+
+  SUBCASE("NVCC auto depend mode")
+  {
+    ctx.config.set_compiler_type(CompilerType::nvcc);
+    const util::Bytes result =
+      compiler::strip_includes_from_msvc_show_includes(ctx, util::Bytes(input));
+    CHECK(result == util::to_span("First\nSecond\n"));
+  }
+
+  SUBCASE("NVCC explicit showIncludes")
+  {
+    ctx.auto_depend_mode = false;
+    ctx.config.set_compiler_type(CompilerType::nvcc);
+    ctx.config.set_depend_mode(true);
+    ctx.args_info.generating_includes = true;
+    const util::Bytes result =
+      compiler::strip_includes_from_msvc_show_includes(ctx, util::Bytes(input));
+    CHECK(result == input);
+  }
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
## Summary

Add NVCC auto depend mode on Windows by having ccache add `-Xcompiler /showIncludes` when `depend_mode=true` and the command line does not already request dependency/include output.

The MSVC-style include lines are then used to compute the depend-mode result key. Since those include lines were injected by ccache, they are stripped from user-visible stdout on both cache miss and cache hit, matching the existing MSVC auto-depend behavior.

If the user explicitly passes `/showIncludes` or `-Xcompiler /showIncludes`, ccache preserves the include output for transparency.

## Tests

- Added argument-processing coverage for explicit `nvcc -Xcompiler /showIncludes`.
- Added argument-processing coverage for NVCC auto depend mode adding `-Xcompiler /showIncludes`.
- Added stdout-stripping coverage for NVCC auto depend mode and explicit showIncludes transparency.
- Verified locally:
  - `cmake --build build-debug --target check_format`
  - `./unittest/unittest --test-case="nvcc_show_includes_via_host_compiler_option"`
  - `./unittest/unittest --test-case="nvcc_auto_depend_mode"`
  - `./unittest/unittest --test-case="strip_includes_from_msvc_show_includes"`
- Verified on Windows with a minimal `.cu` file:
  - auto depend mode strips ccache-injected include output and gets a direct cache hit on the second run
  - explicit `-Xcompiler /showIncludes` preserves include output on both miss and hit and gets a direct cache hit on the second run
