### PR TITLE
fix: Suppress #line directives when preprocessing with MSVC

### DIFF
--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -1453,6 +1453,7 @@ get_result_key_from_cpp(Context& ctx, util::Args& args, Hash& hash)
         args.push_back("-utf-8"); // Avoid garbling filenames in output
       }
       args.push_back("-P");
+      args.push_back("-EP"); // Suppress #line directives in preprocessed output
       args.push_back(FMT("-Fi{}", preprocessed_path));
     } else {
       args.push_back("-E");


### PR DESCRIPTION
When MSVC preprocesses with /P, it emits #line directives that embed absolute source paths into the preprocessed output. These directives are not needed for compilation and cause cache misses when the same source is built from different directories, since the preprocessed content varies by path. GCC does not have this issue.

Passing -EP together with -P suppresses the #line directives.

MSVC reference https://learn.microsoft.com/en-us/cpp/build/reference/p-preprocess-to-a-file
Fixes https://github.com/ccache/ccache/issues/1731