### PR TITLE
fix: Hash relative paths in preprocessor output when `base_dir` is set

### DIFF
--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -664,7 +664,7 @@ process_preprocessed_file(Context& ctx, Hash& hash, const fs::path& path)
       }
 
       if (inc_fs_path != ctx.apparent_cwd || ctx.config.hash_dir()) {
-        hash.hash(inc_fs_path);
+        hash.hash(inc_path);
       }
 
       TRY(remember_include_file(ctx, inc_fs_path, hash, system, nullptr));


### PR DESCRIPTION
- Closes #1761 
- When `base_dir` is set and a relative path is computed, hashes the relative path (`inc_path`) instead of the absolute path (`inc_fs_path`).
- In the scenario described in #1761, with this patch applied, the diff in `.ccache-text-input` is gone, and the ccache statistics after `build2` builds `source.c` has 1 (preprocessor) hit and 0 misses.