### PR TITLE
fix: Handle case-insensitive filesystems when ignoring headers

### DIFF
--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -426,8 +426,12 @@ remember_include_file(Context& ctx,
 
   if (!ctx.ignore_header_paths.empty()) {
     // Canonicalize path for comparison; Clang uses ./header.h.
-    const std::string& canonical_path_str =
+    auto canonical_path_str =
       path_str.str().starts_with("./") ? path_str.str().substr(2) : path_str;
+#ifdef _WIN32
+    // Handle case-insensitive paths by converting to lowercase.
+    canonical_path_str = util::to_lowercase(canonical_path_str);
+#endif
     for (const auto& ignore_header_path : ctx.ignore_header_paths) {
       if (file_path_matches_dir_prefix_or_file(ignore_header_path,
                                                canonical_path_str)) {

--- a/src/ccache/context.cpp
+++ b/src/ccache/context.cpp
@@ -59,6 +59,12 @@ Context::initialize(util::Args&& compiler_and_args,
   util::logging::init(config.debug(), config.log_file());
   ignore_header_paths =
     util::split_path_list(config.ignore_headers_in_manifest());
+#ifdef _WIN32
+  // Handle case-insensitive paths by converting to lowercase.
+  for (auto& path : ignore_header_paths) {
+    path = util::to_lowercase(path.string());
+  }
+#endif
   set_ignore_options(util::split_into_strings(config.ignore_options(), " "));
 
   // Set default umask for all files created by ccache from now on (if


### PR DESCRIPTION
- Fixes #1763
- Converts both input include file paths and all paths in the `ignore_headers_in_manifest` configuration option to lowercase on Windows before `file_path_matches_dir_prefix_or_file` is called.