### PR TITLE
libcxx fixes

### DIFF
--- a/src/ccache/storage/storage.cpp
+++ b/src/ccache/storage/storage.cpp
@@ -17,7 +17,6 @@
 // Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include "storage.hpp"
-
 #include <ccache/config.hpp>
 #include <ccache/context.hpp>
 #include <ccache/core/cacheentry.hpp>
@@ -47,7 +46,7 @@
 #include <ccache/util/xxh3_64.hpp>
 
 #include <cxxurl/url.hpp>
-
+#include <algorithm>
 #include <cmath>
 #include <memory>
 #include <string>

--- a/src/ccache/util/path.cpp
+++ b/src/ccache/util/path.cpp
@@ -15,9 +15,8 @@
 // You should have received a copy of the GNU General Public License along with
 // this program; if not, write to the Free Software Foundation, Inc., 51
 // Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-
+#include <algorithm>
 #include "path.hpp"
-
 #include <ccache/util/direntry.hpp>
 #include <ccache/util/filesystem.hpp>
 #include <ccache/util/format.hpp>


### PR DESCRIPTION
This PR fixes some errors  that came with libcxx include changes that came with llvm 24. 
Basically libc++ headers don't transically include themselves