### PR TITLE
feat: Implement path mapping

### DIFF
--- a/src/ccache/.clang-tidy
+++ b/src/ccache/.clang-tidy
@@ -57,6 +57,7 @@ Checks: '
   -modernize-return-braced-init-list,
   -modernize-use-auto,
   -modernize-use-default-member-init,
+  -modernize-use-designated-initializers,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   performance-*,

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -2160,9 +2160,9 @@ hash_argument(const Context& ctx,
   }
 
   // Optionally map and hash include paths.
-  // There may be more than these three include flags to look out for.
+  // There may be more than these include flags to look out for.
   // If needed, a separate PR can add more.
-  for (const auto prefix : {"-I", "-imsvc", "-isystem"}) {
+  for (const auto prefix : {"-I", "-imsvc", "-isystem", "-external:I"}) {
     if (!args[i].starts_with(prefix)) {
       continue;
     }

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -499,7 +499,7 @@ check_included_pch_file(Context& ctx, Hash& hash)
       && !ctx.args_info.generating_pch) {
     fs::path pch_path =
       core::make_relative_path(ctx, ctx.args_info.included_pch_file);
-    hash.hash(pch_path);
+    hash.hash(util::perform_path_mapping(pch_path, ctx.config.path_mapping()));
     TRY(remember_include_file(ctx, pch_path, hash, false, nullptr));
   }
   return {};
@@ -2144,41 +2144,35 @@ hash_argument(const Context& ctx,
   // directories and similar input paths exist. Note that this is not 100%
   // waterproof since it only detects newly appearing directories and not newly
   // appearing header files.
-  if (direct_mode) {
-    std::optional<std::string_view> path;
-    if (compopt_takes_path(args[i]) && i + 1 < args.size()) {
-      path = args[i + 1];
-    } else {
-      path = compopt_prefix_takes_path(args[i]);
-    }
-    if (path) {
-      const auto fsp =
-        util::perform_path_mapping(*path, ctx.config.path_mapping());
-      hash.hash_delimiter("path exists");
-      hash.hash(FMT("{} {}", fsp, fs::exists(fsp) ? "1" : "0"));
-    }
-  }
-
-  // Optionally map and hash include paths.
-  // There may be more than these include flags to look out for.
-  // If needed, a separate PR can add more.
-  for (const auto prefix : {"-I", "-imsvc", "-isystem", "-external:I"}) {
-    if (!args[i].starts_with(prefix)) {
-      continue;
-    }
+  {
     std::optional<std::string_view> path;
     bool space_in_between = false;
+    std::string compopt;
     if (compopt_takes_path(args[i]) && i + 1 < args.size()) {
-      path = args[i + 1];
+      compopt = args[i];
+      path = args[++i]; // Consume both prefix & path
       space_in_between = true;
     } else {
       path = compopt_prefix_takes_path(args[i]);
+      if (path) {
+        compopt = args[i].substr(0, args[i].length() - path->length());
+      }
     }
     if (path) {
-      const auto fsp =
+      const auto mapped_path =
         util::perform_path_mapping(*path, ctx.config.path_mapping());
-      hash.hash_delimiter("arg");
-      hash.hash(FMT("{}{}{}", prefix, space_in_between ? " " : "", fsp));
+      hash.hash_delimiter("path exists");
+      hash.hash(FMT("{} {}", mapped_path, fs::exists(*path) ? "1" : "0"));
+      if (space_in_between) {
+        // Emulate the behavior at the end of this function
+        hash.hash_delimiter("arg");
+        hash.hash(compopt);
+        hash.hash_delimiter("arg");
+        hash.hash(mapped_path);
+      } else {
+        hash.hash_delimiter("arg");
+        hash.hash(FMT("{}{}", compopt, mapped_path));
+      }
       return {};
     }
   }

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -658,7 +658,8 @@ do_process_preprocessed_data(Context& ctx, Hash& hash, util::Bytes&& data)
       inc_path_str.clear(); // inc_path is used from now on
 
       if (inc_path != ctx.apparent_cwd || ctx.config.hash_dir()) {
-        hash.hash(inc_path);
+        hash.hash(
+          util::perform_path_mapping(inc_path, ctx.config.path_mapping()));
       }
 
       TRY(remember_include_file(ctx, inc_path, hash, system, nullptr));
@@ -2148,14 +2149,37 @@ hash_argument(const Context& ctx,
     if (compopt_takes_path(args[i]) && i + 1 < args.size()) {
       path = args[i + 1];
     } else {
-      auto p = compopt_prefix_takes_path(args[i]);
-      if (p) {
-        path = *p;
-      }
+      path = compopt_prefix_takes_path(args[i]);
     }
     if (path) {
+      const auto fsp =
+        util::perform_path_mapping(*path, ctx.config.path_mapping());
       hash.hash_delimiter("path exists");
-      hash.hash(FMT("{} {}", *path, fs::exists(*path) ? "1" : "0"));
+      hash.hash(FMT("{} {}", fsp, fs::exists(fsp) ? "1" : "0"));
+    }
+  }
+
+  // Optionally map and hash include paths.
+  // There may be more than these three include flags to look out for.
+  // If needed, a separate PR can add more.
+  for (const auto prefix : {"-I", "-imsvc", "-isystem"}) {
+    if (!args[i].starts_with(prefix)) {
+      continue;
+    }
+    std::optional<std::string_view> path;
+    bool space_in_between = false;
+    if (compopt_takes_path(args[i]) && i + 1 < args.size()) {
+      path = args[i + 1];
+      space_in_between = true;
+    } else {
+      path = compopt_prefix_takes_path(args[i]);
+    }
+    if (path) {
+      const auto fsp =
+        util::perform_path_mapping(*path, ctx.config.path_mapping());
+      hash.hash_delimiter("arg");
+      hash.hash(FMT("{}{}{}", prefix, space_in_between ? " " : "", fsp));
+      return {};
     }
   }
 
@@ -2360,7 +2384,8 @@ get_manifest_key(Context& ctx, Hash& hash)
   //     share manifests and a/r.h exists.
   // * The expansion of __FILE__ may be incorrect.
   hash.hash_delimiter("inputfile");
-  hash.hash(ctx.args_info.input_file);
+  hash.hash(util::perform_path_mapping(ctx.args_info.input_file,
+                                       ctx.config.path_mapping()));
 
   if (!ctx.args_info.input_file_prefix.empty()) {
     hash.hash_delimiter("inputfile prefix");

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -675,7 +675,8 @@ do_process_preprocessed_data(Context& ctx, Hash& hash, util::Bytes&& data)
       inc_path_str.clear(); // inc_path is used from now on
 
       if (inc_path != ctx.apparent_cwd || ctx.config.hash_dir()) {
-        hash.hash(inc_path);
+        hash.hash(
+          util::perform_path_mapping(inc_path, ctx.config.path_mapping()));
       }
 
       TRY(remember_include_file(ctx, inc_path, hash, system, nullptr));
@@ -2174,14 +2175,37 @@ hash_argument(const Context& ctx,
     if (compopt_takes_path(args[i]) && i + 1 < args.size()) {
       path = args[i + 1];
     } else {
-      auto p = compopt_prefix_takes_path(args[i]);
-      if (p) {
-        path = *p;
-      }
+      path = compopt_prefix_takes_path(args[i]);
     }
     if (path) {
+      const auto fsp =
+        util::perform_path_mapping(*path, ctx.config.path_mapping());
       hash.hash_delimiter("path exists");
-      hash.hash(FMT("{} {}", *path, fs::exists(*path) ? "1" : "0"));
+      hash.hash(FMT("{} {}", fsp, fs::exists(fsp) ? "1" : "0"));
+    }
+  }
+
+  // Optionally map and hash include paths.
+  // There may be more than these three include flags to look out for.
+  // If needed, a separate PR can add more.
+  for (const auto prefix : {"-I", "-imsvc", "-isystem"}) {
+    if (!args[i].starts_with(prefix)) {
+      continue;
+    }
+    std::optional<std::string_view> path;
+    bool space_in_between = false;
+    if (compopt_takes_path(args[i]) && i + 1 < args.size()) {
+      path = args[i + 1];
+      space_in_between = true;
+    } else {
+      path = compopt_prefix_takes_path(args[i]);
+    }
+    if (path) {
+      const auto fsp =
+        util::perform_path_mapping(*path, ctx.config.path_mapping());
+      hash.hash_delimiter("arg");
+      hash.hash(FMT("{}{}{}", prefix, space_in_between ? " " : "", fsp));
+      return {};
     }
   }
 
@@ -2386,7 +2410,8 @@ get_manifest_key(Context& ctx, Hash& hash)
   //     share manifests and a/r.h exists.
   // * The expansion of __FILE__ may be incorrect.
   hash.hash_delimiter("inputfile");
-  hash.hash(ctx.args_info.input_file);
+  hash.hash(util::perform_path_mapping(ctx.args_info.input_file,
+                                       ctx.config.path_mapping()));
 
   if (!ctx.args_info.input_file_prefix.empty()) {
     hash.hash_delimiter("inputfile prefix");

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -2186,9 +2186,9 @@ hash_argument(const Context& ctx,
   }
 
   // Optionally map and hash include paths.
-  // There may be more than these three include flags to look out for.
+  // There may be more than these include flags to look out for.
   // If needed, a separate PR can add more.
-  for (const auto prefix : {"-I", "-imsvc", "-isystem"}) {
+  for (const auto prefix : {"-I", "-imsvc", "-isystem", "-external:I"}) {
     if (!args[i].starts_with(prefix)) {
       continue;
     }

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -2010,27 +2010,19 @@ hash_native_args(Context& ctx, const util::Args& native_args, Hash& hash)
   return {};
 }
 
-static std::tuple<std::optional<std::string_view>, std::optional<std::string>>
+static std::tuple<std::optional<std::string_view>,
+                  std::optional<std::string_view>>
 get_option_and_value(std::string_view option, const util::Args& args, size_t& i)
 {
-  // Handle MSVC and clang-cl quirks
-  auto arg = args[i];
-  if (arg.starts_with('/')) {
-    arg[0] = '-';
-  }
-  if (arg.starts_with("-clang:")) {
-    arg = arg.substr(7);
-  }
-
-  if (arg == option) {
+  if (args[i] == option) {
     if (i + 1 < args.size()) {
       ++i;
-      return {option, arg};
+      return {option, args[i]};
     } else {
       return {std::nullopt, std::nullopt};
     }
-  } else if (arg.starts_with(option)) {
-    return {option, arg.substr(option.length())};
+  } else if (args[i].starts_with(option)) {
+    return {option, std::string_view(args[i]).substr(option.length())};
   } else {
     return {std::nullopt, std::nullopt};
   }

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -499,7 +499,7 @@ check_included_pch_file(Context& ctx, Hash& hash)
       && !ctx.args_info.generating_pch) {
     fs::path pch_path =
       core::make_relative_path(ctx, ctx.args_info.included_pch_file);
-    hash.hash(pch_path);
+    hash.hash(util::perform_path_mapping(pch_path, ctx.config.path_mapping()));
     TRY(remember_include_file(ctx, pch_path, hash, false, nullptr));
   }
   return {};
@@ -2170,41 +2170,35 @@ hash_argument(const Context& ctx,
   // directories and similar input paths exist. Note that this is not 100%
   // waterproof since it only detects newly appearing directories and not newly
   // appearing header files.
-  if (direct_mode) {
-    std::optional<std::string_view> path;
-    if (compopt_takes_path(args[i]) && i + 1 < args.size()) {
-      path = args[i + 1];
-    } else {
-      path = compopt_prefix_takes_path(args[i]);
-    }
-    if (path) {
-      const auto fsp =
-        util::perform_path_mapping(*path, ctx.config.path_mapping());
-      hash.hash_delimiter("path exists");
-      hash.hash(FMT("{} {}", fsp, fs::exists(fsp) ? "1" : "0"));
-    }
-  }
-
-  // Optionally map and hash include paths.
-  // There may be more than these include flags to look out for.
-  // If needed, a separate PR can add more.
-  for (const auto prefix : {"-I", "-imsvc", "-isystem", "-external:I"}) {
-    if (!args[i].starts_with(prefix)) {
-      continue;
-    }
+  {
     std::optional<std::string_view> path;
     bool space_in_between = false;
+    std::string compopt;
     if (compopt_takes_path(args[i]) && i + 1 < args.size()) {
-      path = args[i + 1];
+      compopt = args[i];
+      path = args[++i]; // Consume both prefix & path
       space_in_between = true;
     } else {
       path = compopt_prefix_takes_path(args[i]);
+      if (path) {
+        compopt = args[i].substr(0, args[i].length() - path->length());
+      }
     }
     if (path) {
-      const auto fsp =
+      const auto mapped_path =
         util::perform_path_mapping(*path, ctx.config.path_mapping());
-      hash.hash_delimiter("arg");
-      hash.hash(FMT("{}{}{}", prefix, space_in_between ? " " : "", fsp));
+      hash.hash_delimiter("path exists");
+      hash.hash(FMT("{} {}", mapped_path, fs::exists(*path) ? "1" : "0"));
+      if (space_in_between) {
+        // Emulate the behavior at the end of this function
+        hash.hash_delimiter("arg");
+        hash.hash(compopt);
+        hash.hash_delimiter("arg");
+        hash.hash(mapped_path);
+      } else {
+        hash.hash_delimiter("arg");
+        hash.hash(FMT("{}{}", compopt, mapped_path));
+      }
       return {};
     }
   }

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -1756,7 +1756,7 @@ hash_common_info(const Context& ctx, const util::Args& args, Hash& hash)
       const char* value = getenv(name);
       if (value) {
         hash.hash_delimiter(name);
-        hash.hash(value);
+        hash.hash(util::perform_path_mapping(value, ctx.config.path_mapping()));
       }
     }
   }
@@ -2387,8 +2387,12 @@ get_manifest_key(Context& ctx, Hash& hash)
   for (const char* name : envvars) {
     const char* v = getenv(name);
     if (v) {
+      auto paths = util::split_path_list(v);
+      for (auto& path : paths) {
+        path = util::perform_path_mapping(path, ctx.config.path_mapping());
+      }
       hash.hash_delimiter(name);
-      hash.hash(v);
+      hash.hash(util::join_path_list(paths));
     }
   }
 

--- a/src/ccache/ccache.cpp
+++ b/src/ccache/ccache.cpp
@@ -2010,19 +2010,27 @@ hash_native_args(Context& ctx, const util::Args& native_args, Hash& hash)
   return {};
 }
 
-static std::tuple<std::optional<std::string_view>,
-                  std::optional<std::string_view>>
+static std::tuple<std::optional<std::string_view>, std::optional<std::string>>
 get_option_and_value(std::string_view option, const util::Args& args, size_t& i)
 {
-  if (args[i] == option) {
+  // Handle MSVC and clang-cl quirks
+  auto arg = args[i];
+  if (arg.starts_with('/')) {
+    arg[0] = '-';
+  }
+  if (arg.starts_with("-clang:")) {
+    arg = arg.substr(7);
+  }
+
+  if (arg == option) {
     if (i + 1 < args.size()) {
       ++i;
-      return {option, args[i]};
+      return {option, arg};
     } else {
       return {std::nullopt, std::nullopt};
     }
-  } else if (args[i].starts_with(option)) {
-    return {option, std::string_view(args[i]).substr(option.length())};
+  } else if (arg.starts_with(option)) {
+    return {option, arg.substr(option.length())};
   } else {
     return {std::nullopt, std::nullopt};
   }

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -180,6 +180,8 @@ const CompOpt compopts[] = {
   {"-v",                      AFFECTS_COMP                                           },
   {"-wrapper",                TAKES_ARG | TOO_HARD                                   },
   {"-z",                      TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP            },
+  {"/external:I",
+   AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH                           }, // msvc
 };
 // clang-format on
 
@@ -189,14 +191,6 @@ compare_compopts(const void* key1, const void* key2)
   const CompOpt* opt1 = static_cast<const CompOpt*>(key1);
   const CompOpt* opt2 = static_cast<const CompOpt*>(key2);
   return opt1->name.compare(opt2->name);
-}
-
-static int
-compare_prefix_compopts(const void* key1, const void* key2)
-{
-  const CompOpt* opt1 = static_cast<const CompOpt*>(key1);
-  const CompOpt* opt2 = static_cast<const CompOpt*>(key2);
-  return opt1->name.substr(0, opt2->name.length()).compare(opt2->name);
 }
 
 static const CompOpt*
@@ -211,13 +205,15 @@ find(std::string_view option)
 static const CompOpt*
 find_prefix(std::string_view option)
 {
-  CompOpt key{option, 0};
-  void* result = bsearch(&key,
-                         compopts,
-                         std::size(compopts),
-                         sizeof(compopts[0]),
-                         compare_prefix_compopts);
-  return static_cast<CompOpt*>(result);
+  const CompOpt* max_co{};
+  for (const auto &co : compopts) {
+    const auto prefix_matches = option.starts_with(co.name);
+    const auto length_larger = (!max_co || co.name.length() > max_co->name.length());
+    if (prefix_matches && length_larger) {
+      max_co = &co;
+    }
+  }
+  return max_co;
 }
 
 // Used by unittest/test_compopt.cpp.

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -206,9 +206,10 @@ static const CompOpt*
 find_prefix(std::string_view option)
 {
   const CompOpt* max_co{};
-  for (const auto &co : compopts) {
+  for (const auto& co : compopts) {
     const auto prefix_matches = option.starts_with(co.name);
-    const auto length_larger = (!max_co || co.name.length() > max_co->name.length());
+    const auto length_larger =
+      (!max_co || co.name.length() > max_co->name.length());
     if (prefix_matches && length_larger) {
       max_co = &co;
     }

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -182,6 +182,8 @@ constexpr CompOpt compopts[] = {
   {"-v",                      AFFECTS_COMP                                           },
   {"-wrapper",                TAKES_ARG | TOO_HARD                                   },
   {"-z",                      TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP            },
+  {"/external:I",
+   AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH                           }, // msvc
 };
 // clang-format on
 

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -182,8 +182,6 @@ constexpr CompOpt compopts[] = {
   {"-v",                      AFFECTS_COMP                                           },
   {"-wrapper",                TAKES_ARG | TOO_HARD                                   },
   {"-z",                      TAKES_ARG | TAKES_CONCAT_ARG | AFFECTS_COMP            },
-  {"/external:I",
-   AFFECTS_CPP | TAKES_ARG | TAKES_CONCAT_ARG | TAKES_PATH                           }, // msvc
 };
 // clang-format on
 

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -137,6 +137,7 @@ enum class ConfigItem : uint8_t {
   msvc_utf8,
   namespace_,
   path,
+  path_mapping,
   pch_external_checksum,
   prefix_command,
   prefix_command_cpp,
@@ -206,6 +207,7 @@ const std::unordered_map<std::string_view, ConfigKeyTableEntry>
     {"msvc_utf8",                  {C::msvc_utf8,                  DCP::allow}},
     {"namespace",                  {C::namespace_,                 DCP::allow}},
     {"path",                       {C::path,                       DCP::unsafe}},
+    {"path_mapping",               {C::path_mapping,               DCP::allow}},
     {"pch_external_checksum",      {C::pch_external_checksum,      DCP::allow}},
     {"prefix_command",             {C::prefix_command,             DCP::unsafe}},
     {"prefix_command_cpp",         {C::prefix_command_cpp,         DCP::unsafe}},
@@ -261,6 +263,7 @@ const std::unordered_map<std::string_view, std::string_view>
     {"MSVC_UTF8",            "msvc_utf8"                 },
     {"NAMESPACE",            "namespace"                 },
     {"PATH",                 "path"                      },
+    {"PATH_MAPPING",         "path_mapping"              },
     {"PCH_EXTSUM",           "pch_external_checksum"     },
     {"PREFIX",               "prefix_command"            },
     {"PREFIX_CPP",           "prefix_command_cpp"        },
@@ -578,6 +581,56 @@ response_file_format_to_string(
   }
 
   ASSERT(false);
+}
+
+#ifdef _WIN32
+const char k_path_delimiter[] = ";";
+#else
+const char k_path_delimiter[] = ":";
+#endif
+
+std::vector<std::pair<fs::path, fs::path>>
+parse_path_mapping(const std::string_view& path_mapping_string)
+{
+  std::vector<std::pair<fs::path, fs::path>> result;
+
+  // Split by path delimiter (platform-specific)
+  auto mappings = util::split_into_views(path_mapping_string, k_path_delimiter);
+
+  for (const auto& mapping : mappings) {
+    // Split each mapping by '='
+    auto [key, value] = util::split_once_into_views(mapping, '=');
+    if (!value) {
+      // Skip invalid entries without '='
+      continue;
+    }
+
+    // Strip whitespace from both key and value
+    std::string_view key_stripped = util::strip_whitespace(key);
+    std::string_view value_stripped = util::strip_whitespace(*value);
+
+    if (!key_stripped.empty() && !value_stripped.empty()) {
+      result.emplace_back(key_stripped, value_stripped);
+    }
+  }
+
+  return result;
+}
+
+std::string
+format_path_mapping(
+  const std::vector<std::pair<fs::path, fs::path>>& path_mapping)
+{
+  if (path_mapping.empty()) {
+    return {};
+  }
+  std::ostringstream ss;
+  for (size_t i = 0; i < path_mapping.size() - 1; ++i) {
+    ss << path_mapping[i].first << '=' << path_mapping[i].second
+       << k_path_delimiter;
+  }
+  ss << path_mapping.back().first << '=' << path_mapping.back().second;
+  return ss.str();
 }
 
 } // namespace
@@ -1113,6 +1166,9 @@ Config::get_string_value(const std::string& key) const
   case ConfigItem::path:
     return m_path;
 
+  case ConfigItem::path_mapping:
+    return format_path_mapping(m_path_mapping);
+
   case ConfigItem::pch_external_checksum:
     return format_bool(m_pch_external_checksum);
 
@@ -1407,6 +1463,10 @@ Config::set_item(const std::string_view& key,
     m_path = value;
     break;
 
+  case ConfigItem::path_mapping:
+    m_path_mapping = parse_path_mapping(value);
+    break;
+
   case ConfigItem::pch_external_checksum:
     m_pch_external_checksum = parse_bool(value, env_var_key, negate);
     break;
@@ -1597,4 +1657,10 @@ Config::find_directory_config() const
     dir = std::move(parent);
     dir_entry = std::move(parent_entry);
   }
+}
+
+const std::vector<std::pair<fs::path, fs::path>>&
+Config::path_mapping() const
+{
+  return m_path_mapping;
 }

--- a/src/ccache/config.cpp
+++ b/src/ccache/config.cpp
@@ -594,23 +594,20 @@ parse_path_mapping(const std::string_view& path_mapping_string)
 {
   std::vector<std::pair<fs::path, fs::path>> result;
 
-  // Split by path delimiter (platform-specific)
-  auto mappings = util::split_into_views(path_mapping_string, k_path_delimiter);
+  const auto mappings =
+    util::split_into_views(path_mapping_string, k_path_delimiter);
 
   for (const auto& mapping : mappings) {
-    // Split each mapping by '='
     auto [key, value] = util::split_once_into_views(mapping, '=');
     if (!value) {
-      // Skip invalid entries without '='
       continue;
     }
 
-    // Strip whitespace from both key and value
-    std::string_view key_stripped = util::strip_whitespace(key);
-    std::string_view value_stripped = util::strip_whitespace(*value);
+    key = util::strip_whitespace(key);
+    value = util::strip_whitespace(*value);
 
-    if (!key_stripped.empty() && !value_stripped.empty()) {
-      result.emplace_back(key_stripped, value_stripped);
+    if (!key.empty() && !value->empty()) {
+      result.emplace_back(key, *value);
     }
   }
 

--- a/src/ccache/config.hpp
+++ b/src/ccache/config.hpp
@@ -92,6 +92,8 @@ public:
   const std::string& msvc_dep_prefix() const;
   bool msvc_utf8() const;
   const std::string& path() const;
+  const std::vector<std::pair<std::filesystem::path, std::filesystem::path>>&
+  path_mapping() const;
   bool pch_external_checksum() const;
   const std::string& prefix_command() const;
   const std::string& prefix_command_cpp() const;
@@ -226,6 +228,8 @@ private:
   std::string m_msvc_dep_prefix = "Note: including file:";
   bool m_msvc_utf8 = true;
   std::string m_path;
+  std::vector<std::pair<std::filesystem::path, std::filesystem::path>>
+    m_path_mapping;
   bool m_pch_external_checksum = false;
   std::string m_prefix_command;
   std::string m_prefix_command_cpp;

--- a/src/ccache/context.hpp
+++ b/src/ccache/context.hpp
@@ -83,7 +83,7 @@ public:
   storage::Storage storage;
 
   // Direct mode manifest.
-  core::Manifest manifest;
+  core::Manifest manifest{this};
 
 #ifdef INODE_CACHE_SUPPORTED
   // InodeCache that caches source file hashes when enabled.

--- a/src/ccache/core/manifest.cpp
+++ b/src/ccache/core/manifest.cpp
@@ -341,22 +341,27 @@ Manifest::get_file_info_index(
 {
   FileInfo fi;
 
-  const auto f_it = mf_files.find(path);
+  const auto fs = file_stater(path);
+  fi.mtime = fs.mtime;
+  fi.ctime = fs.ctime;
+  fi.fsize = fs.size;
+
+  const auto mapped_path =
+    m_ctx
+      ? util::perform_path_mapping(path, m_ctx->config.path_mapping()).string()
+      : path;
+
+  const auto f_it = mf_files.find(mapped_path);
   if (f_it != mf_files.end()) {
     fi.index = f_it->second;
   } else if (m_files.size() > UINT32_MAX) {
     return std::nullopt;
   } else {
-    m_files.push_back(path);
+    m_files.push_back(mapped_path);
     fi.index = static_cast<uint32_t>(m_files.size() - 1);
   }
 
   fi.digest = digest;
-
-  const auto file_stat = file_stater(path);
-  fi.mtime = file_stat.mtime;
-  fi.ctime = file_stat.ctime;
-  fi.fsize = file_stat.size;
 
   const auto fi_it = mf_file_infos.find(fi);
   if (fi_it != mf_file_infos.end()) {
@@ -378,7 +383,11 @@ Manifest::result_matches(
 {
   for (uint32_t file_info_index : result.file_info_indexes) {
     const auto& fi = m_file_infos[file_info_index];
-    const auto& path = m_files[fi.index];
+
+    // Reverse the mapping that occurred in get_file_info_index()
+    const auto path = util::perform_path_mapping(
+                        m_files[fi.index], ctx.config.path_mapping(), true)
+                        .string();
 
     auto stated_files_iter = stated_files.find(path);
     if (stated_files_iter == stated_files.end()) {

--- a/src/ccache/core/manifest.hpp
+++ b/src/ccache/core/manifest.hpp
@@ -50,7 +50,10 @@ public:
 
   using FileStater = std::function<FileStats(std::string)>;
 
-  Manifest() = default;
+  Manifest(const Context* ctx = {})
+    : m_ctx{ctx}
+  {
+  }
 
   void read(std::span<const uint8_t> data);
 
@@ -92,6 +95,7 @@ private:
   std::vector<std::string> m_files;   // Names of referenced include files.
   std::vector<FileInfo> m_file_infos; // Info about referenced include files.
   std::vector<ResultEntry> m_results;
+  const Context* m_ctx; // To help map paths in get_file_info_index()
 
   void clear();
 

--- a/src/ccache/util/path.cpp
+++ b/src/ccache/util/path.cpp
@@ -196,16 +196,16 @@ path_starts_with(const std::filesystem::path& path,
 
 fs::path
 perform_path_mapping(
-  fs::path path, const std::vector<std::pair<fs::path, fs::path>>& path_mapping)
+  const fs::path& path,
+  const std::vector<std::pair<fs::path, fs::path>>& path_mapping)
 {
-  // relative_path() removes the root-path: '/' on POSIX, 'C:/' on Win32
-  path = path.relative_path();
-  for (const auto& mapping : path_mapping) {
-    const auto key = mapping.first.relative_path();
-    if (path_starts_with(path, key)) {
-      return mapping.second
-             / remove_leading_components(path, std::ranges::distance(key));
+  for (const auto& [key, value] : path_mapping) {
+    if (!path_starts_with(path, key)) {
+      continue;
     }
+    const auto& suffix =
+      remove_leading_components(path, std::ranges::distance(key));
+    return suffix.empty() ? value : (value / suffix);
   }
   return path;
 }

--- a/src/ccache/util/path.cpp
+++ b/src/ccache/util/path.cpp
@@ -50,6 +50,22 @@ lexically_relative_case_aware(const fs::path& path, const fs::path& base)
 #endif
 }
 
+fs::path
+remove_leading_components(const fs::path& p, const std::size_t count)
+{
+  fs::path result;
+  std::size_t current = 0;
+
+  for (const auto& element : p) {
+    if (current >= count) {
+      result /= element;
+    }
+    current++;
+  }
+
+  return result;
+}
+
 } // namespace
 
 namespace util {
@@ -176,6 +192,22 @@ path_starts_with(const std::filesystem::path& path,
     std::begin(prefixes), std::end(prefixes), [&](const fs::path& prefix) {
       return path_starts_with(path, prefix);
     });
+}
+
+fs::path
+perform_path_mapping(
+  fs::path path, const std::vector<std::pair<fs::path, fs::path>>& path_mapping)
+{
+  // relative_path() removes the root-path: '/' on POSIX, 'C:/' on Win32
+  path = path.relative_path();
+  for (const auto& mapping : path_mapping) {
+    const auto key = mapping.first.relative_path();
+    if (path_starts_with(path, key)) {
+      return mapping.second
+             / remove_leading_components(path, std::ranges::distance(key));
+    }
+  }
+  return path;
 }
 
 } // namespace util

--- a/src/ccache/util/path.cpp
+++ b/src/ccache/util/path.cpp
@@ -299,8 +299,18 @@ perform_path_mapping(
     if (!path_starts_with(path, from)) {
       continue;
     }
+
+    // Skip empty part at the end that originates from a trailing slash.
+    auto from_end = from.end();
+    if (!from.empty()) {
+      --from_end;
+      if (!from_end->empty()) {
+        ++from_end;
+      }
+    }
+
     const auto& suffix =
-      remove_leading_components(path, std::ranges::distance(from));
+      remove_leading_components(path, std::distance(from.begin(), from_end));
     return suffix.empty() ? to : (to / suffix);
   }
   return path;

--- a/src/ccache/util/path.cpp
+++ b/src/ccache/util/path.cpp
@@ -86,6 +86,22 @@ lexically_relative_case_aware(const fs::path& path, const fs::path& base)
 #endif
 }
 
+fs::path
+remove_leading_components(const fs::path& p, const std::size_t count)
+{
+  fs::path result;
+  std::size_t current = 0;
+
+  for (const auto& element : p) {
+    if (current >= count) {
+      result /= element;
+    }
+    current++;
+  }
+
+  return result;
+}
+
 } // namespace
 
 namespace util {
@@ -269,6 +285,22 @@ path_starts_with(const std::filesystem::path& path,
     std::begin(prefixes), std::end(prefixes), [&](const fs::path& prefix) {
       return path_starts_with(path, prefix);
     });
+}
+
+fs::path
+perform_path_mapping(
+  fs::path path, const std::vector<std::pair<fs::path, fs::path>>& path_mapping)
+{
+  // relative_path() removes the root-path: '/' on POSIX, 'C:/' on Win32
+  path = path.relative_path();
+  for (const auto& mapping : path_mapping) {
+    const auto key = mapping.first.relative_path();
+    if (path_starts_with(path, key)) {
+      return mapping.second
+             / remove_leading_components(path, std::ranges::distance(key));
+    }
+  }
+  return path;
 }
 
 } // namespace util

--- a/src/ccache/util/path.cpp
+++ b/src/ccache/util/path.cpp
@@ -290,15 +290,18 @@ path_starts_with(const std::filesystem::path& path,
 fs::path
 perform_path_mapping(
   const fs::path& path,
-  const std::vector<std::pair<fs::path, fs::path>>& path_mapping)
+  const std::vector<std::pair<fs::path, fs::path>>& path_mapping,
+  bool reverse)
 {
   for (const auto& [key, value] : path_mapping) {
-    if (!path_starts_with(path, key)) {
+    const auto& from = reverse ? value : key;
+    const auto& to = reverse ? key : value;
+    if (!path_starts_with(path, from)) {
       continue;
     }
     const auto& suffix =
-      remove_leading_components(path, std::ranges::distance(key));
-    return suffix.empty() ? value : (value / suffix);
+      remove_leading_components(path, std::ranges::distance(from));
+    return suffix.empty() ? to : (to / suffix);
   }
   return path;
 }

--- a/src/ccache/util/path.cpp
+++ b/src/ccache/util/path.cpp
@@ -289,16 +289,16 @@ path_starts_with(const std::filesystem::path& path,
 
 fs::path
 perform_path_mapping(
-  fs::path path, const std::vector<std::pair<fs::path, fs::path>>& path_mapping)
+  const fs::path& path,
+  const std::vector<std::pair<fs::path, fs::path>>& path_mapping)
 {
-  // relative_path() removes the root-path: '/' on POSIX, 'C:/' on Win32
-  path = path.relative_path();
-  for (const auto& mapping : path_mapping) {
-    const auto key = mapping.first.relative_path();
-    if (path_starts_with(path, key)) {
-      return mapping.second
-             / remove_leading_components(path, std::ranges::distance(key));
+  for (const auto& [key, value] : path_mapping) {
+    if (!path_starts_with(path, key)) {
+      continue;
     }
+    const auto& suffix =
+      remove_leading_components(path, std::ranges::distance(key));
+    return suffix.empty() ? value : (value / suffix);
   }
   return path;
 }

--- a/src/ccache/util/path.cpp
+++ b/src/ccache/util/path.cpp
@@ -289,10 +289,11 @@ path_starts_with(const std::filesystem::path& path,
 
 fs::path
 perform_path_mapping(
-  const fs::path& path,
+  fs::path path,
   const std::vector<std::pair<fs::path, fs::path>>& path_mapping,
   bool reverse)
 {
+  path = lexically_normal(path);
   for (const auto& [key, value] : path_mapping) {
     const auto& from = reverse ? value : key;
     const auto& to = reverse ? key : value;

--- a/src/ccache/util/path.hpp
+++ b/src/ccache/util/path.hpp
@@ -93,6 +93,11 @@ using pstr = PathString;
 std::filesystem::path with_extension(const std::filesystem::path& path,
                                      std::string_view extension);
 
+std::filesystem::path perform_path_mapping(
+  std::filesystem::path path,
+  const std::vector<std::pair<std::filesystem::path, std::filesystem::path>>&
+    path_mapping);
+
 // --- Inline implementations ---
 
 inline std::filesystem::path

--- a/src/ccache/util/path.hpp
+++ b/src/ccache/util/path.hpp
@@ -93,8 +93,10 @@ using pstr = PathString;
 std::filesystem::path with_extension(const std::filesystem::path& path,
                                      std::string_view extension);
 
+// Transform a prefix of `path` using the mappings in `path_mapping`.
+// If no mapping occurred, returns `path`.
 std::filesystem::path perform_path_mapping(
-  std::filesystem::path path,
+  const std::filesystem::path& path,
   const std::vector<std::pair<std::filesystem::path, std::filesystem::path>>&
     path_mapping);
 

--- a/src/ccache/util/path.hpp
+++ b/src/ccache/util/path.hpp
@@ -101,6 +101,11 @@ using pstr = PathString;
 std::filesystem::path with_extension(const std::filesystem::path& path,
                                      std::string_view extension);
 
+std::filesystem::path perform_path_mapping(
+  std::filesystem::path path,
+  const std::vector<std::pair<std::filesystem::path, std::filesystem::path>>&
+    path_mapping);
+
 // --- Inline implementations ---
 
 inline std::filesystem::path

--- a/src/ccache/util/path.hpp
+++ b/src/ccache/util/path.hpp
@@ -101,8 +101,10 @@ using pstr = PathString;
 std::filesystem::path with_extension(const std::filesystem::path& path,
                                      std::string_view extension);
 
+// Transform a prefix of `path` using the mappings in `path_mapping`.
+// If no mapping occurred, returns `path`.
 std::filesystem::path perform_path_mapping(
-  std::filesystem::path path,
+  const std::filesystem::path& path,
   const std::vector<std::pair<std::filesystem::path, std::filesystem::path>>&
     path_mapping);
 

--- a/src/ccache/util/path.hpp
+++ b/src/ccache/util/path.hpp
@@ -104,7 +104,7 @@ std::filesystem::path with_extension(const std::filesystem::path& path,
 // Transform a prefix of `path` using the mappings in `path_mapping`.
 // If no mapping occurred, returns `path`.
 std::filesystem::path perform_path_mapping(
-  const std::filesystem::path& path,
+  std::filesystem::path path,
   const std::vector<std::pair<std::filesystem::path, std::filesystem::path>>&
     path_mapping,
   bool reverse = {});

--- a/src/ccache/util/path.hpp
+++ b/src/ccache/util/path.hpp
@@ -106,7 +106,8 @@ std::filesystem::path with_extension(const std::filesystem::path& path,
 std::filesystem::path perform_path_mapping(
   const std::filesystem::path& path,
   const std::vector<std::pair<std::filesystem::path, std::filesystem::path>>&
-    path_mapping);
+    path_mapping,
+  bool reverse = {});
 
 // --- Inline implementations ---
 

--- a/unittest/test_config.cpp
+++ b/unittest/test_config.cpp
@@ -625,6 +625,7 @@ TEST_CASE("Config::visit_items")
     "msvc_utf8 = true\n"
     "namespace = ns\n"
     "path = p\n"
+    "path_mapping = /123=/456\n"
     "pch_external_checksum = true\n"
     "prefix_command = pc\n"
     "prefix_command_cpp = pcc\n"
@@ -688,6 +689,7 @@ TEST_CASE("Config::visit_items")
     "(test.conf) msvc_utf8 = true",
     "(test.conf) namespace = ns",
     "(test.conf) path = p",
+    "(test.conf) path_mapping = \"/123\"=\"/456\"",
     "(test.conf) pch_external_checksum = true",
     "(test.conf) prefix_command = pc",
     "(test.conf) prefix_command_cpp = pcc",

--- a/unittest/test_util_path.cpp
+++ b/unittest/test_util_path.cpp
@@ -211,3 +211,25 @@ TEST_CASE("util::with_extension")
   CHECK(util::with_extension("foo.x", "") == "foo");
   CHECK(util::with_extension("foo.x", ".y") == "foo.y");
 }
+
+TEST_CASE("util::perform_path_mapping")
+{
+  CHECK(util::perform_path_mapping("", {{"/foo", "/bar"}}) == "");
+  CHECK(util::perform_path_mapping("/", {{"/foo", "/bar"}}) == "/");
+  CHECK(util::perform_path_mapping("/foo/bar", {{"/foo", "/bar"}}) == "/bar/bar");
+  CHECK(util::perform_path_mapping("/foo/bar", {{"/bar", "/foo"}}) == "/foo/bar");
+  CHECK(util::perform_path_mapping("/bar/foo", {{"/bar", "/foo"}}) == "/foo/foo");
+  CHECK(util::perform_path_mapping("/bar/foo", {{"/foo", "/bar"}}) == "/bar/foo");
+#ifdef _WIN32
+  CHECK(util::perform_path_mapping("D:/path", {{"D:/path", "/new-path"}}) == "/new-path");
+  CHECK(util::perform_path_mapping("D:\\path", {{"D:/path", "/new-path"}}) == "/new-path");
+  CHECK(util::perform_path_mapping("D:/path", {{"D:/path", "\\new-path"}}) == "\\new-path");
+
+  CHECK(util::perform_path_mapping("D:/path/to", {{"D:/path", "/new-path"}}) == "/new-path/to");
+  CHECK(util::perform_path_mapping("D:\\path/to", {{"D:/path", "/new-path"}}) == "/new-path/to");
+  CHECK(util::perform_path_mapping("D:\\path\\to", {{"D:/path", "/new-path"}}) == "/new-path\\to");
+  CHECK(util::perform_path_mapping("D:\\path\\to", {{"D:/path", "\\new-path"}}) == "\\new-path\\to");
+
+  CHECK(util::perform_path_mapping("C:/path", {{"D:/path", "/new-path"}}) == "C:/path");
+#endif
+}

--- a/unittest/test_util_path.cpp
+++ b/unittest/test_util_path.cpp
@@ -214,6 +214,7 @@ TEST_CASE("util::with_extension")
 
 TEST_CASE("util::perform_path_mapping")
 {
+  // clang-format off
   CHECK(util::perform_path_mapping("", {{"/foo", "/bar"}}) == "");
   CHECK(util::perform_path_mapping("/", {{"/foo", "/bar"}}) == "/");
   CHECK(util::perform_path_mapping("/foo/bar", {{"/foo", "/bar"}}) == "/bar/bar");
@@ -232,4 +233,5 @@ TEST_CASE("util::perform_path_mapping")
 
   CHECK(util::perform_path_mapping("C:/path", {{"D:/path", "/new-path"}}) == "C:/path");
 #endif
+  // clang-format on
 }

--- a/unittest/test_util_path.cpp
+++ b/unittest/test_util_path.cpp
@@ -261,6 +261,7 @@ TEST_CASE("util::perform_path_mapping")
   CHECK(util::perform_path_mapping("/foo/bar", {{"/bar", "/foo"}}) == "/foo/bar");
   CHECK(util::perform_path_mapping("/bar/foo", {{"/bar", "/foo"}}) == "/foo/foo");
   CHECK(util::perform_path_mapping("/bar/foo", {{"/foo", "/bar"}}) == "/bar/foo");
+  CHECK(util::perform_path_mapping("/bar/foo", {{"/foo", "/bar"}}, true) == "/foo/foo");
 #ifdef _WIN32
   CHECK(util::perform_path_mapping("D:/path", {{"D:/path", "/new-path"}}) == "/new-path");
   CHECK(util::perform_path_mapping("D:\\path", {{"D:/path", "/new-path"}}) == "/new-path");
@@ -272,6 +273,7 @@ TEST_CASE("util::perform_path_mapping")
   CHECK(util::perform_path_mapping("D:\\path\\to", {{"D:/path", "\\new-path"}}) == "\\new-path\\to");
 
   CHECK(util::perform_path_mapping("C:/path", {{"D:/path", "/new-path"}}) == "C:/path");
+  CHECK(util::perform_path_mapping("C:/path", {{"D:/path", "C:/path"}}, true) == "D:/path");
 #endif
   // clang-format on
 }

--- a/unittest/test_util_path.cpp
+++ b/unittest/test_util_path.cpp
@@ -251,3 +251,25 @@ TEST_CASE("util::with_extension")
   CHECK(util::with_extension("foo.x", "") == "foo");
   CHECK(util::with_extension("foo.x", ".y") == "foo.y");
 }
+
+TEST_CASE("util::perform_path_mapping")
+{
+  CHECK(util::perform_path_mapping("", {{"/foo", "/bar"}}) == "");
+  CHECK(util::perform_path_mapping("/", {{"/foo", "/bar"}}) == "/");
+  CHECK(util::perform_path_mapping("/foo/bar", {{"/foo", "/bar"}}) == "/bar/bar");
+  CHECK(util::perform_path_mapping("/foo/bar", {{"/bar", "/foo"}}) == "/foo/bar");
+  CHECK(util::perform_path_mapping("/bar/foo", {{"/bar", "/foo"}}) == "/foo/foo");
+  CHECK(util::perform_path_mapping("/bar/foo", {{"/foo", "/bar"}}) == "/bar/foo");
+#ifdef _WIN32
+  CHECK(util::perform_path_mapping("D:/path", {{"D:/path", "/new-path"}}) == "/new-path");
+  CHECK(util::perform_path_mapping("D:\\path", {{"D:/path", "/new-path"}}) == "/new-path");
+  CHECK(util::perform_path_mapping("D:/path", {{"D:/path", "\\new-path"}}) == "\\new-path");
+
+  CHECK(util::perform_path_mapping("D:/path/to", {{"D:/path", "/new-path"}}) == "/new-path/to");
+  CHECK(util::perform_path_mapping("D:\\path/to", {{"D:/path", "/new-path"}}) == "/new-path/to");
+  CHECK(util::perform_path_mapping("D:\\path\\to", {{"D:/path", "/new-path"}}) == "/new-path\\to");
+  CHECK(util::perform_path_mapping("D:\\path\\to", {{"D:/path", "\\new-path"}}) == "\\new-path\\to");
+
+  CHECK(util::perform_path_mapping("C:/path", {{"D:/path", "/new-path"}}) == "C:/path");
+#endif
+}

--- a/unittest/test_util_path.cpp
+++ b/unittest/test_util_path.cpp
@@ -255,25 +255,54 @@ TEST_CASE("util::with_extension")
 TEST_CASE("util::perform_path_mapping")
 {
   // clang-format off
+
+  // Edge cases
   CHECK(util::perform_path_mapping("", {{"/foo", "/bar"}}) == "");
   CHECK(util::perform_path_mapping("/", {{"/foo", "/bar"}}) == "/");
+
+  // Simple mappings
   CHECK(util::perform_path_mapping("/foo/bar", {{"/foo", "/bar"}}) == "/bar/bar");
-  CHECK(util::perform_path_mapping("/foo/bar", {{"/bar", "/foo"}}) == "/foo/bar");
   CHECK(util::perform_path_mapping("/bar/foo", {{"/bar", "/foo"}}) == "/foo/foo");
+
+  // Original path is returned if no mapping occurred
+  CHECK(util::perform_path_mapping("/foo/bar", {{"/bar", "/foo"}}) == "/foo/bar");
   CHECK(util::perform_path_mapping("/bar/foo", {{"/foo", "/bar"}}) == "/bar/foo");
+
+  // Reverse mapping
   CHECK(util::perform_path_mapping("/bar/foo", {{"/foo", "/bar"}}, true) == "/foo/foo");
+
 #ifdef _WIN32
+  // Simple mappings
   CHECK(util::perform_path_mapping("D:/path", {{"D:/path", "/new-path"}}) == "/new-path");
+
+  // Slashes are just component separators when matching,
+  // but are still in the underlying strings when mapping.
   CHECK(util::perform_path_mapping("D:\\path", {{"D:/path", "/new-path"}}) == "/new-path");
   CHECK(util::perform_path_mapping("D:/path", {{"D:/path", "\\new-path"}}) == "\\new-path");
 
+  // Only the prefix gets mapped
   CHECK(util::perform_path_mapping("D:/path/to", {{"D:/path", "/new-path"}}) == "/new-path/to");
   CHECK(util::perform_path_mapping("D:\\path/to", {{"D:/path", "/new-path"}}) == "/new-path/to");
   CHECK(util::perform_path_mapping("D:\\path\\to", {{"D:/path", "/new-path"}}) == "/new-path\\to");
   CHECK(util::perform_path_mapping("D:\\path\\to", {{"D:/path", "\\new-path"}}) == "\\new-path\\to");
 
+  // Drive letters are part of the prefix to match
   CHECK(util::perform_path_mapping("C:/path", {{"D:/path", "/new-path"}}) == "C:/path");
+
+  // Reverse mapping
   CHECK(util::perform_path_mapping("C:/path", {{"D:/path", "C:/path"}}, true) == "D:/path");
+
+  // Trailing slash in mapping key should be ignored
+  CHECK(util::perform_path_mapping("X:/path/to/file", {{"X:/path/", "C:/new-path"}}) == "C:/new-path/to/file");
+
+  { // Realistic test: mapping prefix of VCToolsInstallDir (which has trailing slash) both ways
+    const auto concrete = "C:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\VC\\Tools";
+    const auto abstract = "/vs\\VC\\Tools";
+    const std::pair<fs::path, fs::path> mapping =
+      {"C:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\", "/vs"};
+    CHECK(util::perform_path_mapping(concrete, {mapping}) == abstract);
+    CHECK(util::perform_path_mapping(abstract, {mapping}, true) == concrete);
+  }
 #endif
   // clang-format on
 }

--- a/unittest/test_util_path.cpp
+++ b/unittest/test_util_path.cpp
@@ -254,6 +254,7 @@ TEST_CASE("util::with_extension")
 
 TEST_CASE("util::perform_path_mapping")
 {
+  // clang-format off
   CHECK(util::perform_path_mapping("", {{"/foo", "/bar"}}) == "");
   CHECK(util::perform_path_mapping("/", {{"/foo", "/bar"}}) == "/");
   CHECK(util::perform_path_mapping("/foo/bar", {{"/foo", "/bar"}}) == "/bar/bar");
@@ -272,4 +273,5 @@ TEST_CASE("util::perform_path_mapping")
 
   CHECK(util::perform_path_mapping("C:/path", {{"D:/path", "/new-path"}}) == "C:/path");
 #endif
+  // clang-format on
 }


### PR DESCRIPTION
### Overview
In GCC/Clang, you can pass `-ffile-prefix-map=<from>=<to>` to have both macros and debug symbols modified to replace absolute, machine-specific paths with abstract paths like `/src` and `/build` that can increase binary reproducibility. ccache can autodetect this compiler flag and use it for mapping certain paths like the CWD and profiler/coverage-related paths.

This PR brings the ability of path mapping to as many hashable paths as possible. Path mapping occurs immediately before hashing in several places:

- `inputfile`,
- any compiler option that takes a path,
- the `path exists` check,
- the path to a precompiled header (which I may consider undoing, since PCH and ccache don't seem to go well together),
- environment variables that can include paths,
- and every include path in preprocessor output.

These are all the places I have needed to transform paths (and where absolute paths can show up), but there may be many more. If any reviewers/onlookers have suggestions, feel free to drop a comment on this PR.

### Related issues
- Closes #1761
- Closes #1772
- Potentially closes #1607
- Closes #1806