### PR TITLE
Search for longer compopt prefix matches after `bsearch()`'s returned pointer

### DIFF
--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -217,7 +217,18 @@ find_prefix(std::string_view option)
                          std::size(compopts),
                          sizeof(compopts[0]),
                          compare_prefix_compopts);
-  return static_cast<CompOpt*>(result);
+  if (!result) {
+    return {};
+  }
+  // It's possible that option starts with "-FI" and result is "-F".
+  // Search forward for a longer match until prefixes stop matching.
+  auto max_co = static_cast<const CompOpt*>(result);
+  for (auto co = max_co + 1; co < std::end(compopts) && option.starts_with(co->name); ++co) {
+    if (co->name.length() > max_co->name.length()) {
+      max_co = co;
+    }
+  }
+  return max_co;
 }
 
 // Used by unittest/test_compopt.cpp.

--- a/src/ccache/compopt.cpp
+++ b/src/ccache/compopt.cpp
@@ -223,7 +223,9 @@ find_prefix(std::string_view option)
   // It's possible that option starts with "-FI" and result is "-F".
   // Search forward for a longer match until prefixes stop matching.
   auto max_co = static_cast<const CompOpt*>(result);
-  for (auto co = max_co + 1; co < std::end(compopts) && option.starts_with(co->name); ++co) {
+  for (auto co = max_co + 1;
+       co < std::end(compopts) && option.starts_with(co->name);
+       ++co) {
     if (co->name.length() > max_co->name.length()) {
       max_co = co;
     }

--- a/unittest/test_compopt.cpp
+++ b/unittest/test_compopt.cpp
@@ -98,6 +98,7 @@ TEST_CASE("prefix_takes_path")
 {
   CHECK(compopt_prefix_takes_path("-Dfoo") == std::nullopt);
   CHECK(*compopt_prefix_takes_path("-Ifoo") == "foo");
+  CHECK(*compopt_prefix_takes_path("-FIfoo") == "foo");
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
- Fixes #1776
- The newly added assertion in the `prefix_takes_path` unit test verifies that the problem existed and was solved by this change.