### PR TITLE
Handle colored and Unicode diagnostics on Windows consoles

### DIFF
--- a/src/ccache/argprocessing.cpp
+++ b/src/ccache/argprocessing.cpp
@@ -178,9 +178,43 @@ private:
 bool
 color_output_possible()
 {
+#ifdef _WIN32
+  DWORD mode;
+  HANDLE stderr_handle =
+    reinterpret_cast<HANDLE>(_get_osfhandle(STDERR_FILENO));
+  return GetConsoleMode(stderr_handle, &mode);
+#else
   const char* term_env = getenv("TERM");
   return isatty(STDERR_FILENO) && term_env
          && util::to_lowercase(term_env) != "dumb";
+#endif
+}
+
+bool
+windows_console_needs_color_translation()
+{
+#ifdef _WIN32
+  DWORD mode;
+  HANDLE stderr_handle =
+    reinterpret_cast<HANDLE>(_get_osfhandle(STDERR_FILENO));
+  if (!GetConsoleMode(stderr_handle, &mode)) {
+    return false;
+  }
+
+#  ifdef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+  if (!(mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING)) {
+    mode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    if (!SetConsoleMode(stderr_handle, mode)) {
+      return true;
+    }
+  }
+  return false;
+#  else
+  return true;
+#  endif
+#else
+  return false;
+#endif
 }
 
 bool
@@ -1835,10 +1869,11 @@ process_args(Context& ctx)
     state.add_common_arg(state.explicit_language);
   }
 
-  args_info.strip_diagnostics_colors =
+  const bool colors_enabled =
     state.color_diagnostics != ColorDiagnostics::automatic
-      ? state.color_diagnostics == ColorDiagnostics::never
-      : !color_output_possible();
+      ? state.color_diagnostics == ColorDiagnostics::always
+      : color_output_possible();
+  args_info.strip_diagnostics_colors = !colors_enabled;
 
   // Since output is redirected, compilers will not color their output by
   // default, so force it explicitly.
@@ -1854,6 +1889,12 @@ process_args(Context& ctx)
   } else {
     // Other compilers shouldn't output color, so no need to strip it.
     args_info.strip_diagnostics_colors = false;
+    args_info.translate_diagnostics_colors = false;
+  }
+
+  if (diagnostics_color_arg) {
+    args_info.translate_diagnostics_colors =
+      colors_enabled && windows_console_needs_color_translation();
   }
 
   if (args_info.generating_dependencies) {

--- a/src/ccache/argsinfo.hpp
+++ b/src/ccache/argsinfo.hpp
@@ -118,6 +118,9 @@ struct ArgsInfo
   // Whether to strip color codes from diagnostic messages on output.
   bool strip_diagnostics_colors = false;
 
+  // Whether to translate color codes to Windows console operations on output.
+  bool translate_diagnostics_colors = false;
+
   // Have we seen --?
   bool seen_double_dash = false;
 

--- a/src/ccache/core/common.cpp
+++ b/src/ccache/core/common.cpp
@@ -28,8 +28,11 @@
 #include <ccache/util/path.hpp>
 #include <ccache/util/tokenizer.hpp>
 
+#include <algorithm>
 #include <charconv>
 #include <cstdint>
+#include <limits>
+#include <utility>
 
 using IncludeDelimiter = util::Tokenizer::IncludeDelimiter;
 
@@ -175,6 +178,85 @@ parse_erase_line_mode(std::string_view parameters)
   }
   return mode;
 }
+
+std::optional<std::pair<std::uint32_t, size_t>>
+decode_utf8_character(std::string_view text)
+{
+  if (text.empty()) {
+    return std::nullopt;
+  }
+
+  const auto first_byte = static_cast<unsigned char>(text[0]);
+  std::uint32_t codepoint;
+  size_t length;
+  if (first_byte < 0x80) {
+    return std::pair{first_byte, size_t{1}};
+  } else if (first_byte >= 0xc2 && first_byte <= 0xdf) {
+    codepoint = first_byte & 0x1f;
+    length = 2;
+  } else if (first_byte >= 0xe0 && first_byte <= 0xef) {
+    codepoint = first_byte & 0x0f;
+    length = 3;
+  } else if (first_byte >= 0xf0 && first_byte <= 0xf4) {
+    codepoint = first_byte & 0x07;
+    length = 4;
+  } else {
+    return std::nullopt;
+  }
+
+  for (size_t i = 1; i < length; ++i) {
+    if (i >= text.size()) {
+      return std::nullopt;
+    }
+    const auto current_byte = static_cast<unsigned char>(text[i]);
+    if ((current_byte & 0xc0) != 0x80) {
+      return std::nullopt;
+    }
+    codepoint = (codepoint << 6) | (current_byte & 0x3f);
+  }
+
+  if ((length == 3 && codepoint < 0x800) || (length == 4 && codepoint < 0x10000)
+      || (codepoint >= 0xd800 && codepoint <= 0xdfff) || codepoint > 0x10ffff) {
+    return std::nullopt;
+  }
+  return std::pair{codepoint, length};
+}
+
+std::optional<std::wstring>
+utf8_to_utf16(std::string_view text)
+{
+  size_t pos = 0;
+  while (pos < text.size()
+         && static_cast<unsigned char>(text[pos]) < 0x80) {
+    ++pos;
+  }
+  if (pos == text.size()) {
+    return std::nullopt;
+  }
+
+  std::wstring result;
+  result.reserve(text.size());
+  for (size_t i = 0; i < pos; ++i) {
+    result.push_back(static_cast<unsigned char>(text[i]));
+  }
+
+  while (pos < text.size()) {
+    auto decoded = decode_utf8_character(text.substr(pos));
+    if (!decoded) {
+      return std::nullopt;
+    }
+    auto [codepoint, length] = *decoded;
+    if (codepoint <= 0xffff) {
+      result.push_back(static_cast<wchar_t>(codepoint));
+    } else {
+      codepoint -= 0x10000;
+      result.push_back(static_cast<wchar_t>(0xd800 + (codepoint >> 10)));
+      result.push_back(static_cast<wchar_t>(0xdc00 + (codepoint & 0x3ff)));
+    }
+    pos += length;
+  }
+  return result;
+}
 #endif
 
 // Search for the first match of the following regular expression:
@@ -213,6 +295,26 @@ find_first_ansi_csi_seq(std::string_view string)
 void
 write_console_data(int fd, std::string_view data)
 {
+  HANDLE handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+  DWORD mode;
+  if (GetConsoleMode(handle, &mode)) {
+    if (auto utf16 = utf8_to_utf16(data)) {
+      size_t pos = 0;
+      while (pos < utf16->size()) {
+        DWORD count = static_cast<DWORD>(std::min<size_t>(
+          utf16->size() - pos, std::numeric_limits<DWORD>::max()));
+        DWORD written;
+        if (!WriteConsoleW(
+              handle, utf16->data() + pos, count, &written, nullptr)
+            || written == 0) {
+          throw core::Error("Failed to write Unicode text to console");
+        }
+        pos += written;
+      }
+      return;
+    }
+  }
+
   util::throw_on_error<core::Error>(
     util::write_fd(fd, data.data(), data.length()),
     FMT("Failed to write to fd {}: ", fd));
@@ -447,9 +549,13 @@ send_to_console(const Context& ctx, std::string_view text, int fd)
   }
 #endif
 
+#ifdef _WIN32
+  write_console_data(fd, text_to_send);
+#else
   util::throw_on_error<core::Error>(
     util::write_fd(fd, text_to_send.data(), text_to_send.length()),
     FMT("Failed to write to fd {}: ", fd));
+#endif
 }
 
 std::string

--- a/src/ccache/core/common.cpp
+++ b/src/ccache/core/common.cpp
@@ -28,11 +28,154 @@
 #include <ccache/util/path.hpp>
 #include <ccache/util/tokenizer.hpp>
 
+#include <charconv>
+#include <cstdint>
+
 using IncludeDelimiter = util::Tokenizer::IncludeDelimiter;
 
 namespace fs = util::filesystem;
 
 namespace {
+
+#ifdef _WIN32
+// SGR and EL handling below is based on GCC's MinGW console translator.
+struct ConsoleAttributes
+{
+  std::uint16_t add = 0;
+  std::uint16_t remove = 0;
+};
+
+ConsoleAttributes
+parse_sgr_for_console(std::string_view parameters)
+{
+  ConsoleAttributes attributes;
+
+  size_t pos = 0;
+  do {
+    size_t end = parameters.find(';', pos);
+    auto parameter =
+      parameters.substr(pos, end == std::string_view::npos ? end : end - pos);
+    int value = 0;
+    if (!parameter.empty()) {
+      auto result = std::from_chars(
+        parameter.data(), parameter.data() + parameter.size(), value);
+      if (result.ec != std::errc()
+          || result.ptr != parameter.data() + parameter.size()) {
+        break;
+      }
+    }
+
+    switch (value) {
+    case 0:
+      attributes.add |= FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+      attributes.remove = static_cast<std::uint16_t>(-1);
+      break;
+    case 1:
+      attributes.add |= FOREGROUND_INTENSITY;
+      break;
+    case 4:
+      attributes.add |= COMMON_LVB_UNDERSCORE;
+      break;
+    case 5:
+      attributes.add |= BACKGROUND_INTENSITY;
+      break;
+    case 7:
+      attributes.add |= COMMON_LVB_REVERSE_VIDEO;
+      break;
+    case 22:
+      attributes.add &= ~FOREGROUND_INTENSITY;
+      attributes.remove |= FOREGROUND_INTENSITY;
+      break;
+    case 24:
+      attributes.add &= ~COMMON_LVB_UNDERSCORE;
+      attributes.remove |= COMMON_LVB_UNDERSCORE;
+      break;
+    case 25:
+      attributes.add &= ~BACKGROUND_INTENSITY;
+      attributes.remove |= BACKGROUND_INTENSITY;
+      break;
+    case 27:
+      attributes.add &= ~COMMON_LVB_REVERSE_VIDEO;
+      attributes.remove |= COMMON_LVB_REVERSE_VIDEO;
+      break;
+    case 30:
+    case 31:
+    case 32:
+    case 33:
+    case 34:
+    case 35:
+    case 36:
+    case 37: {
+      constexpr std::uint16_t foreground =
+        FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+      attributes.add &= ~foreground;
+      int color = value - 30;
+      if (color & 1)
+        attributes.add |= FOREGROUND_RED;
+      if (color & 2)
+        attributes.add |= FOREGROUND_GREEN;
+      if (color & 4)
+        attributes.add |= FOREGROUND_BLUE;
+      attributes.remove |= foreground;
+      break;
+    }
+    case 38:
+    case 48:
+      return attributes;
+    case 39:
+      attributes.add |= FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+      attributes.remove |= FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+      break;
+    case 40:
+    case 41:
+    case 42:
+    case 43:
+    case 44:
+    case 45:
+    case 46:
+    case 47: {
+      constexpr std::uint16_t background =
+        BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE;
+      attributes.add &= ~background;
+      int color = value - 40;
+      if (color & 1)
+        attributes.add |= BACKGROUND_RED;
+      if (color & 2)
+        attributes.add |= BACKGROUND_GREEN;
+      if (color & 4)
+        attributes.add |= BACKGROUND_BLUE;
+      attributes.remove |= background;
+      break;
+    }
+    case 49:
+      attributes.add &= ~(BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE);
+      attributes.remove |= BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE;
+      break;
+    }
+
+    if (end == std::string_view::npos)
+      break;
+    pos = end + 1;
+  } while (pos <= parameters.size());
+
+  return attributes;
+}
+
+std::optional<int>
+parse_erase_line_mode(std::string_view parameters)
+{
+  if (parameters.empty())
+    return 0;
+  int mode;
+  auto result = std::from_chars(
+    parameters.data(), parameters.data() + parameters.size(), mode);
+  if (result.ec != std::errc()
+      || result.ptr != parameters.data() + parameters.size()) {
+    return std::nullopt;
+  }
+  return mode;
+}
+#endif
 
 // Search for the first match of the following regular expression:
 //
@@ -65,6 +208,81 @@ find_first_ansi_csi_seq(std::string_view string)
     return {};
   }
 }
+
+#ifdef _WIN32
+void
+write_console_data(int fd, std::string_view data)
+{
+  util::throw_on_error<core::Error>(
+    util::write_fd(fd, data.data(), data.length()),
+    FMT("Failed to write to fd {}: ", fd));
+}
+
+void
+apply_sgr(HANDLE handle, std::string_view parameters)
+{
+  auto attributes = parse_sgr_for_console(parameters);
+
+  CONSOLE_SCREEN_BUFFER_INFO info;
+  if (attributes.remove != static_cast<WORD>(-1)
+      && GetConsoleScreenBufferInfo(handle, &info)) {
+    attributes.add |= info.wAttributes & ~attributes.remove;
+  }
+  if (attributes.add & COMMON_LVB_REVERSE_VIDEO) {
+    attributes.add = static_cast<WORD>((attributes.add & 0xff00)
+                                       | ((attributes.add & 0x00f0) >> 4)
+                                       | ((attributes.add & 0x000f) << 4));
+    attributes.add &= ~COMMON_LVB_REVERSE_VIDEO;
+  }
+  SetConsoleTextAttribute(handle, attributes.add);
+}
+
+void
+translate_ansi_to_console(std::string_view text, int fd)
+{
+  HANDLE handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+  size_t pos = 0;
+  while (pos < text.size()) {
+    auto sequence = find_first_ansi_csi_seq(text.substr(pos));
+    if (sequence.empty()) {
+      write_console_data(fd, text.substr(pos));
+      break;
+    }
+
+    size_t sequence_pos = sequence.data() - text.data();
+    write_console_data(fd, text.substr(pos, sequence_pos - pos));
+    auto parameters = sequence.substr(2, sequence.size() - 3);
+    if (sequence.back() == 'm') {
+      apply_sgr(handle, parameters);
+    } else if (sequence.back() == 'K') {
+      CONSOLE_SCREEN_BUFFER_INFO info;
+      if (GetConsoleScreenBufferInfo(handle, &info)) {
+        auto mode = parse_erase_line_mode(parameters);
+        if (!mode) {
+          pos = sequence_pos + sequence.size();
+          continue;
+        }
+        COORD start = info.dwCursorPosition;
+        DWORD count;
+        if (*mode == 0) {
+          count = info.dwSize.X - info.dwCursorPosition.X;
+        } else if (*mode == 1) {
+          start.X = 0;
+          count = info.dwCursorPosition.X + 1;
+        } else {
+          start.X = 0;
+          count = info.dwSize.X;
+        }
+        DWORD written;
+        FillConsoleOutputCharacterW(handle, L' ', count, start, &written);
+        FillConsoleOutputAttribute(
+          handle, info.wAttributes, count, start, &written);
+      }
+    }
+    pos = sequence_pos + sequence.size();
+  }
+}
+#endif
 
 } // namespace
 
@@ -189,6 +407,18 @@ send_to_console(const Context& ctx, std::string_view text, int fd)
   std::string modified_text;
 
 #ifdef _WIN32
+  DWORD console_mode;
+  HANDLE handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+  bool translate_colors =
+    ctx.args_info.translate_diagnostics_colors
+    && GetConsoleMode(handle, &console_mode)
+#  ifdef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    && !(console_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+#  endif
+    ;
+#endif
+
+#ifdef _WIN32
   // stdout/stderr are normally opened in text mode, which would convert
   // newlines a second time since we treat output as binary data. Make sure to
   // switch to binary mode.
@@ -196,7 +426,11 @@ send_to_console(const Context& ctx, std::string_view text, int fd)
   DEFER(_setmode(fd, oldmode));
 #endif
 
-  if (ctx.args_info.strip_diagnostics_colors) {
+  if (ctx.args_info.strip_diagnostics_colors
+#ifdef _WIN32
+      && !translate_colors
+#endif
+  ) {
     modified_text = strip_ansi_csi_seqs(text);
     text_to_send = modified_text;
   }
@@ -205,6 +439,13 @@ send_to_console(const Context& ctx, std::string_view text, int fd)
     modified_text = rewrite_stderr_to_absolute_paths(text_to_send);
     text_to_send = modified_text;
   }
+
+#ifdef _WIN32
+  if (translate_colors) {
+    translate_ansi_to_console(text_to_send, fd);
+    return;
+  }
+#endif
 
   util::throw_on_error<core::Error>(
     util::write_fd(fd, text_to_send.data(), text_to_send.length()),

--- a/src/ccache/core/common.hpp
+++ b/src/ccache/core/common.hpp
@@ -56,7 +56,8 @@ std::string rewrite_stderr_to_absolute_paths(std::string_view text);
 // translating them to Win32 console operations if
 // `ctx.args_info.translate_diagnostics_colors` is true and `fd` refers to a
 // console without virtual terminal processing), and rewriting paths to
-// absolute if `ctx.config.absolute_paths_in_stderr()` is true. Throws
+// absolute if `ctx.config.absolute_paths_in_stderr()` is true. On Windows,
+// non-ASCII UTF-8 text is converted to UTF-16 for native console output. Throws
 // `core::Error` on error.
 void send_to_console(const Context& ctx, std::string_view text, int fd);
 

--- a/src/ccache/core/common.hpp
+++ b/src/ccache/core/common.hpp
@@ -51,10 +51,12 @@ std::filesystem::path make_relative_path(const Context& ctx,
 // See get_diagnostics_path_length().
 std::string rewrite_stderr_to_absolute_paths(std::string_view text);
 
-// Send `text` to file descriptor `fd` (typically stdout or stderr, which
-// potentially is connected to a console), optionally stripping ANSI color
-// sequences if `ctx.args_info.strip_diagnostics_colors` is true and rewriting
-// paths to absolute if `ctx.config.absolute_paths_in_stderr()` is true. Throws
+// Send `text` to file descriptor `fd` (typically stdout or stderr, which may
+// be connected to a console), optionally stripping ANSI color sequences (or
+// translating them to Win32 console operations if
+// `ctx.args_info.translate_diagnostics_colors` is true and `fd` refers to a
+// console without virtual terminal processing), and rewriting paths to
+// absolute if `ctx.config.absolute_paths_in_stderr()` is true. Throws
 // `core::Error` on error.
 void send_to_console(const Context& ctx, std::string_view text, int fd);
 


### PR DESCRIPTION
## Summary

This fixes two problems when ccache replays compiler diagnostics to a native
Windows console:

- ANSI color sequences may be printed literally when `TERM` suggests color
  support but the console does not support virtual terminal processing.
- Non-ASCII UTF-8 text is interpreted using the active console code page,
  resulting in mojibake.

The original issue was reported in
https://github.com/skeeto/w64devkit/issues/413.

## Diagnostic colors

Ccache captures compiler stderr and forces supported compilers to emit colored
diagnostics. The existing `isatty` and `TERM` checks do not accurately describe
the capabilities of a Win32 console.

On Windows, this change instead:

1. Uses `GetConsoleMode` to identify native console handles.
2. Attempts to enable virtual terminal processing.
3. Falls back to translating the SGR and erase-line sequences used by GCC into
   Win32 console operations when VT processing is unavailable.
4. Leaves redirected output and unsupported compilers unchanged.

The fallback is based on GCC's MinGW console handling in
`gcc/pretty-print.cc`, limited to the sequences needed by GCC diagnostics.

To reproduce this, try:

```sh
printf 'int main(void) { return undeclared; }\n' > error.c
TERM=cygwin ccache gcc -c error.c
TERM=cygwin ccache gcc -c error.c
```

Before this change, on a Windows console that doesn't support virtual terminal
processing, it will emit something like:

?[01m?[Kerror.c:?[m?[K In function '?[01m?[Kmain?[m?[K':

Afterward, diagnostics use either native VT processing
or the Win32 translation fallback.

## Unicode diagnostics

Ccache currently replays stderr through a byte-oriented file descriptor. On a
native Windows console, UTF-8 bytes are interpreted using the active code page.

For valid non-ASCII UTF-8, this change converts the text to UTF-16 and writes it
with `WriteConsoleW`. ASCII, invalid UTF-8, and redirected output continue using
the existing byte-oriented path.

A reproduction is:

```sh
printf 'float π(void) { return 3; }\nvoid f(void) { float unused = π(); }\n' > unicode.c
ccache gcc -Wall -Wextra -c unicode.c
rm unicode.o 2>/dev/null
ccache gcc -Wall -Wextra -c unicode.c

ccache gcc test.c -Wextra -Wall -c unicode.c
unicode.c: In function 'foo':
unicode.c:8:15: warning: unused variable 'f' [-Wunused-variable]
    8 |         float f = ¤Ç();
      |               ^
```

Before this change, `π` may appear as
mojibake; afterward it is rendered correctly.